### PR TITLE
proton-drive: downgrade to 2.10.3

### DIFF
--- a/Casks/p/proton-drive.rb
+++ b/Casks/p/proton-drive.rb
@@ -1,15 +1,20 @@
 cask "proton-drive" do
-  version "2.11.1"
-  sha256 "004878bb816f86627d80f48c3f3fce0870806aba45a17ff62d5617d42fcf25cf"
+  version "2.10.3"
+  sha256 "7ccf585786a66f6173aec359cf5b91c59c7c4db7aa4268a9f96618dd9afd213a"
 
   url "https://proton.me/download/drive/macos/#{version}/ProtonDrive-#{version}.dmg"
   name "Proton Drive"
   desc "Client for Proton Drive"
   homepage "https://proton.me/drive"
 
+  # The appcast publishes versions in `gradual-rollout` and `stable` channals.
+  # The upstream download page serves the `stable` version, so we track the
+  # `stable` channel.
   livecheck do
     url "https://proton.me/download/drive/macos/appcast.xml"
-    strategy :sparkle, &:short_version
+    strategy :sparkle do |items|
+      items.find { |item| item.channel == "stable" }&.short_version
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

It was brought to my attention that the `proton-drive` appcast uses separate `gradual-rollout` and `stable` channels. The upstream download page serves the stable version but autobump recently updated the cask to the `gradual-rollout` version, 2.11.1, because it's the newest release in the appcast.

This downgrades the cask to the newest stable version, 2.10.3, and modifies the `livecheck` block to track the newest version in the `stable` channel.