### PR TITLE
intiface-central 3.0.1 (new cask)

### DIFF
--- a/Casks/i/intiface-central.rb
+++ b/Casks/i/intiface-central.rb
@@ -1,0 +1,29 @@
+cask "intiface-central" do
+  version "3.0.1,37"
+  sha256 "4dca9f17f8d082564e4480b8eb15e68acfeb593be8f000690184d8d585e5c2c9"
+
+  url "https://github.com/intiface/intiface-central/releases/download/v#{version.csv.first}%2B#{version.csv.second}/intiface-central-v#{version.csv.first}-macos-universal.dmg"
+  name "Intiface Central"
+  desc "Frontend application for the Buttplug sex toy control library"
+  homepage "https://github.com/intiface/intiface-central"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)\+(\d+)$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Intiface Central.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.nonpolynomial.intifacecentral",
+    "~/Library/Containers/com.nonpolynomial.intifacecentral",
+  ]
+end

--- a/Casks/i/intiface-central.rb
+++ b/Casks/i/intiface-central.rb
@@ -1,8 +1,8 @@
 cask "intiface-central" do
-  version "3.0.1,37"
-  sha256 "4dca9f17f8d082564e4480b8eb15e68acfeb593be8f000690184d8d585e5c2c9"
+  version "3.0.3,39"
+  sha256 "c3605043d8a1bbb30a2ce5873e07b5d0d34395f2ad09cc1b82d29a2932ff357e"
 
-  url "https://github.com/intiface/intiface-central/releases/download/v#{version.csv.first}%2B#{version.csv.second}/intiface-central-v#{version.csv.first}-macos-universal.dmg"
+  url "https://github.com/intiface/intiface-central/releases/download/v#{version.csv.first}#{"%2B#{version.csv.second}" if version.csv.second}/intiface-central-v#{version.csv.first}-macos-universal.dmg"
   name "Intiface Central"
   desc "Frontend application for the Buttplug sex toy control library"
   homepage "https://github.com/intiface/intiface-central"
@@ -14,7 +14,7 @@ cask "intiface-central" do
       match = json["tag_name"]&.match(regex)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}"
+      match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

I used claude to help with the livecheck strategy, since the versioning tags used by intiface make the default github latest not work properly, but reviewed and manually tested it and all other aspects of the cask.

I tested and verified the zap stanza is correct, one thing I noticed is homebrew cannot delete the folder `~/Library/Containers/com.nonpolynomial.intifacecentral` due to SIP, but I wrote the zap consistent to other casks I looked at with similar file structures, like [crystalfetch](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/c/crystalfetch.rb).