### PR TITLE
Update SHA256 for torrent-file-editor cask

### DIFF
--- a/Casks/t/torrent-file-editor.rb
+++ b/Casks/t/torrent-file-editor.rb
@@ -1,6 +1,6 @@
 cask "torrent-file-editor" do
   version "1.0.1"
-  sha256 "cd0c50ca4ae05fd3160dcc0881ccfa9f6fe38d030ab4cfc7a6b3b750e3564b18"
+  sha256 "65a1d3a324904cf61e9e0caac3d128ff1c7876bb02cf537affdecf013b2b889a"
 
   url "https://github.com/torrent-file-editor/torrent-file-editor/releases/download/v#{version}/torrent-file-editor-#{version}.dmg",
       verified: "github.com/torrent-file-editor/torrent-file-editor/"


### PR DESCRIPTION
Updated SHA256 checksum for torrent-file-editor.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.