### PR TITLE
paseo: add binary artifact

### DIFF
--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -14,6 +14,7 @@ cask "paseo" do
   depends_on macos: ">= :ventura"
 
   app "Paseo.app"
+  binary "#{appdir}/Paseo.app/Contents/MacOS/Paseo", target: "paseo"
 
   zap trash: [
     "~/Library/Application Support/dev.paseo.desktop",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

AI assisted with identifying the correct Homebrew cask pattern and drafting the one-line `binary` artifact change. I manually verified the app bundle entrypoint, ran `brew style --fix ~/dev/homebrew-cask/Casks/p/paseo.rb`, `brew audit --cask --online boudra/cask/paseo`, `brew uninstall --cask paseo`, and `brew install --cask boudra/cask/paseo`, and confirmed `/opt/homebrew/bin/paseo` links to `/Applications/Paseo.app/Contents/MacOS/Paseo`. I also reviewed the unchanged `zap` paths against the current app data on disk.

-----

Adds a Homebrew-managed `paseo` CLI symlink to the app executable.
