### PR TITLE
gram: fix subscriptions typo in desc

### DIFF
--- a/Casks/g/gram.rb
+++ b/Casks/g/gram.rb
@@ -8,7 +8,7 @@ cask "gram" do
   url "https://codeberg.org/GramEditor/gram/releases/download/#{version}/Gram-mac-#{arch}-#{version}.dmg",
       verified: "codeberg.org/GramEditor/"
   name "Gram"
-  desc "Code editor focused on stability, without AI, subscsriptions, or telemetry"
+  desc "Code editor focused on stability, without AI, subscriptions, or telemetry"
   homepage "https://gram.liten.app/"
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
Built and tested locally on macOS 15.

Fixes typo: `subscsriptions` → `subscriptions` in the `desc` stanza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)