### PR TITLE
nova: Re-enable installation of CLI tool

### DIFF
--- a/Casks/n/nova.rb
+++ b/Casks/n/nova.rb
@@ -18,6 +18,9 @@ cask "nova" do
   depends_on macos: ">= :ventura"
 
   app "Nova.app"
+  binary "#{appdir}/Nova.app/Contents/SharedSupport/nova"
+  zsh_completion "#{appdir}/Nova.app/Contents/Resources/nova_completions.txt",
+                 target: "_nova"
 
   uninstall delete: [
     "/Library/LaunchDaemons/com.panic.NovaPrivilegedHelper.plist",


### PR DESCRIPTION
The Nova editor has a [command-line tool](https://help.nova.app/projects/cli/) so the editor can be launched from the terminal.  This diff links it automatically when the cask is installed. (Note: The Settings screen still shows the tool as "Not installed" because it's not in `/usr/local/bin` which is where the app looks for and installs it.)

It looks like the Cask used to support this but it was disabled (#138123) because moving a ZSH completions file was breaking the signing on the app.  By using as `zsh_completion` stanza instead of `artifact`, this problem is avoided now because a symlink is used _into_ the app bundle.

Tested locally with oh-my-zsh installed (since [this is why the completion file is necessary](https://help.panic.com/nova/cli-zsh-not-working/)). Tab completion works as expected and the app is able to launch.

----


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----