### PR TITLE
supasidebar 0.15.3 (new cask)

### DIFF
--- a/Casks/s/supasidebar.rb
+++ b/Casks/s/supasidebar.rb
@@ -1,0 +1,26 @@
+cask "supasidebar" do
+  version "0.15.3"
+  sha256 "a93efb4b41539ca764d71a5c2d7fb45a5273f9be7724af79f297cc40dc986df0"
+
+  url "https://github.com/auspy/supasidebar-updates/releases/download/v#{version}/supasidebar_v#{version}.dmg",
+      verified: "github.com/auspy/supasidebar-updates/"
+  name "SupaSidebar"
+  desc "Arc-like sidebar to save links, files and folders from any browser"
+  homepage "https://supasidebar.com/"
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "supasidebar.app"
+
+  uninstall quit: "com.supasidebar"
+
+  zap trash: [
+    "~/Library/Application Support/com.supasidebar",
+    "~/Library/Caches/com.supasidebar",
+    "~/Library/HTTPStorages/com.supasidebar",
+    "~/Library/HTTPStorages/com.supasidebar.binarycookies",
+    "~/Library/Preferences/com.supasidebar.plist",
+    "~/Library/Saved Application State/com.supasidebar.savedState",
+  ]
+end


### PR DESCRIPTION
This pull request adds SupaSidebar 0.15.3, a commercial macOS sidebar application for quick access to links, files and folders from any browser.

- URL: uses GitHub release downloads with version interpolation
- sha256: `a93efb4b41539ca764d71a5c2d7fb45a5273f9be7724af79f297cc40dc986df0`
- verified: `github.com/auspy/supasidebar-updates/`
- depends_on: macOS >= Sonoma
- zap: cleans up user data and preferences

SupaSidebar is a proprietary macOS productivity app with **1,500+ downloads**, **$5k+ revenue**, with regular releases since 2025. The download URL points to `auspy/supasidebar-updates`, a dedicated releases repository for hosting update artifacts — the main codebase is private. This is the same pattern used by ExtraDock (#250560) and DockFlow (#232830).

Requesting `ci-skip-repository` (GitHub notability exception) — `brew audit --cask --new` fails only on GitHub notability because the URL points to a releases-only repo.

Website: https://supasidebar.com/
GitHub (releases): https://github.com/auspy/supasidebar-updates

**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
  Fails only on GitHub notability; requesting `ci-skip-repository`.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.

I am the author of SupaSidebar. I used Claude Code to generate the initial Cask definition and to help format and submit this PR. I personally configured the DMG notarization pipeline, built and archived the app in Xcode, and ran the release script. I tested `brew install`, `brew uninstall`, and `brew style` locally and confirmed the app launches correctly after installation. I reviewed and verified the `zap` stanza paths.

- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

*Note: I am the author of this software.*
