### PR TITLE
amiberry 8.0.0

### DIFF
--- a/Casks/a/amiberry.rb
+++ b/Casks/a/amiberry.rb
@@ -1,8 +1,8 @@
 cask "amiberry" do
   version "8.0.0"
-  sha256 "6a40360afb5fa391445ade177815e711677b8f83adf105897cf104c7e4bf37f0"
+  sha256 "701b75af6d0e612fa77d476ad0aa81ae1fcef85c2e95615177fad7c2b4c8fa44"
 
-  url "https://github.com/BlitterStudio/amiberry/releases/download/v#{version}/Amiberry-v#{version}-macOS-universal.zip",
+  url "https://github.com/BlitterStudio/amiberry/releases/download/v#{version}/Amiberry-#{version}-Darwin.dmg",
       verified: "github.com/BlitterStudio/amiberry/"
   name "Amiberry"
   desc "Amiga emulator"
@@ -12,8 +12,6 @@ cask "amiberry" do
     url :url
     strategy :github_latest
   end
-
-  container nested: "Amiberry-#{version}-Darwin.dmg"
 
   app "Amiberry.app"
 

--- a/Casks/a/amiberry.rb
+++ b/Casks/a/amiberry.rb
@@ -13,6 +13,8 @@ cask "amiberry" do
     strategy :github_latest
   end
 
+  depends_on macos: ">= :sequoia"
+
   app "Amiberry.app"
 
   zap trash: "~/Library/Application Support/Amiberry"

--- a/Casks/a/amiberry.rb
+++ b/Casks/a/amiberry.rb
@@ -1,11 +1,8 @@
 cask "amiberry" do
-  arch arm: "apple-silicon", intel: "x86_64"
+  version "8.0.0"
+  sha256 "6a40360afb5fa391445ade177815e711677b8f83adf105897cf104c7e4bf37f0"
 
-  version "7.1.1"
-  sha256 arm:   "6df092a58bc78f06409b0de6d3aaa3bddd9577b0df8554443e8a2117369c2e67",
-         intel: "6e12ae55a2d791aa009a384c707142b5d3a5da2e6df9289a69fa5aafa927ce0d"
-
-  url "https://github.com/BlitterStudio/amiberry/releases/download/v#{version}/Amiberry-v#{version}-macOS-#{arch}.zip",
+  url "https://github.com/BlitterStudio/amiberry/releases/download/v#{version}/Amiberry-v#{version}-macOS-universal.zip",
       verified: "github.com/BlitterStudio/amiberry/"
   name "Amiberry"
   desc "Amiga emulator"
@@ -15,6 +12,8 @@ cask "amiberry" do
     url :url
     strategy :github_latest
   end
+
+  container nested: "Amiberry-#{version}-Darwin.dmg"
 
   app "Amiberry.app"
 


### PR DESCRIPTION
Updated amiberry from 7.1.1 to 8.0.0.

v8.0.0 switched from per-architecture builds to a single universal binary (x86_64 + arm64 via lipo), now distributed as a signed+notarized DMG. This update:

- Removes the `arch` stanza (no longer needed — single universal binary)
- Changes from per-arch SHA256 to single SHA256
- Points URL directly at the DMG release asset (previously per-arch ZIPs containing the .app)