### PR TITLE
gcloud-cli: use linked python path

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -78,7 +78,7 @@ cask "gcloud-cli" do
       end
       system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                       args:      ["config", "virtualenv", "create", "--python-to-use",
-                                  "#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python3"],
+                                  "#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python"],
                       reset_uid: true
       system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                       args:      ["config", "virtualenv", "enable"],


### PR DESCRIPTION
Built and tested locally on macOS 15.3.2.

Validated with `brew style --fix Casks/g/gcloud-cli.rb`, `brew audit --cask --online --tap=homebrew/cask gcloud-cli`, install/uninstall, and `gcloud version`.

Use the linked Python executable path in `libexec/bin` when creating the gcloud virtualenv. `python3` is not guaranteed to exist there, while `python` is the linked executable Homebrew guarantees (see [comment here](https://github.com/Homebrew/homebrew-cask/pull/220818#issuecomment-4059026564)).