### PR TITLE
Remove livecheck from discontinued casks

### DIFF
--- a/Casks/b/boxcryptor.rb
+++ b/Casks/b/boxcryptor.rb
@@ -18,11 +18,6 @@ cask "boxcryptor" do
   on_monterey :or_newer do
     version "3.13.680"
     sha256 "b2f4ba62013636bd2db3685eb7c3d9dae3a919eee25b09945ccdc95a9146b05d"
-
-    livecheck do
-      url "https://www.boxcryptor.com/l/download-macosx"
-      strategy :header_match
-    end
   end
 
   url "https://downloads.boxcryptor.com/boxcryptor/mac/Boxcryptor_v#{version}_Installer.dmg"

--- a/Casks/font/font-a/font-andron-scriptor-web.rb
+++ b/Casks/font/font-a/font-andron-scriptor-web.rb
@@ -6,11 +6,6 @@ cask "font-andron-scriptor-web" do
   name "Andron Scriptor Web"
   homepage "https://folk.uib.no/hnooh/mufi/fonts/"
 
-  livecheck do
-    url :homepage
-    regex(/AND[._-]SCR[._-]WEB[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-  end
-
   disable! date: "2026-01-24", because: :no_longer_available
 
   font "AND_SCR_WEB_#{version}/Andron Scriptor Web.ttf"

--- a/Casks/l/logitech-options.rb
+++ b/Casks/l/logitech-options.rb
@@ -6,11 +6,6 @@ cask "logitech-options" do
     url "https://web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
         verified: "web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/"
 
-    livecheck do
-      url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.14"
-      regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
-    end
-
     # The url is unversioned, but the download returns an app with a version number
     rename "LogiMgr Installer*.app", "LogiMgr Installer.app"
 
@@ -22,15 +17,6 @@ cask "logitech-options" do
 
     url "https://download01.logi.com/web/ftp/pub/techsupport/options/options_installer.zip",
         verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
-
-    livecheck do
-      url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0"
-      regex(/Software Version: .*?v?(\d+(?:\.\d+)+)/i)
-      strategy :json do |json, regex|
-        json["articles"]&.select { |item| item["name"] == "Logitech Options" }
-                        &.map { |item| item["body"]&.[](regex, 1) }
-      end
-    end
 
     # The url is unversioned, but the download returns an app with a version number
     rename "LogiMgr Installer*.app", "LogiMgr Installer.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

This removes the `livecheck` block from a few casks that have been disabled as discontinued or no longer available, so livecheck will no longer check them unnecessarily. The `boxcryptor` and `font-andron-scriptor-web` checks no longer work. The `logitech-options` check works but the software has reached end of support and is no longer maintained (it has been replaced by `logitech-options+`), so presumably it's safe to skip checking for new versions.

Other related casks are:

* `pencil`: disabled as discontinued but this was added because the dmg URL was temporarily unavailable. The asset URL now works again but the app is unsigned, so I'll open a PR to rework the `disable!` call.
* `teleport-suite@17`: disabled as discontinued but there have been several releases since then because the EOL date isn't until August 2026. I'll work on updating this as well.