### PR TITLE
codelite 18.3.0

### DIFF
--- a/Casks/c/codelite.rb
+++ b/Casks/c/codelite.rb
@@ -31,10 +31,10 @@ cask "codelite" do
       end
     end
     on_sequoia :or_newer do
-      arch arm: "macOS_15.6.1-arm64"
+      arch arm: "macOS_26.1-arm64"
 
-      version "18.2.0"
-      sha256 "49f919ebed4cf42e49275dc89b5df12bc14cbd4b435f07dbcdaeddef4849a9df"
+      version "18.3.0"
+      sha256 "81c6ec0e705aa936cabffb564d546b6fdf20cf6605a3dd9667270e58543584b9"
 
       livecheck do
         url "https://downloads.codelite.org/"
@@ -63,6 +63,8 @@ cask "codelite" do
   name "CodeLite"
   desc "IDE for C, C++, PHP and Node.js"
   homepage "https://codelite.org/"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`codelite` is autobumped but the workflow failed to update to version 18.3.0 because the macOS version in the file name  has changed. Despite the reference to macOS 26, the app still lists 15.5 as the minimum macOS version. Besides that, the app fails Gatekeeper checks, so this adds a `disable!` call with the future date we've been using for this scenario.