### PR TITLE
slack-cli 3.14.0

### DIFF
--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -3,19 +3,23 @@ cask "slack-cli" do
   os macos: "macOS", linux: "linux"
 
   version "3.14.0"
-  sha256 arm:          "f52829396dd6ecc875a026a6ab5944e8d2129ceef6ff9e534ae9e96e17a3e1c8",
-         intel:        "effdbe158444419de38923d44c3147982b1425c108b5ee604b0a504bf91b3f7e",
-         x86_64_linux: "9f4bce2953a227208eb343ae098154a4489cb31a03dc73df05cb4ccb0270581d"
 
-  url do
-    on_macos do
-      "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_#{os}_#{arch}.tar.gz"
-    end
-
-    on_linux do
-      "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_#{os}_64-bit.tar.gz"
-    end
+  on_macos do
+    url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_#{os}_#{arch}.tar.gz",
+        verified: "downloads.slack-edge.com/"
+    sha256 arm:   "f52829396dd6ecc875a026a6ab5944e8d2129ceef6ff9e534ae9e96e17a3e1c8",
+           intel: "effdbe158444419de38923d44c3147982b1425c108b5ee604b0a504bf91b3f7e"
   end
+
+  on_linux do
+    sha256 "9f4bce2953a227208eb343ae098154a4489cb31a03dc73df05cb4ccb0270581d"
+
+    url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_#{os}_64-bit.tar.gz",
+        verified: "downloads.slack-edge.com/"
+
+    depends_on arch: :x86_64
+  end
+
   name "Slack CLI"
   desc "CLI to create, run, and deploy Slack apps"
   homepage "https://docs.slack.dev/tools/slack-cli/"
@@ -26,8 +30,6 @@ cask "slack-cli" do
       json.dig("slack-cli", "releases")&.map { |release| release["version"] }
     end
   end
-
-  depends_on arch: :x86_64 if OS.linux? # No arm64 build for Linux yet
 
   binary "bin/slack"
 

--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -23,7 +23,7 @@ cask "slack-cli" do
   end
 
   livecheck do
-    url "https://api.slack.com/slackcli/metadata.json"
+    url "https://docs.slack.dev/tools/metadata.json"
     strategy :json do |json|
       json.dig("slack-cli", "releases")&.map { |release| release["version"] }
     end
@@ -31,7 +31,5 @@ cask "slack-cli" do
 
   binary "bin/slack"
 
-  zap trash: [
-    "~/.slack",
-  ]
+  zap trash: "~/.slack"
 end

--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -1,26 +1,24 @@
 cask "slack-cli" do
   arch arm: "arm64", intel: "amd64"
+  os macos: "macOS", linux: "linux"
 
+  version "3.14.0"
+  sha256 arm:          "f52829396dd6ecc875a026a6ab5944e8d2129ceef6ff9e534ae9e96e17a3e1c8",
+         intel:        "effdbe158444419de38923d44c3147982b1425c108b5ee604b0a504bf91b3f7e",
+         x86_64_linux: "9f4bce2953a227208eb343ae098154a4489cb31a03dc73df05cb4ccb0270581d"
+
+  url do
+    on_macos do
+      "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_#{os}_#{arch}.tar.gz"
+    end
+
+    on_linux do
+      "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_#{os}_64-bit.tar.gz"
+    end
+  end
   name "Slack CLI"
   desc "CLI to create, run, and deploy Slack apps"
   homepage "https://docs.slack.dev/tools/slack-cli/"
-
-  on_macos do
-    version "3.14.0"
-    sha256 arm:   "f52829396dd6ecc875a026a6ab5944e8d2129ceef6ff9e534ae9e96e17a3e1c8",
-           intel: "effdbe158444419de38923d44c3147982b1425c108b5ee604b0a504bf91b3f7e"
-
-    url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_macOS_#{arch}.tar.gz",
-        verified: "downloads.slack-edge.com/slack-cli/"
-  end
-
-  on_linux do
-    version "3.14.0"
-    sha256 "9f4bce2953a227208eb343ae098154a4489cb31a03dc73df05cb4ccb0270581d"
-
-    url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_linux_64-bit.tar.gz",
-        verified: "downloads.slack-edge.com/slack-cli/"
-  end
 
   livecheck do
     url "https://docs.slack.dev/tools/metadata.json"
@@ -28,6 +26,8 @@ cask "slack-cli" do
       json.dig("slack-cli", "releases")&.map { |release| release["version"] }
     end
   end
+
+  depends_on arch: :x86_64 if OS.linux? # No arm64 build for Linux yet
 
   binary "bin/slack"
 

--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -1,15 +1,18 @@
 cask "slack-cli" do
   arch arm: "arm64", intel: "amd64"
 
-  version "3.10.0"
-  sha256 arm:   "f4b322ca33b5c4922969ce95d26124ec255a947a77a6f630af2b1f502c323082",
-         intel: "2ae60a438eaa4e04272bbf98008b8ef876ad9d49e4b41812e675714bf73f569a"
-
-  url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_macOS_#{arch}.tar.gz",
-      verified: "downloads.slack-edge.com/slack-cli/"
   name "Slack CLI"
   desc "CLI to create, run, and deploy Slack apps"
   homepage "https://docs.slack.dev/tools/slack-cli/"
+
+  on_macos do
+    version "3.14.0"
+    sha256 arm:   "f52829396dd6ecc875a026a6ab5944e8d2129ceef6ff9e534ae9e96e17a3e1c8",
+           intel: "effdbe158444419de38923d44c3147982b1425c108b5ee604b0a504bf91b3f7e"
+
+    url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_macOS_#{arch}.tar.gz",
+        verified: "downloads.slack-edge.com/slack-cli/"
+  end
 
   livecheck do
     url "https://api.slack.com/slackcli/metadata.json"

--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -14,6 +14,14 @@ cask "slack-cli" do
         verified: "downloads.slack-edge.com/slack-cli/"
   end
 
+  on_linux do
+    version "3.14.0"
+    sha256 "9f4bce2953a227208eb343ae098154a4489cb31a03dc73df05cb4ccb0270581d"
+
+    url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_linux_64-bit.tar.gz",
+        verified: "downloads.slack-edge.com/slack-cli/"
+  end
+
   livecheck do
     url "https://api.slack.com/slackcli/metadata.json"
     strategy :json do |json|
@@ -23,5 +31,7 @@ cask "slack-cli" do
 
   binary "bin/slack"
 
-  # No zap stanza required
+  zap trash: [
+    "~/.slack",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Updated `slack-cli` to 3.14.0, fixed deprecated livecheck URL, added Linux support and zap cleanup.

- Bumped macOS version to `3.14.0`
- Added Linux release URL and checksum (`slack_cli_#{version}_linux_64-bit.tar.gz`) 
- Updated livecheck URL to `https://docs.slack.dev/tools/metadata.json` (ref: [the official script](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux) has changed the URL) 
- Added `zap trash: ["~/.slack"]`  ([ref](https://docs.slack.dev/tools/slack-cli/guides/uninstalling-the-slack-cli))