### PR TITLE
gram: Install cli by default

### DIFF
--- a/Casks/g/gram.rb
+++ b/Casks/g/gram.rb
@@ -14,6 +14,7 @@ cask "gram" do
   depends_on macos: ">= :catalina"
 
   app "Gram.app"
+  binary "#{appdir}/Gram.app/Contents/MacOS/cli", target: "gram"
 
   zap trash: [
     "~/Library/Application Support/Gram",


### PR DESCRIPTION


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

=> no AI was used for this PR

-----

gram ships with a cli that can be installed from within the app, but it's much more convenient to have it installed by default.
https://gram.liten.app/docs/command-line-interface/

```sh
❯ eza -la /Applications/Gram.app/Contents/MacOS/cli
.rwxr-xr-x@ 3.7M pandi  2 Mar 00:36 /Applications/Gram.app/Contents/MacOS/cli
```
 