### PR TITLE
feedflow 1.11.1

### DIFF
--- a/Casks/f/feedflow.rb
+++ b/Casks/f/feedflow.rb
@@ -1,8 +1,8 @@
 cask "feedflow" do
-  version "1.10.0"
-  sha256 "dfbcaa2d7623ee0b3d35793c9dc75946b65c17b3ddb754afe9cbe62266baedfa"
+  version "1.11.1,windows"
+  sha256 "8e98011bc4fa380cdac984174b6b75cb4117723dc36d7632d4c77dbb33789ef1"
 
-  url "https://github.com/prof18/feed-flow/releases/download/#{version}-all/FeedFlow-#{version}.dmg",
+  url "https://github.com/prof18/feed-flow/releases/download/#{version.csv.first}-#{version.csv.second}/FeedFlow-#{version.csv.first}.dmg",
       verified: "github.com/prof18/feed-flow/"
   name "FeedFlow"
   desc "RSS reader"
@@ -10,7 +10,15 @@ cask "feedflow" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(%r{/v?(\d+(?:\.\d+)+)(?:[._-](.+))?/[^/]+\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.filter_map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next unless match
+
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
+    end
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`feedflow` is autobumped but the workflow failed to update to version 1.11.1 because the tag uses a "-windows" suffix instead of "-all", even though the release provides all the usual assets that an "-all" release provides. Upstream also used a "-desktop" suffix in the past past before they started using "-all" but it served the same purpose.

This updates the version and modifies the `livecheck` block to include the suffix in the cask `version`, due to it being unreliable. This isn't ideal but it will save us from having to manually update the cask whenever the suffix doesn't match what the cask expects. This `livecheck` block regex matches the version from the tag name in the "browser_download_url" field, so it will only surface a new version if the release provides a dmg file. This will fail to match for Windows-only releases but that's better than matching and causing autobump to continually try to update to a version that doesn't provide a dmg file.