### PR TITLE
Add Cask for Clipto clipboard manager

### DIFF
--- a/Casks/c/clipto.rb
+++ b/Casks/c/clipto.rb
@@ -1,0 +1,27 @@
+cask "clipto" do
+  version "0.1.0"
+
+  if Hardware::CPU.arm?
+    sha256 "0f479eae04aba43c4b735612833d49a4a82b123cfc2fc162aab568d38322eb62"
+    url "https://github.com/junler/clipto/releases/download/v#{version}/clipto_#{version}_aarch64.dmg"
+  else
+    sha256 "0f479eae04aba43c4b735612833d49a4a82b123cfc2fc162aab568d38322eb62"
+    url "https://github.com/junler/clipto/releases/download/v#{version}/clipto_#{version}_x64.dmg"
+  end
+
+  name "clipto"
+  desc "Clipboard manager"
+  homepage "https://github.com/junler/clipto"
+
+  app "clipto.app"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/clipto.app"]
+  end
+
+  zap trash: [
+    "~/Library/Application Support/clipto",
+    "~/Library/Preferences/cc.junler.clipto.plist"
+  ]
+end


### PR DESCRIPTION
* [x] The submission is for a stable version.
* [x] `brew audit --cask --online clipto` is error-free.
* [x] `brew style --fix clipto` reports no offenses.

Additionally, **if adding a new cask**:

* [x] Named the cask according to the token reference.
* [x] Checked the cask was not already refused.
* [x] `brew audit --cask --new clipto` worked successfully.
* [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask clipto` worked successfully.
* [x] `brew uninstall --cask clipto` worked successfully.

---

**If AI was used to generate or assist with generating the PR**:

* [x] I used AI to generate or assist with generating this PR.
* [x] I have personally reviewed, tested and verified *all* changes/additions, including `zap` stanza paths.

**AI usage details:**

I used ChatGPT to assist with generating the initial cask file and fixing style issues. I have manually reviewed the cask, tested installation and uninstallation locally, and verified all fields including the `zap` stanza paths.
