### PR TITLE
Add macquit cask

### DIFF
--- a/Casks/m/macquit.rb
+++ b/Casks/m/macquit.rb
@@ -1,0 +1,18 @@
+cask "macquit" do
+  version "1.0.3"
+  sha256 "9fa3c894a2625585dc6a05bdd6d2c45fdb3fc80047204b6e3d30cf8f877fd363"
+
+  url "https://imeymrmybnvwcikczvme.supabase.co/storage/v1/object/public/releases/MacQuit-latest.dmg"
+  name "MacQuit"
+  desc "Quit and force quit apps from the menu bar with resource monitoring"
+  homepage "https://www.awesomemacapp.com/"
+
+  depends_on macos: ">= :ventura"
+
+  app "MacQuit.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.macquit.app.plist",
+    "~/Library/Application Support/MacQuit",
+  ]
+end


### PR DESCRIPTION
## Description

Add cask for [MacQuit](https://www.awesomemacapp.com/) — a native macOS menu bar app to quit and force quit running applications with real-time CPU/memory monitoring.

### Details

- **App name:** MacQuit
- **Homepage:** https://www.awesomemacapp.com/
- **Version:** 1.0.3
- **Download URL:** https://imeymrmybnvwcikczvme.supabase.co/storage/v1/object/public/releases/MacQuit-latest.dmg
- **SHA256:** 9fa3c894a2625585dc6a05bdd6d2c45fdb3fc80047204b6e3d30cf8f877fd363

### Features

- Quit all running apps with one click from the menu bar
- Real-time CPU and memory usage monitoring per app
- Force quit frozen applications
- Smart app protection (never-quit list)
- Auto-quit idle apps
- Native Swift, lightweight (~5MB)