### PR TITLE
Add muesli cask

### DIFF
--- a/Casks/m/muesli.rb
+++ b/Casks/m/muesli.rb
@@ -1,11 +1,11 @@
 cask "muesli" do
   version "0.5.3"
-  sha256 "b33748a2bb05009a7aa4d805605239e9ce10c410562f3534455ed9777ee7c115"
+  sha256 "a82d2099d24c4ae507a20f1504b64d93b5d7a22b5d13967d2af596b8d964cc02"
 
   url "https://github.com/pHequals7/muesli/releases/download/v#{version}/Muesli-#{version}.dmg",
       verified: "github.com/pHequals7/muesli/"
   name "Muesli"
-  desc "Local-first macOS dictation and meeting transcription on Apple Silicon"
+  desc "Local-first dictation and meeting transcription"
   homepage "https://freedspeech.xyz/"
 
   livecheck do
@@ -19,7 +19,7 @@ cask "muesli" do
   app "Muesli.app"
 
   zap trash: [
-    "~/Library/Application Support/Muesli",
     "~/.cache/muesli",
+    "~/Library/Application Support/Muesli",
   ]
 end

--- a/Casks/m/muesli.rb
+++ b/Casks/m/muesli.rb
@@ -1,0 +1,25 @@
+cask "muesli" do
+  version "0.5.3"
+  sha256 "b33748a2bb05009a7aa4d805605239e9ce10c410562f3534455ed9777ee7c115"
+
+  url "https://github.com/pHequals7/muesli/releases/download/v#{version}/Muesli-#{version}.dmg",
+      verified: "github.com/pHequals7/muesli/"
+  name "Muesli"
+  desc "Local-first macOS dictation and meeting transcription on Apple Silicon"
+  homepage "https://freedspeech.xyz/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+  depends_on arch: :arm64
+
+  app "Muesli.app"
+
+  zap trash: [
+    "~/Library/Application Support/Muesli",
+    "~/.cache/muesli",
+  ]
+end


### PR DESCRIPTION
**App name:** Muesli
**App homepage:** https://freedspeech.xyz/
**Download URL:** https://github.com/pHequals7/muesli/releases/download/v0.5.3/Muesli-0.5.3.dmg
**Repo:** https://github.com/pHequals7/muesli (37+ stars, MIT license)

Local-first macOS app for dictation and meeting transcription on Apple Silicon. All speech-to-text runs on-device via CoreML/Neural Engine — no cloud, no subscription required.

- Signed, notarized, and stapled with Developer ID
- Apple Silicon only (arm64)
- Requires macOS Sonoma 14.2+
- 7 ASR models (Parakeet, Whisper, Qwen3, Nemotron)