### PR TITLE
Add font-selawik cask

### DIFF
--- a/Casks/font/font-s/font-selawik.rb
+++ b/Casks/font/font-s/font-selawik.rb
@@ -4,13 +4,7 @@ cask "font-selawik" do
 
   url "https://github.com/microsoft/Selawik/releases/download/#{version}/Selawik_Release.zip"
   name "Microsoft Selawik"
-  desc "Open-source sans-serif font family, metrics-compatible replacement for Segoe UI"
   homepage "https://github.com/microsoft/Selawik"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   font "selawk.ttf"
   font "selawkb.ttf"

--- a/Casks/font/font-s/font-selawik.rb
+++ b/Casks/font/font-s/font-selawik.rb
@@ -17,4 +17,6 @@ cask "font-selawik" do
   font "selawkl.ttf"
   font "selawksb.ttf"
   font "selawksl.ttf"
+
+  # No zap stanza required
 end

--- a/Casks/font/font-s/font-selawik.rb
+++ b/Casks/font/font-s/font-selawik.rb
@@ -1,0 +1,20 @@
+cask "font-selawik" do
+  version "1.01"
+  sha256 "3f62c51e05e3b5a1e6241cf92a371f0be2ea1183aa87b30718bbd40832a8d423"
+
+  url "https://github.com/microsoft/Selawik/releases/download/#{version}/Selawik_Release.zip"
+  name "Microsoft Selawik"
+  desc "Open-source sans-serif font family, metrics-compatible replacement for Segoe UI"
+  homepage "https://github.com/microsoft/Selawik"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "selawk.ttf"
+  font "selawkb.ttf"
+  font "selawkl.ttf"
+  font "selawksb.ttf"
+  font "selawksl.ttf"
+end


### PR DESCRIPTION
## Summary

Adds a Homebrew cask for the Microsoft Selawik font family.

Selawik is an open-source, metrics-compatible replacement for Segoe UI, useful for cross-platform apps that need a Windows-style appearance without bundling the proprietary Segoe UI font.

- **Repository**: https://github.com/microsoft/Selawik
- **License**: SIL Open Font License 1.1
- **Version**: 1.01

## Checklist

- [x] `brew style` passes
- [x] `brew audit` passes
- [x] Font files (TTF only, no web formats)