### PR TITLE
canon-ufrii-driver 0.19.24

### DIFF
--- a/Casks/c/canon-ufrii-driver.rb
+++ b/Casks/c/canon-ufrii-driver.rb
@@ -1,8 +1,8 @@
 cask "canon-ufrii-driver" do
-  version "10.19.23"
-  sha256 "aa6cb2d87c2c16baf890dd14bedf9fa3a2f4cc6d990dd247c050bb153d13b5a5"
+  version "10.19.24,2026"
+  sha256 "8681b6aab54f09938497f625b4f43048d26a09497c52f565976dac96d233d621"
 
-  url "https://downloads.canon.com/sss2025/drivers/UFRII_v#{version}_mac.zip",
+  url "https://downloads.canon.com/sss#{version.csv.second}/drivers/UFRII_v#{version.csv.first}_mac.zip",
       verified: "downloads.canon.com/"
   name "Canon UFR II/UFRII LT/LIPSLX/CARPS2 Printer Driver"
   desc "Printer driver for Canon imageRUNNER office printers"
@@ -11,13 +11,13 @@ cask "canon-ufrii-driver" do
   livecheck do
     url "https://www.usa.canon.com/bin/canon/support/getsoftwarediver.ds.MACOS_14.39319.All.English.json",
         user_agent: :browser
-    regex(/UFRII[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i)
+    regex(%r{(\d+)/drivers/UFRII[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip}i)
     strategy :json do |json, regex|
       json.map do |item|
         match = item["fileUrl"]&.match(regex)
         next if match.blank?
 
-        match[1]
+        "#{match[2]},#{match[1]}"
       end
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`canon-ufrii-driver` is autobumped but the workflow failed to update to version 0.19.24 because the year in the asset URL path is now 2026 instead of 2025. This updates the version and adjusts the cask to include the year from the URL in the `version`, as this changes over time.