### PR TITLE
paseo 0.1.30

### DIFF
--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -1,15 +1,20 @@
 cask "paseo" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.1.29"
-  sha256 arm:   "1bd8eed3e6cd7d6ec4cfdf2f56b5248dbef6b3a9ed43c260d4b939d1bac24408",
-         intel: "6b2c5b44de1a3d8df8c91ebe67e73e4d83fefd0d730394ca8aca93e00af1fb51"
+  version "0.1.30"
+  sha256 arm:   "8e00aa114442f6cd9cfd40559708773c4991dab20b12bc23c00f6f1b45fc59b5",
+         intel: "bd57c4821dc5f7113486b4bb5722958401331adccaa83a681174af9dd36f6e1b"
 
   url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo_#{version}_#{arch}.dmg",
       verified: "github.com/getpaseo/paseo/"
   name "Paseo"
   desc "Self-hosted daemon for AI coding agents"
   homepage "https://paseo.sh/"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`paseo` is autobumped but the workflow failed to update to version 0.1.30 because livecheck was returning 0.1.30-r3 as the newest version, from a `desktop-linux-v0.1.30-r3` tag. This updates the version and adds a `livecheck` block that restricts matching to tags like `v1.2.3`, as those are the ones that upstream uses for releases.