### PR TITLE
stremioservice 0.1.18

### DIFF
--- a/Casks/s/stremioservice.rb
+++ b/Casks/s/stremioservice.rb
@@ -1,6 +1,6 @@
 cask "stremioservice" do
-  version "0.1.17"
-  sha256 "e74fe7a085e7462abfefcd050e09ac053342ce37a062f9878f24f0d459b60414"
+  version "0.1.18"
+  sha256 "341592cc918ee0c581340b7284b1cfd65daaa660ec0f095f7b929db936e87509"
 
   url "https://github.com/Stremio/stremio-service/releases/download/v#{version}/StremioService.dmg",
       verified: "github.com/Stremio/stremio-service/"
@@ -9,13 +9,9 @@ cask "stremioservice" do
   homepage "https://web.strem.io/"
 
   livecheck do
-    url "https://www.stremio.com/updater/check?product=stremio-service"
-    strategy :json do |json|
-      json["version"]
-    end
+    url :url
+    strategy :github_latest
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :big_sur"
   depends_on arch: :arm64


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`stremioservice` is autobumped but the workflow failed to update to version 0.1.18 because the `livecheck` block JSON URL is advertising 0.1.20 as the newest version but it's marked as pre-release on GitHub. 0.1.18 is the "latest" release on GitHub, so this updates the version and modifies the `livecheck` block to use the `GithubLatest` strategy. Besides that, this removes the `disable!` call, as this version passes Gatekeeper checks.

For what it's worth, the first-party download page for Stremio Service (https://www.stremio.com/download-service) links to a dmg file for 0.1.19 but it's really 0.1.18 and that app is Intel-only, whereas the file from GitHub is ARM-only. [If not for the version discrepancy, we could use that to add Intel support to the cask but no such luck.]