### PR TITLE
unite-phone 2026.3.3

### DIFF
--- a/Casks/u/unite-phone.rb
+++ b/Casks/u/unite-phone.rb
@@ -1,17 +1,19 @@
 cask "unite-phone" do
-  version "2025.10.7"
-  sha256 "09ca6ee8263baf87e137e8129caf79e7e4496904c08c3e550f4ac795c2223b34"
+  version "2026.3.3"
+  sha256 "1d975bb091c77657168aba27000dfca6c024d42df0407a8d2138ba6b28033b11"
 
-  url "https://update.unitephone.nl/updates/unite_phone-#{version}-universal-mac.zip",
+  url "https://update.unitephone.nl/download/unitephone-#{version}.dmg",
       user_agent: :browser
   name "Unite Phone"
   desc "Video and voice calling application"
   homepage "https://unitephone.nl/"
 
-  # Artifact URL is consistently unreachable in the homebrew/cask CI environment
-  disable! date: "2025-12-31", because: :unreachable
+  livecheck do
+    url "https://update.unitephone.nl/"
+    regex(%r{<small>(\d+(?:\.\d+)+)</small>}i)
+  end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Unite Phone.app"
 


### PR DESCRIPTION
Built and tested locally on macOS Sequoia 15.

Re-enables the cask with the new version. The URL format changed from a ZIP to a DMG and the download path changed. Also adds a livecheck stanza and corrects the minimum macOS version to `:monterey` (as required by the artifact).

- [x] `brew audit --cask --online unite-phone` is error-free
- [x] `brew style --fix unite-phone` reports no offenses
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask unite-phone` worked successfully
- [x] `brew uninstall --cask unite-phone` worked successfully

This pull request was created with AI assistance. All changes were manually reviewed and tested.