### PR TITLE
Update ChatWise to v26

### DIFF
--- a/Casks/c/chatwise.rb
+++ b/Casks/c/chatwise.rb
@@ -1,20 +1,20 @@
 cask "chatwise" do
-  arch arm: "aarch64", intel: "x64"
+  arch arm: "arm64", intel: "x64"
 
-  version "0.10.8"
-  sha256 arm:   "c317243d0f28ab9719fe4ea314e295878af0b6aa22955dbba3a21c473284fb4d",
-         intel: "965ecc45e49e80dd2f262bbd092df83489a645e91cdba0ea68785e8eb7af18a0"
+  version "26.3.21"
+  sha256 arm:   "/S28y/3Isdb5iEJpl0mGqo0d1FzdutHF486sKyRaeROOr7SyNoXzVK99KeUPJ2aHVS8x4/MqxN2JRKxuwsK4xQ=="
+         intel: "DTYVz92qdatRtCijnH6NsPQz+eeAzRu9l7G+D0fsOJKIgOu/2fcfiGfAmSI/IYU/IxOd7wsi7PKZtucOsRYjAQ=="
 
-  url "https://github.com/egoist/chatwise-releases/releases/download/v#{version}/ChatWise_#{version}_#{arch}.dmg",
-      verified: "github.com/egoist/chatwise-releases/"
+  url "https://releases.chatwise.app/#{version}/ChatWise-#{version}-#{arch}.dmg",
+    verified: "releases.chatwise.app/"
   name "ChatWise"
   desc "AI chatbot for many LLMs"
   homepage "https://chatwise.app/"
 
   livecheck do
-    url "https://chatwise.app/api/trpc/getReleases"
+    url "https://releases.chatwise.app/releases"
     strategy :json do |json|
-      json.dig("result", "data")&.map { |item| item["tag"]&.tr("v", "") }
+      Array(json).filter_map { |item| item["version"] }
     end
   end
 

--- a/Casks/c/chatwise.rb
+++ b/Casks/c/chatwise.rb
@@ -18,7 +18,7 @@ cask "chatwise" do
   end
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: ">= :monterey"
 
   app "ChatWise.app"
 

--- a/Casks/c/chatwise.rb
+++ b/Casks/c/chatwise.rb
@@ -2,11 +2,10 @@ cask "chatwise" do
   arch arm: "arm64", intel: "x64"
 
   version "26.3.21"
-  sha256 arm:   "/S28y/3Isdb5iEJpl0mGqo0d1FzdutHF486sKyRaeROOr7SyNoXzVK99KeUPJ2aHVS8x4/MqxN2JRKxuwsK4xQ=="
-         intel: "DTYVz92qdatRtCijnH6NsPQz+eeAzRu9l7G+D0fsOJKIgOu/2fcfiGfAmSI/IYU/IxOd7wsi7PKZtucOsRYjAQ=="
+  sha256 arm:   "a4a46630471c71ea63743bbb5018ad5f21a0eff1a76c5144cc05e84fd7629a38",
+         intel: "8b7bfc97248218f5e20ba763ec5cc838de4fec1d5372236f3bcba53d0b49a754"
 
-  url "https://releases.chatwise.app/#{version}/ChatWise-#{version}-#{arch}.dmg",
-    verified: "releases.chatwise.app/"
+  url "https://releases.chatwise.app/#{version}/ChatWise-#{version}-#{arch}.dmg"
   name "ChatWise"
   desc "AI chatbot for many LLMs"
   homepage "https://chatwise.app/"
@@ -14,7 +13,7 @@ cask "chatwise" do
   livecheck do
     url "https://releases.chatwise.app/releases"
     strategy :json do |json|
-      Array(json).filter_map { |item| item["version"] }
+      json.map { |v| v["version"] }
     end
   end
 


### PR DESCRIPTION
v26 is a breaking change.

It comes with a new release cycle.
For info: https://docs.chatwise.app/migrate-to-v26.html

Now, releases are published on
https://releases.chatwise.app/releases
Distributions are no longer published on GitHub but on their website: "https://releases.chatwise.app/26.3.21/ChatWise-26.3.21-x64.dmg"

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.


-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

I used GPT 5.2 to help me with Ruby.

-----
