### PR TITLE
recut 4.4.3

### DIFF
--- a/Casks/r/recut.rb
+++ b/Casks/r/recut.rb
@@ -1,15 +1,26 @@
 cask "recut" do
-  version "4.3.4"
-  sha256 "db979442ba85ac4eb9fe34fac1c7dbcadb579cf8c24bb4387287f3fce8496f0b"
+  version "4.4.3,eyJfcmFpbHMiOnsiZGF0YSI6MTA0LCJwdXIiOiJibG9iX2lkIn19--e995f3090d9cfd4a349253e3682ae4d3e686bcf9"
+  sha256 "554b8c2fc19a7e3768c01c6efe933a4c6db8fc92c87f771c6a1367b1f895abd5"
 
-  url "https://updates.getrecut.com/universal/Recut_#{version}_universal.dmg"
+  url "https://updates.getrecut.com/rails/active_storage/blobs/redirect/#{version.csv.second}/Recut_#{version.csv.first}_universal.dmg"
   name "Recut"
   desc "Remove silence from videos and automatically generate a cut list"
   homepage "https://getrecut.com/"
 
   livecheck do
     url "https://updates.getrecut.com/latest-mac"
-    strategy :header_match
+    regex(%r{/redirect/([^/]+)/Recut[._-]v?(\d+(?:\.\d+)+)}i)
+    strategy :header_match do |all_headers, regex|
+      version = nil
+      all_headers.each do |headers|
+        match = headers["location"]&.match(regex)
+        next unless match
+
+        version = "#{match[2]},#{match[1]}"
+        break
+      end
+      version
+    end
   end
 
   depends_on :macos

--- a/Casks/r/recut.rb
+++ b/Casks/r/recut.rb
@@ -9,6 +9,7 @@ cask "recut" do
 
   livecheck do
     url "https://updates.getrecut.com/latest-mac"
+    regex(/Recut[._-]v?(\d+(?:\.\d+)+)/i)
     strategy :header_match
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`recut` is autobumped but the workflow failed to update to versions past 4.3.4 because livecheck erroneously returns text other than the version (e.g., "9") because the final URL that the /latest-mac redirection points to now includes a lot of query string parameters. We can't use the final redirection URL for the cask and we need to use the URL from the `Location` header in the first response instead.

Up to now, the livecheck `HeaderMatch` strategy has only provided the last instance of each header found in the responses, so we haven't been able to access prior `Location` headers like we need to do here. To allow for this, I modified the `HeaderMatch` strategy to allow for an `all_headers` argument to the `strategy` block, which will provide an array of header hashes corresponding to each response (instead of the default merged headers).

This updates the version and modifies the cask setup to use the new redirecting URL format. The `livecheck` block iterates through `Location` headers until it finds a matching URL and returns the `version` information from that, so we're not relying on a specific response (e.g., the first) providing the URL we need.