### PR TITLE
guitar-pro: disable

### DIFF
--- a/Casks/g/guitar-pro.rb
+++ b/Casks/g/guitar-pro.rb
@@ -7,10 +7,16 @@ cask "guitar-pro" do
   desc "Sheet music editor software for guitar, bass, keyboards, drums and more"
   homepage "https://www.guitar-pro.com/"
 
-  livecheck do
-    url "https://updates.guitar-pro.com/gp#{version.major}?os=macOS&channel=stable"
-    strategy :sparkle, &:version
-  end
+  # The download now requires authentication key which is returned from a POST request that requires
+  # user information. There is no way to assemble this link systematically.
+  # The Sparkle feed has also changed as below, which can be used if the situation changes in the future.
+  #
+  # livecheck do
+  #   url "https://cast.assets-arobas-music.com/sparkleAppCast?os=MACOS&channel=stable&version=0"
+  #   strategy :sparkle, &:version
+  # end
+
+  disable! date: "2026-03-21", because: "has a download url that requires authentication"
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

A download issue was reported in https://github.com/Homebrew/homebrew-cask/issues/255000.
After spending some time exploring alternatives I found that the in-app updater returns a link that requires authentication headers, so we have no way of replicating this in the Cask. Additionally, the upstream website now requires a form submission with user details to fetch the authenticated download url, so there's no way to work around this.

Closes https://github.com/Homebrew/homebrew-cask/issues/255000