### PR TITLE
aegisub: deprecate

### DIFF
--- a/Casks/a/aegisub.rb
+++ b/Casks/a/aegisub.rb
@@ -13,6 +13,8 @@ cask "aegisub" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   app "Aegisub.app"
 
   uninstall quit: "com.aegisub.aegisub"

--- a/Casks/a/aegisub.rb
+++ b/Casks/a/aegisub.rb
@@ -6,7 +6,7 @@ cask "aegisub" do
       verified: "github.com/TypesettingTools/Aegisub/"
   name "Aegisub"
   desc "Create and modify subtitles"
-  homepage "https://aegisub.org/"
+  homepage "https://github.com/TypesettingTools/Aegisub/"
 
   livecheck do
     url :url
@@ -14,6 +14,8 @@ cask "aegisub" do
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :ventura"
 
   app "Aegisub.app"
 

--- a/Casks/a/aegisub.rb
+++ b/Casks/a/aegisub.rb
@@ -2,8 +2,7 @@ cask "aegisub" do
   version "3.4.2"
   sha256 "cbbfd3276e0414b540f6b1bc12a69abd6b8a96b0a452de3b08c290d553754ad3"
 
-  url "https://github.com/TypesettingTools/Aegisub/releases/download/v#{version}/Aegisub-#{version}.dmg",
-      verified: "github.com/TypesettingTools/Aegisub/"
+  url "https://github.com/TypesettingTools/Aegisub/releases/download/v#{version}/Aegisub-#{version}.dmg"
   name "Aegisub"
   desc "Create and modify subtitles"
   homepage "https://github.com/TypesettingTools/Aegisub/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `aegisub` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online aegisub` is error-free.
- [ ] `brew style --fix aegisub` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new aegisub` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask aegisub` worked successfully.
- [ ] `brew uninstall --cask aegisub` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Deprecating because the cask fails the macOS gatekeeper check
