### PR TITLE
fx-cast-bridge: deprecate

### DIFF
--- a/Casks/f/fx-cast-bridge.rb
+++ b/Casks/f/fx-cast-bridge.rb
@@ -24,6 +24,8 @@ cask "fx-cast-bridge" do
     end
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   pkg "fx_cast_bridge-#{version}-#{arch}.pkg"
 
   uninstall pkgutil: "tf.matt.fx_cast_bridge"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `fx-cast-bridge` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online fx-cast-bridge` is error-free.
- [ ] `brew style --fix fx-cast-bridge` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new fx-cast-bridge` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask fx-cast-bridge` worked successfully.
- [ ] `brew uninstall --cask fx-cast-bridge` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Deprecating because the cask fails the macOS gatekeeper check
