### PR TITLE
hfsleuth: deprecate

### DIFF
--- a/Casks/h/hfsleuth.rb
+++ b/Casks/h/hfsleuth.rb
@@ -11,6 +11,8 @@ cask "hfsleuth" do
     skip "unversioned command-line application"
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   binary "hfsleuth.universal", target: "hfsleuth"
   manpage "hfsleuth.1"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `hfsleuth` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online hfsleuth` is error-free.
- [ ] `brew style --fix hfsleuth` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new hfsleuth` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask hfsleuth` worked successfully.
- [ ] `brew uninstall --cask hfsleuth` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Deprecating because the cask fails the macOS gatekeeper check
