### PR TITLE
icanhazshortcut: deprecate

### DIFF
--- a/Casks/i/icanhazshortcut.rb
+++ b/Casks/i/icanhazshortcut.rb
@@ -7,6 +7,8 @@ cask "icanhazshortcut" do
   desc "Shortcut manager"
   homepage "https://github.com/deseven/icanhazshortcut/"
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   app "iCanHazShortcut.app"
 
   uninstall quit: "info.deseven.icanhazshortcut"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `icanhazshortcut` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online icanhazshortcut` is error-free.
- [ ] `brew style --fix icanhazshortcut` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new icanhazshortcut` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask icanhazshortcut` worked successfully.
- [ ] `brew uninstall --cask icanhazshortcut` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Deprecating because the cask fails the macOS gatekeeper check
