### PR TITLE
milkytracker: deprecate

### DIFF
--- a/Casks/m/milkytracker.rb
+++ b/Casks/m/milkytracker.rb
@@ -13,6 +13,8 @@ cask "milkytracker" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   app "MilkyTracker.app"
 
   zap trash: "~/Library/Preferences/com.Titan.MilkyTracker.plist"

--- a/Casks/m/milkytracker.rb
+++ b/Casks/m/milkytracker.rb
@@ -6,7 +6,7 @@ cask "milkytracker" do
       verified: "github.com/milkytracker/MilkyTracker/"
   name "MilkyTracker"
   desc "Music tracker compatible with FT2"
-  homepage "https://milkytracker.titandemo.org/"
+  homepage "https://milkytracker.org/"
 
   livecheck do
     url :url
@@ -14,6 +14,8 @@ cask "milkytracker" do
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :sequoia"
 
   app "MilkyTracker.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `milkytracker` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online milkytracker` is error-free.
- [ ] `brew style --fix milkytracker` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new milkytracker` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask milkytracker` worked successfully.
- [ ] `brew uninstall --cask milkytracker` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Deprecating because the cask fails the macOS gatekeeper check
