### PR TITLE
gram 1.1.0

### DIFF
--- a/Casks/g/gram.rb
+++ b/Casks/g/gram.rb
@@ -1,11 +1,11 @@
 cask "gram" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "1.0.0"
-  sha256 arm:   "5f2518b3cc8baa27b1166e42b8d6e811aae795b84e6b1110348da926570e6f8e",
-         intel: "e49f76ac1ddaa26da00fd358596088c0e7d57d10947541e7fc3489472dbcc9df"
+  version "1.1.0"
+  sha256 arm:   "96d8d3295784ca23727e1aabab731552462abb63a280852c2400be83b20aa80b",
+         intel: "1fa30202830264a99c5ae650b802e41c49b1a610b4e955594f6d7fc9f15dc75d"
 
-  url "https://codeberg.org/GramEditor/gram/releases/download/#{version}/Gram-mac-#{arch}-#{version}.dmg",
+  url "https://codeberg.org/GramEditor/gram/releases/download/#{version}/Gram-#{arch}-#{version}.dmg",
       verified: "codeberg.org/GramEditor/"
   name "Gram"
   desc "Code editor focused on stability, without AI, subscriptions, or telemetry"


### PR DESCRIPTION
`gram` is autobumped but the workflow failed to update to version 1.1.0 because the dmg file name no longer includes the `-mac` prefix. This updates the version and adjusts the `url` accordingly.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
