### PR TITLE
lidanglesensor 1.1

### DIFF
--- a/Casks/l/lidanglesensor.rb
+++ b/Casks/l/lidanglesensor.rb
@@ -1,13 +1,13 @@
 cask "lidanglesensor" do
-  version "1.0.3"
-  sha256 "3ee216765f12673527cea98d5509bcd5799333653030ac7f953e3c7fa3dd2cd2"
+  version "1.1"
+  sha256 "d4b14e7d866589117e5b2cfc7f06e8f8b915dc81948073d9df091177d21e0780"
 
-  url "https://github.com/samhenrigold/LidAngleSensor/releases/download/#{version}/LidAngleSensor.app.zip"
+  url "https://github.com/samhenrigold/LidAngleSensor/releases/download/#{version}/LidAngleSensor.zip"
   name "LidAngleSensor"
   desc "Utility to display the lid angle and play a creaking sound"
   homepage "https://github.com/samhenrigold/LidAngleSensor"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :sonoma"
 
   app "LidAngleSensor.app"
 


### PR DESCRIPTION
`lidanglesensor` is autobumped but the workflow failed to update to version 1.1 because the zip file name no longer includes ".app" in the extension. This updates the version and adjusts the `url` accordingly.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
