### PR TITLE
supacode: update livecheck

### DIFF
--- a/Casks/s/supacode.rb
+++ b/Casks/s/supacode.rb
@@ -7,10 +7,17 @@ cask "supacode" do
   desc "Native terminal coding agents command center"
   homepage "https://supacode.sh/"
 
+  # The appcast items can't be reliably ordered by `pubDate` and there are
+  # unstable versions in the "tip" channel, so we do simple version comparison
+  # (ignoring `pubDate`) and only work with the items in the default channel.
   livecheck do
     url "https://supacode.sh/download/latest/appcast.xml"
     strategy :sparkle do |items|
-      items.map(&:short_version)
+      items.map do |item|
+        next unless item.channel.nil?
+
+        item.short_version
+      end
     end
   end
 


### PR DESCRIPTION
livecheck uses the `Sparkle` strategy for `supacode` and this works but it's returning 0.6.12 as newest and this is currently an unstable version in the "tip" channel. This updates the `livecheck` block to skip items that aren't in the default channel, so it correctly returns 0.6.9 as newest (aligning with the version served from the upstream website).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
