### PR TITLE
lunarbar: add Apple Silicon support

### DIFF
--- a/Casks/l/lunarbar.rb
+++ b/Casks/l/lunarbar.rb
@@ -1,5 +1,5 @@
 cask "lunarbar" do
-  arch arm: "-apple-silicon", intel: ""
+  arch arm: "-apple-silicon"
 
   version "1.9.0"
   sha256 arm:   "58bb109d5a1e9909a786dd3fbcad535c795ff0e081659d2ea1425e82fb48f74b",

--- a/Casks/l/lunarbar.rb
+++ b/Casks/l/lunarbar.rb
@@ -1,8 +1,11 @@
 cask "lunarbar" do
-  version "1.9.0"
-  sha256 "04fd942cbf70d8557370de5fd62a1e2d477232b6e96953278c60f49d6ffb4ce8"
+  arch arm: "-apple-silicon", intel: ""
 
-  url "https://github.com/LunarBar-app/LunarBar/releases/download/v#{version}/LunarBar-#{version}.dmg"
+  version "1.9.0"
+  sha256 arm:   "58bb109d5a1e9909a786dd3fbcad535c795ff0e081659d2ea1425e82fb48f74b",
+         intel: "04fd942cbf70d8557370de5fd62a1e2d477232b6e96953278c60f49d6ffb4ce8"
+
+  url "https://github.com/LunarBar-app/LunarBar/releases/download/v#{version}/LunarBar-#{version}#{arch}.dmg"
   name "LunarBar"
   desc "Lunar calendar for menu bar"
   homepage "https://github.com/LunarBar-app/LunarBar"


### PR DESCRIPTION

LunarBar introduced Apple Silicon support starting with version 1.8.3. Since the upstream author hasn't updated the Homebrew cask and their GitHub repository has issues disabled, I'm submitting this PR to add the arm architecture build.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

