### PR TITLE
Add nudge-run cask v1.0.0

### DIFF
--- a/Casks/n/nudge-run.rb
+++ b/Casks/n/nudge-run.rb
@@ -5,14 +5,12 @@ cask "nudge-run" do
   url "https://github.com/mikusnuz/nudge/releases/download/v#{version}/Nudge.dmg",
       verified: "github.com/mikusnuz/nudge/"
   name "Nudge"
-  desc "Lightweight macOS window manager with keyboard shortcuts and drag-to-edge snapping"
-  homepage "https://nudge.run"
+  desc "Lightweight window manager with keyboard shortcuts and drag-to-edge snapping"
+  homepage "https://nudge.run/"
 
   depends_on macos: ">= :big_sur"
 
   app "Nudge.app"
 
-  zap trash: [
-    "~/Library/Preferences/app.nudge.Nudge.plist",
-  ]
+  zap trash: "~/Library/Preferences/app.nudge.Nudge.plist"
 end

--- a/Casks/n/nudge-run.rb
+++ b/Casks/n/nudge-run.rb
@@ -1,0 +1,18 @@
+cask "nudge-run" do
+  version "1.0.0"
+  sha256 "b5f61ba7b8bd4c6b7676c86acd7212cb516b911e2b1fc4e21d45d437eca63942"
+
+  url "https://github.com/mikusnuz/nudge/releases/download/v#{version}/Nudge.dmg",
+      verified: "github.com/mikusnuz/nudge/"
+  name "Nudge"
+  desc "Lightweight macOS window manager with keyboard shortcuts and drag-to-edge snapping"
+  homepage "https://nudge.run"
+
+  depends_on macos: ">= :big_sur"
+
+  app "Nudge.app"
+
+  zap trash: [
+    "~/Library/Preferences/app.nudge.Nudge.plist",
+  ]
+end


### PR DESCRIPTION
## Description

Add new cask for [Nudge](https://github.com/mikusnuz/nudge), a lightweight, free and open-source macOS window manager.

- Snap windows with keyboard shortcuts or drag-to-edge
- 17 snap layouts (halves, quarters, thirds, two-thirds)
- Multi-monitor support
- Signed & notarized by Apple

### Details

- **Name**: nudge-run (to avoid conflict with existing `nudge` cask by macadmins)
- **Homepage**: https://nudge.run
- **Download**: GitHub Releases (public repo)
- **License**: MIT