### PR TITLE
clearly 1.6.0 (new cask)

### DIFF
--- a/Casks/c/clearly.rb
+++ b/Casks/c/clearly.rb
@@ -1,0 +1,26 @@
+cask "clearly" do
+  version "1.6.0"
+  sha256 "33f07501517048edd66c4ad04c4c3e2d00ac996847df842427fc13697efa5dc1"
+
+  url "https://github.com/Shpigford/clearly/releases/download/v#{version}/Clearly.dmg",
+      verified: "github.com/Shpigford/clearly/"
+  name "Clearly"
+  desc "Clean, native markdown editor"
+  homepage "https://clearly.md/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Clearly.app"
+
+  zap trash: [
+        "~/Library/Application Scripts/com.sabotage.clearly*",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sabotage.clearly.sfl*",
+        "~/Library/Containers/com.sabotage.clearly*",
+      ],
+      rmdir: "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments"
+end

--- a/Casks/c/clearly.rb
+++ b/Casks/c/clearly.rb
@@ -5,14 +5,10 @@ cask "clearly" do
   url "https://github.com/Shpigford/clearly/releases/download/v#{version}/Clearly.dmg",
       verified: "github.com/Shpigford/clearly/"
   name "Clearly"
-  desc "Clean, native markdown editor"
+  desc "Markdown editor"
   homepage "https://clearly.md/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
+  auto_updates true
   depends_on macos: ">= :sonoma"
 
   app "Clearly.app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online clearly` is error-free.
- [x] `brew style --fix clearly` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new clearly` worked successfully.
  - NOTE: audit passes with one warning about the GitHub repository being less than 30 days old. Submitting for review and happy to wait for merge until notability requirements are met.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask clearly` worked successfully.
- [x] `brew uninstall --cask clearly` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.
  - Claude Code (`claude-sonnet-4-6`) generated the initial cask structure and stanzas (`desc`, `livecheck`, `depends_on`, `app`), suggested the `verified:` fix for the URL stanza, and advised on commit message format based on commit history. 
  - DeepWiki queried the repository's `project.yml` to get the bundle ID (`com.sabotage.clearly`) and minimum macOS version (14.0).
  - I ran `brew generate-zap clearly` after installing and launching the app to replace the AI-generated `zap` paths, then ran `brew style --fix clearly` to correct the glob pattern.
  -  Claude Code also helped interpret audit errors and style violations throughout the process.


-----
