### PR TITLE
react-proto: deprecate

### DIFF
--- a/Casks/r/react-proto.rb
+++ b/Casks/r/react-proto.rb
@@ -16,4 +16,8 @@ cask "react-proto" do
     "~/Library/Application Support/react-proto",
     "~/Library/Preferences/com.react.proto*.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/r/react-proto.rb
+++ b/Casks/r/react-proto.rb
@@ -8,6 +8,8 @@ cask "react-proto" do
   desc "React application prototyping tool for developers and designers"
   homepage "https://react-proto.github.io/react-proto"
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   app "React-Proto.app"
 
   zap trash: [


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `react-proto` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online react-proto` is error-free.
- [ ] `brew style --fix react-proto` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new react-proto` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask react-proto` worked successfully.
- [ ] `brew uninstall --cask react-proto` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Deprecating because the cask fails the macOS gatekeeper check
