### PR TITLE
Add formulatepro 1.0.0

### DIFF
--- a/Casks/f/formulatepro.rb
+++ b/Casks/f/formulatepro.rb
@@ -1,0 +1,15 @@
+cask "formulatepro" do
+  version "1.0.0"
+  sha256 "29872caacb885a11c7e48fc8276269ed135324364271885030f78bc88435aa80"
+
+  url "https://github.com/stangri/formulatepro/releases/download/v#{version}/FormulatePro-#{version}.dmg"
+  name "FormulatePro"
+  desc "PDF annotation and markup tool"
+  homepage "https://github.com/stangri/formulatepro"
+
+  app "FormulatePro.app"
+
+  zap trash: [
+    "~/Library/Preferences/net.melmac.FormulatePro.plist",
+  ]
+end


### PR DESCRIPTION
## Description

Add FormulatePro, a macOS PDF annotation and markup tool.

**Homepage:** https://github.com/stangri/formulatepro
**Download:** https://github.com/stangri/formulatepro/releases/download/v1.0.0/FormulatePro-1.0.0.dmg

### App details
- Open-source PDF annotation application for macOS
- Draw shapes, add text, place checkmarks on PDFs
- Export annotated documents as PDF
- Available on the Mac App Store and as a direct download

```
brew install --cask formulatepro
```