### PR TITLE
altar-ai 1.0.50 (new cask)

### DIFF
--- a/Casks/a/altar-ai.rb
+++ b/Casks/a/altar-ai.rb
@@ -6,7 +6,7 @@ cask "altar-ai" do
       verified: "altar-prototype.sgp1.cdn.digitaloceanspaces.com/"
   name "Altar AI"
   desc "AI-powered meeting assistant"
-  homepage "https://altar.inc/"
+  homepage "https://app.altar.inc/"
 
   livecheck do
     url "https://altar-prototype.sgp1.cdn.digitaloceanspaces.com/latest/latest-mac.yml"

--- a/Casks/a/altar-ai.rb
+++ b/Casks/a/altar-ai.rb
@@ -1,0 +1,27 @@
+cask "altar-ai" do
+  version "1.0.50"
+  sha256 "970f4e74957b2f80e6c7f78227b13bcd73d82fc3f6047ecd1056496d33c01af7"
+
+  url "https://altar-prototype.sgp1.cdn.digitaloceanspaces.com/releases/v#{version}/altar-app-#{version}.dmg",
+      verified: "altar-prototype.sgp1.cdn.digitaloceanspaces.com/"
+  name "Altar AI"
+  desc "AI-powered meeting assistant"
+  homepage "https://altar.inc/"
+
+  livecheck do
+    url "https://altar-prototype.sgp1.cdn.digitaloceanspaces.com/latest/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "Altar AI.app"
+
+  zap trash: [
+    "~/Library/Application Support/altar-app",
+    "~/Library/Caches/com.electron.altar-app",
+    "~/Library/Preferences/com.electron.altar-app.plist",
+    "~/Library/Saved Application State/com.electron.altar-app.savedState",
+  ]
+end

--- a/Casks/a/altar-ai.rb
+++ b/Casks/a/altar-ai.rb
@@ -14,7 +14,7 @@ cask "altar-ai" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :monterey"
 
   app "Altar AI.app"
 

--- a/Casks/a/altar-ai.rb
+++ b/Casks/a/altar-ai.rb
@@ -1,6 +1,6 @@
 cask "altar-ai" do
-  version "1.0.50"
-  sha256 "970f4e74957b2f80e6c7f78227b13bcd73d82fc3f6047ecd1056496d33c01af7"
+  version "1.0.52"
+  sha256 "2f33c34d4df8fb9dd03e3331d72dc54efc55e883ad533f43fedeef368454a3c9"
 
   url "https://altar-prototype.sgp1.cdn.digitaloceanspaces.com/releases/v#{version}/altar-app-#{version}.dmg",
       verified: "altar-prototype.sgp1.cdn.digitaloceanspaces.com/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

- AI (Claude) was used to update the cask version and sha256, and to run the verification checklist (brew style, brew install, brew uninstall). The zap stanza paths were verified against actual files on disk in ~/Library/Application Support/altar-app, ~/Library/Caches/com.electron.altar-app, ~/Library/Preferences/com.electron.altar-app.plist, and ~/Library/Saved Application State/com.electron.altar-app.savedState.
-----