### PR TITLE
notchi 1.0.2 (new cask)

### DIFF
--- a/Casks/n/notchi.rb
+++ b/Casks/n/notchi.rb
@@ -8,11 +8,6 @@ cask "notchi" do
   desc "Notch companion for Claude Code"
   homepage "https://notchi.app/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
   depends_on macos: ">= :sequoia"
 

--- a/Casks/n/notchi.rb
+++ b/Casks/n/notchi.rb
@@ -1,0 +1,34 @@
+cask "notchi" do
+  version "1.0.2"
+  sha256 "00cf9f00f40d0d8c0da6b96d22f392f996fb8d04a38721369677a0c9b378458c"
+
+  url "https://github.com/sk-ruban/notchi/releases/download/v#{version}/Notchi-#{version}.dmg",
+      verified: "github.com/sk-ruban/notchi/"
+  name "Notchi"
+  desc "Notch companion for Claude Code"
+  homepage "https://notchi.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "Notchi.app"
+
+  zap trash: [
+    "~/Library/Caches/com.ruban.notchi",
+    "~/Library/HTTPStorages/com.ruban.notchi",
+    "~/Library/Preferences/com.ruban.notchi.plist",
+    "~/Library/Saved Application State/com.ruban.notchi.savedState",
+  ]
+
+  caveats do
+    <<~EOS
+      Notchi is intended for MacBook models with a display notch and expects Claude Code to be installed.
+      Uninstalling the app does not automatically remove Claude Code hook configuration written on first launch.
+    EOS
+  end
+end

--- a/Casks/n/notchi.rb
+++ b/Casks/n/notchi.rb
@@ -24,11 +24,4 @@ cask "notchi" do
     "~/Library/Preferences/com.ruban.notchi.plist",
     "~/Library/Saved Application State/com.ruban.notchi.savedState",
   ]
-
-  caveats do
-    <<~EOS
-      Notchi is intended for MacBook models with a display notch and expects Claude Code to be installed.
-      Uninstalling the app does not automatically remove Claude Code hook configuration written on first launch.
-    EOS
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. 


AI helped to draft the initial cask and PR text. I manually reviewed the final cask, ran `brew style --fix notchi/validation/notchi`, ran `brew audit --cask --new notchi/validation/notchi`, removed the `caveats` stanza per review, and manually verified the `zap` paths against the app's bundle identifier and the repo's use of cache, HTTP storage, preferences, and saved-state paths.

-----