### PR TITLE
Update SoundAnchor cask with new URL and SHA256

### DIFF
--- a/Casks/s/soundanchor.rb
+++ b/Casks/s/soundanchor.rb
@@ -1,15 +1,14 @@
 cask "soundanchor" do
   version "1.6.2"
-  sha256 "8aaee5b7869d79d95af1c9e421dff6c90ce12bcc991b1b50b7a3cbad2944c478"
+  sha256 "035065faf2fdd3e5e9b2c7e43d09f17254cf637c6882d34b78d8c0f4d81868cb"
 
-  url "https://kopiro.s3.amazonaws.com/soundanchor/soundanchor-#{version}.dmg",
-      verified: "kopiro.s3.amazonaws.com/soundanchor/"
+  url "https://cdn.kopiro.me/soundanchor/SoundAnchor.dmg"
   name "SoundAnchor"
   desc "Audio device utility"
   homepage "https://apps.kopiro.me/soundanchor/"
 
   livecheck do
-    url "https://kopiro.s3.eu-west-1.amazonaws.com/soundanchor/appcast.xml"
+    url "https://cdn.kopiro.me/soundanchor/appcast.xml"
     strategy :sparkle, &:short_version
   end
 
@@ -20,3 +19,4 @@ cask "soundanchor" do
 
   # No zap stanza required
 end
+

--- a/Casks/s/soundanchor.rb
+++ b/Casks/s/soundanchor.rb
@@ -2,7 +2,7 @@ cask "soundanchor" do
   version "1.6.2"
   sha256 "035065faf2fdd3e5e9b2c7e43d09f17254cf637c6882d34b78d8c0f4d81868cb"
 
-  url "https://cdn.kopiro.me/soundanchor/SoundAnchor.dmg"
+  url "https://cdn.kopiro.me/soundanchor/soundanchor-#{version}.dmg"
   name "SoundAnchor"
   desc "Audio device utility"
   homepage "https://apps.kopiro.me/soundanchor/"


### PR DESCRIPTION
The download URL and livecheck URL have migrated from S3 to CDN.

- Old: `https://kopiro.s3.amazonaws.com/soundanchor/soundanchor-1.6.2.dmg` (returns 403)
- New: `https://cdn.kopiro.me/soundanchor/SoundAnchor.dmg`
- Updated sha256 accordingly
- Updated livecheck URL to `https://cdn.kopiro.me/soundanchor/appcast.xml` (returns 200 ✓)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
