### PR TITLE
redeclipse: deprecate

### DIFF
--- a/Casks/r/redeclipse.rb
+++ b/Casks/r/redeclipse.rb
@@ -8,6 +8,8 @@ cask "redeclipse" do
   desc "Multiplayer & singleplayer first person shooter"
   homepage "https://www.redeclipse.net/"
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   app "redeclipse.app"
 
   caveats do

--- a/Casks/r/redeclipse.rb
+++ b/Casks/r/redeclipse.rb
@@ -11,8 +11,4 @@ cask "redeclipse" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "redeclipse.app"
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `redeclipse` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online redeclipse` is error-free.
- [ ] `brew style --fix redeclipse` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new redeclipse` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask redeclipse` worked successfully.
- [ ] `brew uninstall --cask redeclipse` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Deprecating because the cask fails the macOS gatekeeper check
