### PR TITLE
OB-Xf 1.0.1 (New Cask)

### DIFF
--- a/Casks/o/ob-xf.rb
+++ b/Casks/o/ob-xf.rb
@@ -1,0 +1,23 @@
+cask "ob-xf" do
+  version "1.0.1"
+  sha256 "255378d5ee3cfff89c169d00bbbec7ffa8a809bec0676768b07ee9f9bfebf1a6"
+
+  url "https://github.com/surge-synthesizer/OB-Xf/releases/download/v#{version}/ob-xf-macOS-2026-03-24-89eb632.dmg",
+      verified: "github.com/surge-synthesizer/OB-Xf/"
+  name "OB-Xf"
+  desc "Virtual analog synthesiser"
+  homepage "https://surge-synth-team.org/ob-xf/"
+
+  pkg "ob-xf-macOS-2026-03-24-89eb632.pkg"
+
+  uninstall pkgutil: [
+              "org.surge-synth-team.ob-xf.app.pkg",
+              "org.surge-synth-team.ob-xf.clap.pkg",
+              "org.surge-synth-team.ob-xf.component.pkg",
+              "org.surge-synth-team.ob-xf.resources.pkg",
+              "org.surge-synth-team.ob-xf.vst3.pkg",
+            ],
+            delete:  "/Applications/OB-Xf.app"
+
+  # No zap stanza required
+end

--- a/Casks/o/ob-xf.rb
+++ b/Casks/o/ob-xf.rb
@@ -5,7 +5,7 @@ cask "ob-xf" do
   url "https://github.com/surge-synthesizer/OB-Xf/releases/download/v#{version}/ob-xf-macOS-2026-03-24-89eb632.dmg",
       verified: "github.com/surge-synthesizer/OB-Xf/"
   name "OB-Xf"
-  desc "Virtual analog synthesiser"
+  desc "Virtual analog synthesizer"
   homepage "https://surge-synth-team.org/ob-xf/"
 
   pkg "ob-xf-macOS-2026-03-24-89eb632.pkg"

--- a/Casks/o/ob-xf.rb
+++ b/Casks/o/ob-xf.rb
@@ -19,5 +19,5 @@ cask "ob-xf" do
             ],
             delete:  "/Applications/OB-Xf.app"
 
-  # No zap stanza required
+  zap trash: "~/Library/Application Support/OB-Xf.settings"
 end

--- a/Casks/o/ob-xf.rb
+++ b/Casks/o/ob-xf.rb
@@ -1,14 +1,14 @@
 cask "ob-xf" do
-  version "1.0.1"
-  sha256 "255378d5ee3cfff89c169d00bbbec7ffa8a809bec0676768b07ee9f9bfebf1a6"
+  version "1.0.2"
+  sha256 "e069c10a1b45b8ac3d4a2243969fad030c91b661ed30b7ea9daa7d1316c42d4f"
 
-  url "https://github.com/surge-synthesizer/OB-Xf/releases/download/v#{version}/ob-xf-macOS-2026-03-24-89eb632.dmg",
+  url "https://github.com/surge-synthesizer/OB-Xf/releases/download/v#{version}/ob-xf-macOS-v#{version}.dmg",
       verified: "github.com/surge-synthesizer/OB-Xf/"
   name "OB-Xf"
   desc "Virtual analog synthesizer"
   homepage "https://surge-synth-team.org/ob-xf/"
 
-  pkg "ob-xf-macOS-2026-03-24-89eb632.pkg"
+  pkg "ob-xf-macOS-v#{version}.pkg"
 
   uninstall pkgutil: [
               "org.surge-synth-team.ob-xf.app.pkg",


### PR DESCRIPTION
OB-Xf is a newly released stable version of the OB-Xd synthesizer, maintained by the surge-synth team (who also maintains the surge-xt rb here). This is a new but increasingly popular release from the team and early users asked for homebrew integration.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
