### PR TITLE
minecraft-server 26.1

### DIFF
--- a/Casks/m/minecraft-server.rb
+++ b/Casks/m/minecraft-server.rb
@@ -1,9 +1,9 @@
 cask "minecraft-server" do
-  version "1.21.11,64bb6d763bed0a9f1d632ec347938594144943ed"
-  sha256 "f83b8e093865806f931c7e34aae41b177d4c076335263dd124c75d6d65dd1726"
+  version "26.1,3872a7f07a1a595e651aef8b058dfc2bb3772f46"
+  sha256 "98ab064389a8b34d48ac3d4c5ed858dd9433d0dfd1a12e1cbbda916448d92994"
 
-  url "https://launcher.mojang.com/v#{version.major}/objects/#{version.csv.second}/server.jar",
-      verified: "launcher.mojang.com/"
+  url "https://piston-data.mojang.com/v1/objects/#{version.csv.second}/server.jar",
+      verified: "piston-data.mojang.com/"
   name "Minecraft Server"
   desc "Run a Minecraft multiplayer server"
   homepage "https://www.minecraft.net/en-us/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`minecraft-server` is autobumped but the current `url` format doesn't work for version 26.1, as the URL uses `v1` but the version is 26.1 (i.e., `v1` seemingly isn't related to the major version). This updates the version, makes `v1` a hardcoded part of the `url`, and uses the host from the current download URL on the upstream website.