### PR TITLE
freecad 1.1.0

### DIFF
--- a/Casks/f/freecad.rb
+++ b/Casks/f/freecad.rb
@@ -1,19 +1,26 @@
 cask "freecad" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "1.0.2"
-  sha256 arm:   "2fde16da356b62cfce656cd12effaa79f97f2f28a71f1520dd90fabb88f9d3fd",
-         intel: "8d68ef4f8d91a5ecda64d0f27bc2b87b782c534f02ebda27984f69d081a48601"
+  version "1.1.0"
+  sha256 arm:   "52b069f86471ccf4fdd535c42cd9b74b9a8079a7abfd0f51ff19b0a30c6d795b",
+         intel: "9eb363a4bd2e7c718713635a7aecb29c3550302192f89517a157ba07d486da4b"
 
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version}/FreeCAD_#{version}-conda-macOS-#{arch}-py311.dmg",
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
+
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version}/FreeCAD_#{version}-macOS-#{arch}-py311.dmg",
       verified: "github.com/FreeCAD/FreeCAD/"
   name "FreeCAD"
   desc "3D parametric modeller"
   homepage "https://www.freecad.org/"
 
   # Upstream uses GitHub releases to indicate that a version is released
-  # (there's also sometimes a notable gap between the release being created
-  # and the homepage being updated), so the `GithubLatest` strategy is necessary.
+  # (there's also sometimes a notable gap between when the release is created
+  # and the homepage is updated), so the `GithubLatest` strategy is necessary.
   livecheck do
     url :url
     strategy :github_latest


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`freecad` is autobumped but the workflow failed to update to version 1.1.0 because the file name no longer contains a `-conda` suffix. This updates the version and adjusts the `url` accordingly. Besides that, this also massages the `livecheck` block comment to ease readability.