### PR TITLE
tiled 1.12.1

### DIFF
--- a/Casks/t/tiled.rb
+++ b/Casks/t/tiled.rb
@@ -1,10 +1,10 @@
 cask "tiled" do
-  version "1.12.0"
+  version "1.12.1"
 
   on_monterey :or_older do
-    sha256 "e64a5f1fcdfecdf3b615383174c54f392e84f368e84cfdd02274214858ad1e52"
+    sha256 "7ccac675b6e71e7a87d558f5b3330040c59a091eafba9cff313261eb84eb8214"
 
-    url "https://github.com/mapeditor/tiled/releases/download/v#{version}/Tiled-#{version}_macOS-10.13-10.15.zip",
+    url "https://github.com/mapeditor/tiled/releases/download/v#{version}/Tiled-#{version}_macOS-10.13-12.zip",
         verified: "github.com/mapeditor/tiled/"
 
     caveats do
@@ -12,9 +12,9 @@ cask "tiled" do
     end
   end
   on_ventura :or_newer do
-    sha256 "071b80c7802a25af164e97dd9ed0742e0eae318ca4a12dbc8189bdb59e94f29f"
+    sha256 "bc6b4958d4fa8701137ff9c61327f53b708f2b8b2feb8db51c925b8908eb1298"
 
-    url "https://github.com/mapeditor/tiled/releases/download/v#{version}/Tiled-#{version}_macOS-11+.zip",
+    url "https://github.com/mapeditor/tiled/releases/download/v#{version}/Tiled-#{version}_macOS-13+.zip",
         verified: "github.com/mapeditor/tiled/"
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`tiled` is autobumped but the workflow failed to update to version 1.12.1 because the macOS version suffixes were changed in this release (the supported macOS versions changed in a previous version but they didn't update the suffixes at the time). This updates the version and adjusts the URLs accordingly.