### PR TITLE
fredm-fuse 1.7.0

### DIFF
--- a/Casks/f/fredm-fuse.rb
+++ b/Casks/f/fredm-fuse.rb
@@ -1,6 +1,6 @@
 cask "fredm-fuse" do
-  version "1.5.6"
-  sha256 "fb7997f06f445a80ee426c9403c8a0244c0ca891479f6b80de6fc53f101df767"
+  version "1.7.0"
+  sha256 "75902a76b4c45bed9d4cf60405edddb7068c778609eab558aa2cbe7c375c6ce1"
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip",
       verified: "downloads.sourceforge.net/fuse-for-macosx/"
@@ -8,12 +8,9 @@ cask "fredm-fuse" do
   desc "Port of the UNIX ZX Spectrum emulator Fuse"
   homepage "https://fuse-for-macosx.sourceforge.io/"
 
-  deprecate! date: "2024-09-01", because: :unmaintained
-  disable! date: "2025-09-02", because: :unmaintained
+  depends_on macos: ">= :big_sur"
 
   app "Fuse for MacOS/Fuse.app"
 
-  caveats do
-    requires_rosetta
-  end
+  zap trash: "~/Library/Preferences/net.sourceforge.fuse-for-macosx.Fuse.plist"
 end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online fredm-fuse` is error-free.
- [x] `brew style --fix fredm-fuse` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Following changes made in addition to version bump:

- `deprecate!` and `disable!` removed as this program is no longer unsupported
- `depends_on` added. `big_sur` is specified (although [the official announcement post](https://spectrumcomputing.co.uk/forums/viewtopic.php?p=190714) states 11.5 is required)
- `zap` added
- Rosetta requirement removed as the official announcement post states that an Apple Silicon Mac is required