### PR TITLE
paseo: fix Electron assets

### DIFF
--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -19,7 +19,7 @@ cask "paseo" do
   depends_on macos: ">= :monterey"
 
   app "Paseo.app"
-  binary "#{appdir}/Paseo.app/Contents/Resources/bin/paseo", target: "paseo"
+  binary "#{appdir}/Paseo.app/Contents/Resources/bin/paseo"
 
   zap trash: [
     "~/Library/Application Support/dev.paseo.desktop",

--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -1,11 +1,11 @@
 cask "paseo" do
-  arch arm: "-arm64"
+  arch arm: "arm64", intel: "x64"
 
   version "0.1.34"
-  sha256 arm:   "84613910a360f00aa5b2de321365b53458ebb334051fba4dfedd230e1265831a",
-         intel: "a9df6ffd293bc4c15f760364921092017c83efa38e5f0ca1d9bbdb70b8f19eb7"
+  sha256 arm:   "460f90aa4f17386689267723c9dd6eded459d0b63ad5f4ee1cd82db235b274f8",
+         intel: "8d1198335e27449e31d3f50fc1088c074272493d9a116e00889f9c00d94003a5"
 
-  url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo-#{version}#{arch}.dmg",
+  url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo-#{version}-#{arch}.dmg",
       verified: "github.com/getpaseo/paseo/"
   name "Paseo"
   desc "Self-hosted daemon for AI coding agents"
@@ -19,7 +19,7 @@ cask "paseo" do
   depends_on macos: ">= :monterey"
 
   app "Paseo.app"
-  binary "#{appdir}/Paseo.app/Contents/MacOS/Paseo", target: "paseo"
+  binary "#{appdir}/Paseo.app/Contents/Resources/bin/paseo", target: "paseo"
 
   zap trash: [
     "~/Library/Application Support/dev.paseo.desktop",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with checking prior Paseo cask PRs, the Homebrew cask docs/template, and drafting the minimal stanza changes. I manually verified the release asset names and SHA256 values for `Paseo-0.1.34-arm64.dmg` and `Paseo-0.1.34-x64.dmg`, ran `brew style --fix` and `brew audit --cask --online`, reinstalled the cask locally on macOS 15.6.1, confirmed `/opt/homebrew/bin/paseo` now links to `/Applications/Paseo.app/Contents/Resources/bin/paseo`, ran `paseo --help`, and reviewed the unchanged `zap` paths.

-----

This updates the macOS asset naming and binary artifact path to match the current Electron packaging layout after migrating from Tauri to Electron.
