### PR TITLE
canon-mg2500-driver 16.91.0.0,05,0100011526,6

### DIFF
--- a/Casks/c/canon-mg2500-driver.rb
+++ b/Casks/c/canon-mg2500-driver.rb
@@ -1,15 +1,15 @@
 cask "canon-mg2500-driver" do
-  version "16.90.0.0,04,0100011526,6"
-  sha256 "93a2289b5c69017cc87289b972566411c802d0e73457fb33c8b88a9f2947d13b"
+  version "16.91.0.0,05,0100011526,6"
+  sha256 "95d2cfd5ded450b0e2cecdbed792c7a592223adf3209182d05347f0a44ce96be"
 
   url "https://gdlp01.c-wss.com/gds/#{version.csv.fourth}/#{version.csv.third}/#{version.csv.second}/mcpd-mac-mg2500-#{version.csv.first.dots_to_underscores}-ea21_3.dmg",
       verified: "gdlp01.c-wss.com/"
   name "Canon PIXMA driver"
-  desc "CUPS driver for Canon PIXMA 2500 series"
+  desc "CUPS driver for Canon PIXMA MG2500 series"
   homepage "https://ij.manual.canon/ij/webmanual/Manual/M/MG2500%20series/EN/CNT/Top.html"
 
   livecheck do
-    url "https://pdisp01.c-wss.com/gdl/WWUFORedirectTarget.do?id=MDEwMDAxMTUyNjA0&cmp=ABR&lang=EN"
+    url "https://pdisp01.c-wss.com/gdl/WWUFORedirectTarget.do?id=MDEwMDAxMTUyNjA1&cmp=ABR&lang=EN"
     regex(%r{(\d+)/(\d+)/(\d+)/mcpd-mac-mg2500-(\d+(?:_\d+)+)-ea21_3\.dmg}i)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

This is a new update to the Canon PIXMA MG2500 printer series driver, which was released given the new release of macOS Tahoe 26.0 (and subsequent later releases). This update still supports as old as macOS Big Sur.