### PR TITLE
tablepro: update repository URL and description

### DIFF
--- a/Casks/t/tablepro.rb
+++ b/Casks/t/tablepro.rb
@@ -5,14 +5,14 @@ cask "tablepro" do
   sha256 arm:   "ccbc49e990ed76a68c0b8e96f3f54db9f54c84ba238c8fb2ff523002cacd9e78",
          intel: "6af908da76c65f90b41a37939ddd762adb554b3069ce18d3d58bf9c6af797cfe"
 
-  url "https://github.com/datlechin/TablePro/releases/download/v#{version}/TablePro-#{version}-#{arch}.dmg",
-      verified: "github.com/datlechin/TablePro/"
+  url "https://github.com/TableProApp/TablePro/releases/download/v#{version}/TablePro-#{version}-#{arch}.dmg",
+      verified: "github.com/TableProApp/TablePro/"
   name "TablePro"
   desc "Native database client for MySQL, PostgreSQL, SQLite, and MongoDB"
   homepage "https://tablepro.app/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/datlechin/TablePro/main/appcast.xml"
+    url "https://raw.githubusercontent.com/TableProApp/TablePro/main/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
The TablePro repository moved from `datlechin/TablePro` to `TableProApp/TablePro`. Also updates the cask description.