### PR TITLE
Update Dictionaries 2.9 checksum

### DIFF
--- a/Casks/d/dictionaries.rb
+++ b/Casks/d/dictionaries.rb
@@ -1,6 +1,6 @@
 cask "dictionaries" do
   version "2.9"
-  sha256 "262858a6cd8ba8ab37709da7c1991c5d1cfa32214b5ad02053114e023b134845"
+  sha256 "c4c189f0f4a80874e30777457ef089af5bafb27f5ceebec5e382d80fea99133c"
 
   url "https://download.dictionaries.io/mac/Dictionaries-#{version}.zip"
   name "Dictionaries"


### PR DESCRIPTION
sha256 checksum of https://download.dictionaries.io/mac/Dictionaries-2.9.zip has been changed for some reason after yesterday's release of 2.9, thus `dictionaries` is not installable via Homebrew as of now.

```
❯ brew install --cask dictionaries
==> Fetching downloads for: dictionaries
✘ Cask dictionaries (2.9)                                                                                                                                              Verifying     9.5MB/  9.5MB
Error: Cask reports different checksum:     262858a6cd8ba8ab37709da7c1991c5d1cfa32214b5ad02053114e023b134845
       SHA-256 checksum of downloaded file: c4c189f0f4a80874e30777457ef089af5bafb27f5ceebec5e382d80fea99133c

❯ wget https://download.dictionaries.io/mac/Dictionaries-2.9.zip
--2026-03-29 18:53:43--  https://download.dictionaries.io/mac/Dictionaries-2.9.zip
Resolving download.dictionaries.io (download.dictionaries.io)... 152.89.160.26
Connecting to download.dictionaries.io (download.dictionaries.io)|152.89.160.26|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 9531058 (9.1M) [application/zip]
Saving to: ‘Dictionaries-2.9.zip’

Dictionaries-2.9.zip                             100%[========================================================================================================>]   9.09M  24.9MB/s    in 0.4s

2026-03-29 18:53:43 (24.9 MB/s) - ‘Dictionaries-2.9.zip’ saved [9531058/9531058]


❯ sha256sum Dictionaries-2.9.zip
c4c189f0f4a80874e30777457ef089af5bafb27f5ceebec5e382d80fea99133c  Dictionaries-2.9.zip
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
