### PR TITLE
Add flock-terminal cask

### DIFF
--- a/Casks/f/flock-terminal.rb
+++ b/Casks/f/flock-terminal.rb
@@ -1,0 +1,26 @@
+cask "flock-terminal" do
+  version "0.9.1"
+  sha256 "5507b2ec1e8b3d78b013a61bce4aacc236b2718ce29fc38f013f1f7963a49969"
+
+  url "https://github.com/Divagation/flock/releases/download/v#{version}/Flock-#{version}-mac.zip",
+      verified: "github.com/Divagation/flock/"
+  name "Flock"
+  desc "Terminal multiplexer for Claude Code sessions"
+  homepage "https://divagation.github.io/flock/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+  depends_on arch: :arm64
+
+  app "Flock.app"
+  binary "#{appdir}/Flock.app/Contents/MacOS/Flock", target: "flock"
+
+  zap trash: [
+    "~/Library/Preferences/com.baa.flock.plist",
+    "~/Library/Saved Application State/com.baa.flock.savedState",
+  ]
+end


### PR DESCRIPTION
## Description

Adds a cask for **Flock**, a native macOS terminal multiplexer built for Claude Code sessions.

- **Cask name**: `flock-terminal` (avoiding conflict with existing `flock` formula in homebrew-core and `flock-app` cask)
- **Version**: 0.9.1
- **Architecture**: arm64
- **Minimum macOS**: Ventura (13.0)

Flock provides parallel Claude Code session management with theming, agent mode, prompt compression (via Wren), and usage tracking.

- Homepage: https://divagation.github.io/flock/
- Source: https://github.com/Divagation/flock

## Checklist

- [x] `brew style` passes with no offenses
- [x] SHA256 verified against release asset
- [x] Livecheck configured with `strategy :github_latest`
- [x] `zap` stanza includes preferences and saved state
- [x] Binary artifact creates `flock` CLI symlink