### PR TITLE
Add orchard-ops cask

### DIFF
--- a/Casks/o/orchard-ops.rb
+++ b/Casks/o/orchard-ops.rb
@@ -1,0 +1,24 @@
+cask "orchard-ops" do
+  version "0.2.1"
+  sha256 "601735973627a68124213a160aac6b881d6bc48224778a88d0871ec1cfa4f830"
+
+  url "https://github.com/shinout/orchard-ops-site/releases/download/v#{version}/OrchardOps.dmg"
+  name "Orchard Ops"
+  desc "Schedule scripts and commands on your Mac with a visual timeline"
+  homepage "https://orchard-ops.com/"
+
+  livecheck do
+    url "https://orchard-ops.com/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Orchard Ops.app"
+
+  zap trash: [
+    "~/Library/Application Support/OrchardOps",
+    "~/Library/Preferences/com.orchard-ops.OrchardOps.plist",
+  ]
+end


### PR DESCRIPTION
## Description

Add a new cask for [Orchard Ops](https://orchard-ops.com/), a native macOS task scheduler.

**What it does:** Schedule scripts, CLI commands, and Apple Shortcuts to run automatically with a visual timeline. Wakes Mac from sleep before tasks run via pmset.

- Homepage: https://orchard-ops.com/
- Download: DMG from GitHub Releases
- Livecheck: Sparkle appcast at https://orchard-ops.com/appcast.xml
- Requires macOS 14.0 (Sonoma) or later
- Notarized and signed with Developer ID