### PR TITLE
Add craft-agents 0.8.1

### DIFF
--- a/Casks/c/craft-agents.rb
+++ b/Casks/c/craft-agents.rb
@@ -1,0 +1,31 @@
+cask "craft-agents" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.8.1"
+  sha256 arm:   "93b18f372de8590510c7bf216b090e4344889fe5b2959a12bee06d69e2aaae47",
+         intel: "f8f02b80a771d3f4ac94badfeeab9ee8e5832485b9e92aa1327b1b12faac780e"
+
+  url "https://github.com/lukilabs/craft-agents-oss/releases/download/v#{version}/Craft-Agents-#{version}-mac-#{arch}.dmg",
+      verified: "github.com/lukilabs/craft-agents-oss/"
+  name "Craft Agents"
+  desc "AI assistant for connecting and working across data sources"
+  homepage "https://agents.craft.do/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "Craft Agents.app"
+
+  zap trash: [
+    "~/Library/Application Support/Craft Agents",
+    "~/Library/Caches/com.lukilabs.craft-agent",
+    "~/Library/HTTPStorages/com.lukilabs.craft-agent",
+    "~/Library/Preferences/com.lukilabs.craft-agent.plist",
+    "~/Library/Saved Application State/com.lukilabs.craft-agent.savedState",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online craft-agents` is error-free.
- [x] `brew style --fix craft-agents` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new craft-agents` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask craft-agents` worked successfully.
- [x] `brew uninstall --cask craft-agents` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. The cask definition was drafted with AI assistance. All `brew audit`, `brew style`, `brew install`, and `brew uninstall` commands were run manually to verify correctness. `zap` stanza paths were verified by inspecting the installed app's sandbox containers and preferences on disk.