### PR TITLE
rnote 0.14.0+227 (arm only)

### DIFF
--- a/Casks/r/rnote.rb
+++ b/Casks/r/rnote.rb
@@ -1,9 +1,18 @@
 cask "rnote" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "0.13.1+215"
-  sha256 arm:   "940af287a78ee242b05b14f649b32e9cc297090e6d7d69759945f97fe49c55b0",
-         intel: "c985ea4757b9ac03cd7485ac824d3488a31b52b98fdb221a1d5ee062d58d7af8"
+  on_arm do
+    version "0.14.0+227"
+    sha256 "63f3178f1fba2b0d2d2ac131766e3f581df4550a1d49dfa3d24e8cc909e44803"
+
+    depends_on macos: ">= :ventura"
+  end
+  on_intel do
+    version "0.13.1+215"
+    sha256 "c985ea4757b9ac03cd7485ac824d3488a31b52b98fdb221a1d5ee062d58d7af8"
+
+    depends_on macos: ">= :big_sur"
+  end
 
   url "https://gitlab.com/api/v4/projects/44053427/packages/generic/rnote_macos/#{version}/Rnote-#{version}_#{arch}.dmg",
       verified: "gitlab.com/api/v4/projects/44053427/packages/generic/rnote_macos/"
@@ -11,15 +20,19 @@ cask "rnote" do
   desc "Sketch and take handwritten notes"
   homepage "https://rnote.flxzt.net/"
 
+  # This matches the version from arch-specific asset file names, as releases
+  # may not provide assets for both ARM and Intel.
   livecheck do
     url "https://gitlab.com/api/v4/projects/44053427/releases"
-    regex(/^v?(\d+(?:\.\d+)+(?:\+\d+)?)$/i)
+    regex(/Rnote[._-]v?(\d+(?:\.\d+)+(?:\+\d+)?)[._-]#{arch}/i)
     strategy :json do |json, regex|
-      json.filter_map { |item| item["tag_name"]&.[](regex, 1) }
+      json.map do |item|
+        item.dig("assets", "links")&.filter_map do |asset|
+          asset["direct_asset_url"]&.[](regex, 1)
+        end
+      end.flatten
     end
   end
-
-  depends_on macos: ">= :big_sur"
 
   app "Rnote.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`rnote` is autobumped but the workflow failed to update to version 0.14.0+227 for ARM, as there is no Intel asset for this release and fetching the asset predictably fails. The upstream release notes say, "There is no Intel release. The Intel runner cannot build for Ventura at the moment." With that in mind, this splits the ARM and Intel versions to handle the ARM version update and modifies the `livecheck` block to match the version from the arch-specific asset file names.