### PR TITLE
shipclip 1.3.0 (new cask)

### DIFF
--- a/Casks/s/shipclip.rb
+++ b/Casks/s/shipclip.rb
@@ -2,8 +2,7 @@ cask "shipclip" do
   version "1.3.0"
   sha256 "c7a7870be3f1a16acba723b2509d37a4a51657b62421ad9359ea4aa99bcd222a"
 
-  url "https://api.shipclip.app/releases/ShipClip-#{version}.dmg",
-      verified: "api.shipclip.app/"
+  url "https://api.shipclip.app/releases/ShipClip-#{version}.dmg"
   name "ShipClip"
   desc "Screen recorder with zoom-to-click and multi-track audio"
   homepage "https://shipclip.app/"

--- a/Casks/s/shipclip.rb
+++ b/Casks/s/shipclip.rb
@@ -1,0 +1,30 @@
+cask "shipclip" do
+  version "1.3.0"
+  sha256 "c7a7870be3f1a16acba723b2509d37a4a51657b62421ad9359ea4aa99bcd222a"
+
+  url "https://api.shipclip.app/releases/ShipClip-#{version}.dmg",
+      verified: "api.shipclip.app/"
+  name "ShipClip"
+  desc "Screen recorder with zoom-to-click and multi-track audio"
+  homepage "https://shipclip.app/"
+
+  livecheck do
+    url "https://api.shipclip.app/api/releases/latest"
+    strategy :json do |json|
+      json.dig("latest", "version")
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "ShipClip.app"
+
+  zap trash: [
+        "~/Library/Caches/digital.ligma.shipclip",
+        "~/Library/HTTPStorages/digital.ligma.shipclip",
+        "~/Library/Preferences/digital.ligma.shipclip.plist",
+        "~/Library/Saved Application State/digital.ligma.shipclip.savedState",
+      ],
+      rmdir: "~/Movies/ShipClip"
+end


### PR DESCRIPTION
**Name:** ShipClip
**Homepage:** https://shipclip.app/
**Description:** Screen recorder with zoom-to-click and multi-track audio
**Download:** DMG from https://api.shipclip.app/releases/ShipClip-1.3.0.dmg

Native macOS screen recorder (macOS 14+ / Sonoma) with automatic zoom-to-click effects, multi-track audio, camera PiP with background removal, and shareable links with viewer analytics.

- Livecheck uses the JSON API at `/api/releases/latest`
- `auto_updates true` (uses Sparkle)
- Zap stanza cleans up caches, preferences, and the recordings directory