### PR TITLE
Enable auto updates for Figma

### DIFF
--- a/Casks/f/figma.rb
+++ b/Casks/f/figma.rb
@@ -17,6 +17,8 @@ cask "figma" do
     end
   end
 
+  auto_updates true
+
   app "Figma.app"
 
   zap trash: [


### PR DESCRIPTION
Enable auto updates for Figma.
Given the current situation, Figma already has very good automatic updates.
I saw #239533, but there is no similar issue at the moment.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.