### PR TITLE
claude-code@latest: revision to 2.1.87

### DIFF
--- a/Casks/c/claude-code@latest.rb
+++ b/Casks/c/claude-code@latest.rb
@@ -2,11 +2,11 @@ cask "claude-code@latest" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.1.88"
-  sha256 arm:          "fe0d191adb7b0d26badd1e303e95a63d62d526ca1fb5882f53644754e1e9fe95",
-         x86_64:       "4036c17c5ebdeaf024f198b041e012e494b8cab8c7dec1bdde567ebbbfc5124d",
-         x86_64_linux: "ced6cac958fa4425b90e6c9341a26731715fcb1a253d5bc0f51c8d5a3a6ab66e",
-         arm64_linux:  "2ba4ac149b2198c15e45837fc504146c735fc1e82b9fdf717c2a6b9e0f70c02c"
+  version "2.1.87"
+  sha256 arm:          "80b51562db1a51bfb654aec1fea6a04106daa0bc1525d88c9c74741ff5d9469a",
+         x86_64:       "c1a4cde29e74e4c3952ead69f90a37a2388aa097d7c567a81ca3669a309e9226",
+         x86_64_linux: "b1a5b89469862adee0e4dc28cab5a8314bc4d0117e19ab26a7b7ff7ce9b59bd5",
+         arm64_linux:  "193c5e9c091eadde302fa23af46c8d646b7263f74fa06ed32746e504bd09df18"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION
## Summary

Restore **claude-code@latest** to **2.1.87** and the checksums from the last working cask revision.

## Problem

`brew install --cask claude-code@latest` fails because **2.1.88** binaries return **404** (e.g. `.../claude-code-releases/2.1.88/darwin-arm64/claude`).

The CDN `latest` file (same URL as `livecheck`) still returns **2.1.87**; **2.1.87** artifacts respond **200**.

## Changes

- `version` **2.1.88 → 2.1.87**
- `sha256` stanzas restored to match **2.1.87** for all architectures (same values as commit before the 2.1.88 bump).