### PR TITLE
Add saddle 1.2

### DIFF
--- a/Casks/s/saddle.rb
+++ b/Casks/s/saddle.rb
@@ -1,0 +1,17 @@
+cask "saddle" do
+  version "1.2"
+  sha256 "aebc612cb791c46a07eee98947587282e4ba3a0d36020ed69cc4865f7cfc4267"
+
+  url "https://github.com/smandable/Saddle/releases/download/v#{version}/Saddle-#{version}.dmg"
+  name "Saddle"
+  desc "Menu bar app for managing external drives on macOS"
+  homepage "https://github.com/smandable/Saddle"
+
+  depends_on macos: ">= :ventura"
+
+  app "Saddle.app"
+
+  zap trash: [
+    "~/Library/Application Support/Saddle",
+  ]
+end


### PR DESCRIPTION
New cask for [Saddle](https://github.com/smandable/Saddle) — a native macOS menu bar app for managing external drives. Mount, unmount, organize into groups, and auto-manage drives at login.

- **Name:** Saddle
- **Homepage:** https://github.com/smandable/Saddle
- **Download:** DMG from GitHub Releases (Developer ID signed + notarized by Apple)
- **Requires:** macOS 13.0 (Ventura) or later