### PR TITLE
kameleo 4.4.0

### DIFF
--- a/Casks/k/kameleo.rb
+++ b/Casks/k/kameleo.rb
@@ -2,8 +2,8 @@ cask "kameleo" do
   version "4.3.0"
   sha256 "d184faa065b89350bf0aeb4e4647556964288499c4f6db4c51305c137990b4c2"
 
-  url "https://github.com/kameleo-io/releases/releases/download/#{version}/kameleo-#{version}-osx-arm64.dmg",
-      verified: "github.com/kameleo-io/releases/"
+  url "https://github.com/kameleo-io/kameleo/releases/download/#{version}/kameleo-#{version}-osx-arm64.dmg",
+      verified: "github.com/kameleo-io/kameleo/"
   name "Kameleo"
   desc "Antidetect browser to bypass anti-bot systems"
   homepage "https://kameleo.io/"

--- a/Casks/k/kameleo.rb
+++ b/Casks/k/kameleo.rb
@@ -1,6 +1,6 @@
 cask "kameleo" do
-  version "4.3.0"
-  sha256 "d184faa065b89350bf0aeb4e4647556964288499c4f6db4c51305c137990b4c2"
+  version "4.4.0"
+  sha256 "effe2420c98e4c08ae5d55793b437c056d0e61462440ca1e9c47f2682c31d7a8"
 
   url "https://github.com/kameleo-io/kameleo/releases/download/#{version}/kameleo-#{version}-osx-arm64.dmg",
       verified: "github.com/kameleo-io/kameleo/"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I haven't run brew, because the change is only to the URL, the sha256 still matched for [4.3.0](https://github.com/kameleo-io/kameleo/releases/tag/4.3.0). Edit: bumped to 4.4.0 to fix live-check issue.