### PR TITLE
proton-meet 1.0.7 (new cask)

### DIFF
--- a/Casks/p/proton-meet.rb
+++ b/Casks/p/proton-meet.rb
@@ -1,0 +1,32 @@
+cask "proton-meet" do
+  version "1.0.7"
+  sha256 "beed0ac38756179b0608f0857db814f1ee9e164753ea43501e2f487fe47346bf"
+
+  url "https://proton.me/download/meet/macos/#{version}/ProtonMeet-desktop.dmg"
+  name "Proton Meet"
+  desc "Desktop client for Proton Meet"
+  homepage "https://proton.me/meet"
+
+  livecheck do
+    url "https://proton.me/download/meet/macos/version.json"
+    strategy :json do |json|
+      json["Releases"]&.map do |item|
+        next unless item["CategoryName"]&.match?("Stable")
+
+        item["Version"]
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "Proton Meet.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/ch.protonmeet.desktop.sfl*",
+    "~/Library/Application Support/Proton Meet",
+    "~/Library/Logs/Proton Meet",
+    "~/Library/Preferences/ch.protonmeet.desktop.plist",
+  ]
+end


### PR DESCRIPTION
Adding Proton Meet cask which was generally released yesterday (announced on https://proton.me/business/blog/introducing-proton-meet)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

No "AI" was used. I did use the existing Proton casks for reference, as well as the cookbook. For `zap` stanza:
- I manually went through all the paths mentioned in the Cookbook
- I manually went through all the paths listed in all other existing Proton casks, i.e. ProtonVPN (`protonvpn.rb`), Proton Pass (`proton-pass.rb`), Proton Drive (`proton-drive.rb`), Proton Mail (`proton-mail`), and Proton Mail Bridge (`proton-mail-bridge`)
- I ran the following but not to completion as they were taking an inordinate amount of time to complete:
  - `sudo find / -iname "*Proton Meet*"`
  - `sudo find / -iname "*proton*"`
  - `sudo find / -iname "*meet*"`

-----
