### PR TITLE
obsidian: fix CLI binary to avoid unnecessary GUI launch

### DIFF
--- a/Casks/o/obsidian.rb
+++ b/Casks/o/obsidian.rb
@@ -19,16 +19,7 @@ cask "obsidian" do
   depends_on macos: ">= :monterey"
 
   app "Obsidian.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/obsidian.wrapper.sh"
-  binary shimscript, target: "obsidian"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/Obsidian.app/Contents/MacOS/Obsidian' "$@"
-    EOS
-  end
+  binary "#{appdir}/Obsidian.app/Contents/MacOS/obsidian-cli", target: "obsidian"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/md.obsidian.sfl*",


### PR DESCRIPTION
The binary stanza was pointing to the Obsidian GUI binary instead of the dedicated obsidian-cli binary. While the GUI binary can delegate CLI commands, it does so by first launching the full GUI, causing a visible Obsidian window to appear before the command is executed.

The correct binary for terminal CLI usage is obsidian-cli, which communicates directly with a running Obsidian instance without launching the GUI.

Also removes the shim script workaround, as it is not needed when linking the correct binary directly.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used just to create a proper commit message

-----
