### PR TITLE
nextcloud-vfs: deprecate (merged into nextcloud)

### DIFF
--- a/Casks/n/nextcloud-vfs.rb
+++ b/Casks/n/nextcloud-vfs.rb
@@ -8,10 +8,7 @@ cask "nextcloud-vfs" do
   desc "Desktop sync client for Nextcloud software products"
   homepage "https://nextcloud.com/"
 
-  livecheck do
-    url "https://nextcloud.com/install/#desktop-files"
-    regex(/href=.*?Nextcloud[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]vfs\.pkg/i)
-  end
+  deprecate! date: "2026-04-01", because: :discontinued, replacement_cask: "nextcloud"
 
   auto_updates true
   conflicts_with cask: "nextcloud"


### PR DESCRIPTION
The VFS and classic clients were merged in the 33.0.0 release (see release notes: https://github.com/nextcloud-releases/desktop/releases/tag/v33.0.0-rc1). There is no longer a separate VFS package — VFS support is now included in the standard \`nextcloud\` cask.