### PR TITLE
Update fiji: change app to suite to fix launch configuration error

### DIFF
--- a/Casks/f/fiji.rb
+++ b/Casks/f/fiji.rb
@@ -19,7 +19,7 @@ cask "fiji" do
   auto_updates true
   depends_on macos: ">= :big_sur"
 
-  app "Fiji/Fiji.app"
+  suite "Fiji"
 
   zap trash: [
     "~/Library/Preferences/sc.fiji.cellcounter.plist",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

-----

Installing the fiji cask currently results in a broken application. When launching Fiji.app, users receive the following error: "Launch configuration files not found."

Fiji recently updated its application launcher (utilizing jaunch). As a result, Fiji.app is no longer a fully self-contained macOS bundle. It now strictly depends on configuration files that are located in the parent directory of the extracted ZIP, outside of the .app bundle itself.

The current cask uses the app "Fiji/Fiji.app" stanza, which cherry-picks only the .app bundle, moves it to /Applications, and discards the parent directory. This deletes the required configuration files and breaks the launcher.