### PR TITLE
Add battery-notifier 4.2.1

### DIFF
--- a/Casks/b/battery-notifier.rb
+++ b/Casks/b/battery-notifier.rb
@@ -1,0 +1,18 @@
+cask "battery-notifier" do
+  version "4.2.1"
+  sha256 "c92024319e8c14290f921585d6dc57c233f3c719c1b1a2d69ad08e85771fca15"
+
+  url "https://github.com/Sandip124/BatteryNotifier/releases/download/v#{version}/BatteryNotifier-osx-arm64.zip"
+  name "BatteryNotifier"
+  desc "Cross-platform battery monitoring and notification app"
+  homepage "https://github.com/Sandip124/BatteryNotifier"
+
+  depends_on macos: ">= :ventura"
+
+  app "BatteryNotifier.app"
+
+  zap trash: [
+    "~/Library/Application Support/BatteryNotifier",
+    "~/Library/LaunchAgents/com.batterynotifier.plist",
+  ]
+end


### PR DESCRIPTION
## Description

New cask for [BatteryNotifier](https://github.com/Sandip124/BatteryNotifier) — a cross-platform battery monitoring and notification app built with Avalonia UI.

**Features:**
- Battery full/low notifications with escalating reminders
- System tray integration
- DND/fullscreen-aware notification suppression
- Custom notification sounds
- Theme support (system/light/dark)
- Power-hungry app detection (battery drainers)

**GitHub:** 75+ stars, actively maintained

**Artifact:** Signed and notarized `.app` bundle in a `.zip` archive (arm64)

```
brew install --cask battery-notifier
```