### PR TITLE
menuwhere 2.3.0

### DIFF
--- a/Casks/m/menuwhere.rb
+++ b/Casks/m/menuwhere.rb
@@ -1,15 +1,25 @@
 cask "menuwhere" do
-  version "2.2.2"
-  sha256 "eccd3a9e986d1e5ee20717ad00387ff669ad21abfc8a7d2b50e99e0f5f8ca978"
+  version "2.3.0"
+  sha256 "26018be00b8d097e24c397c2f93996af47353dd1c8e54c7fcf28067fadd0dd3b"
 
   url "https://manytricks.com/download/_do_not_hotlink_/menuwhere#{version.no_dots}.dmg"
   name "Menuwhere"
   desc "Access the menu from anywhere"
   homepage "https://manytricks.com/menuwhere/"
 
+  # The dotless version in the file name uses major/minor/patch but the appcast
+  # `shortVersionString` may omit patch for new major/minor versions (e.g.
+  # 230 and 2.3 respectively). This adds `.0` to versions without a patch to
+  # avoid this mismatch.
   livecheck do
     url "https://manytricks.com/menuwhere/appcast/"
-    strategy :sparkle, &:short_version
+    regex(/^v?(\d+\.\d+)(\.\d+)*$/i)
+    strategy :sparkle do |item, regex|
+      match = item.short_version&.match(regex)
+      next unless match
+
+      "#{match[1]}#{match[2].presence || ".0"}"
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`menuwhere` is autobumped but the workflow failed to update to version 2.3.0 because the `shortVersionString` in the appcast is 2.3 but the file name uses a dotless 230 version. We already handle this in the `witch` cask from the same source, so this updates the version and borrows that approach (i.e., appending `.0` to versions with only a major/minor).