### PR TITLE
Add token-jandi 0.4.0

### DIFF
--- a/Casks/t/token-jandi.rb
+++ b/Casks/t/token-jandi.rb
@@ -1,0 +1,17 @@
+cask "token-jandi" do
+  version "0.4.0"
+  sha256 "0afeff9c31062c2bfa28390c2caede6e61f56067113f1d18ba17d60d65d33290"
+
+  url "https://github.com/wheon06/token-jandi/releases/download/v#{version}/Token.Jandi-#{version}.zip"
+  name "Token Jandi"
+  desc "AI token usage heatmap for macOS menu bar"
+  homepage "https://github.com/wheon06/token-jandi"
+
+  depends_on macos: ">= :sonoma"
+
+  app "Token Jandi.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.heeyeonlee.token-jandi.plist",
+  ]
+end


### PR DESCRIPTION
## Description

**Token Jandi** is a macOS menu bar app that visualizes AI (Claude Code) token usage as a GitHub-style contribution heatmap.

### Features
- GitHub-style grass heatmap (20 weeks)
- Real token data from local Claude Code session files
- Daily/Monthly usage bar charts
- Menu bar today's usage display (toggleable)
- Korean/English localization
- Auto-update support
- Signed & Notarized by Apple (Developer ID: HEEYEON LEE)

### Links
- **Homepage:** https://github.com/wheon06/token-jandi
- **Download:** https://github.com/wheon06/token-jandi/releases/tag/v0.4.0

### Checklist
- [x] `brew audit --cask --strict token-jandi` passes with no warnings
- [x] App is signed with Developer ID Application certificate
- [x] App is notarized by Apple
- [x] Formula follows Homebrew cask conventions