### PR TITLE
Update and rename sleek-app.rb to sleek-todo-txt.rb

### DIFF
--- a/Casks/s/sleek-todo-txt.rb
+++ b/Casks/s/sleek-todo-txt.rb
@@ -1,4 +1,4 @@
-cask "sleek-app" do
+cask "sleek-todo-txt" do
   arch arm: "arm64", intel: "x64"
 
   version "2.0.24"


### PR DESCRIPTION
Unfortunately, someone renamed my app from "sleek" to "sleek-app." I believe this change causes a lot of confusion, since users were already accustomed to installing it simply as "sleek"—which is now reserved by another package.

To make "sleek-app" more recognizable as the known todo.txt app, I would like to change the cask name to "sleek-todo-txt"

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
