### PR TITLE
radial 4.1.0 (new cask)

### DIFF
--- a/Casks/r/radial.rb
+++ b/Casks/r/radial.rb
@@ -1,5 +1,5 @@
 cask "radial" do
-  version "4.1.0,410"
+  version "4.1.0"
   sha256 :no_check
 
   url "https://radial.appverge.net/downloads/Radial.dmg"
@@ -12,7 +12,7 @@ cask "radial" do
 
   livecheck do
     url "https://radial.appverge.net/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   app "Radial.app"

--- a/Casks/r/radial.rb
+++ b/Casks/r/radial.rb
@@ -7,13 +7,13 @@ cask "radial" do
   desc "Gesture-based launcher for apps, text snippets, and scripts"
   homepage "https://radial.appverge.net/"
 
-  auto_updates true
-  depends_on macos: ">= :sequoia"
-
   livecheck do
     url "https://radial.appverge.net/appcast.xml"
     strategy :sparkle, &:short_version
   end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
 
   app "Radial.app"
 

--- a/Casks/r/radial.rb
+++ b/Casks/r/radial.rb
@@ -1,0 +1,22 @@
+cask "radial" do
+  version "4.1.0"
+  sha256 :no_check
+
+  url "https://github.com/Glubker/radial-releases/releases/download/v#{version}/Radial.dmg",
+    verified: "github.com/Glubker/radial-releases/"
+  name "Radial"
+  desc "Gesture-based launcher for apps, text snippets, and scripts on macOS"
+  homepage "https://radial.appverge.net"
+
+  auto_updates true
+
+  depends_on macos: ">= :sequoia"
+
+  app "Radial.app"
+
+  zap trash: [
+    "~/Library/Preferences/dk.FirstForm.Radial.plist",
+    "~/Library/Caches/dk.FirstForm.Radial",
+    "~/Library/HTTPStorages/dk.FirstForm.Radial",
+  ]
+end

--- a/Casks/r/radial.rb
+++ b/Casks/r/radial.rb
@@ -4,18 +4,17 @@ cask "radial" do
 
   url "https://radial.appverge.net/downloads/Radial.dmg"
   name "Radial"
-  desc "Gesture-based launcher for apps, text snippets, and scripts on macOS"
-  homepage "https://radial.appverge.net"
+  desc "Gesture-based launcher for apps, text snippets, and scripts"
+  homepage "https://radial.appverge.net/"
 
   auto_updates true
-
   depends_on macos: ">= :sequoia"
 
   app "Radial.app"
 
   zap trash: [
-    "~/Library/Preferences/dk.FirstForm.Radial.plist",
     "~/Library/Caches/dk.FirstForm.Radial",
     "~/Library/HTTPStorages/dk.FirstForm.Radial",
+    "~/Library/Preferences/dk.FirstForm.Radial.plist",
   ]
 end

--- a/Casks/r/radial.rb
+++ b/Casks/r/radial.rb
@@ -2,8 +2,7 @@ cask "radial" do
   version "4.1.0"
   sha256 :no_check
 
-  url "https://github.com/Glubker/radial-releases/releases/download/v#{version}/Radial.dmg",
-    verified: "github.com/Glubker/radial-releases/"
+  url "https://radial.appverge.net/downloads/Radial.dmg"
   name "Radial"
   desc "Gesture-based launcher for apps, text snippets, and scripts on macOS"
   homepage "https://radial.appverge.net"

--- a/Casks/r/radial.rb
+++ b/Casks/r/radial.rb
@@ -1,5 +1,5 @@
 cask "radial" do
-  version "4.1.0"
+  version "4.1.0,410"
   sha256 :no_check
 
   url "https://radial.appverge.net/downloads/Radial.dmg"

--- a/Casks/r/radial.rb
+++ b/Casks/r/radial.rb
@@ -10,6 +10,11 @@ cask "radial" do
   auto_updates true
   depends_on macos: ">= :sequoia"
 
+  livecheck do
+    url "https://radial.appverge.net/appcast.xml"
+    strategy :sparkle
+  end
+
   app "Radial.app"
 
   zap trash: [


### PR DESCRIPTION
Add Radial (new cask)

Radial is a gesture-based launcher for macOS that allows users to open apps, insert text snippets, and trigger scripts.

The app uses Sparkle for in-app updates and distributes a stable build via GitHub Releases.

-----

- [x] The submission is for a stable version.
- [x] brew audit --cask --new radial worked successfully.
- [x] brew style --fix radial reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask radial worked successfully.
- [x] brew uninstall --cask radial worked successfully.

-----

- [x] AI was used to assist with generating this PR.

AI was used to help draft the cask file and guide the setup process. All steps were manually tested, including installation, uninstallation, and verification of zap paths. The zap paths were confirmed by inspecting the application's actual files in ~/Library.