### PR TITLE
Add Trabant

### DIFF
--- a/Casks/t/trabant.rb
+++ b/Casks/t/trabant.rb
@@ -1,0 +1,18 @@
+cask "trabant" do
+  version "1.0.0"
+  sha256 "45c39af1a4ae88743d4bd6c0f99ebf318b90fe2776cad65a1af0b033500deaaa"
+
+  url "https://github.com/gsdv/trabant/releases/download/v#{version}/Trabant.dmg"
+  name "Trabant"
+  desc "Local HTTP/HTTPS debugging proxy for iOS devices"
+  homepage "https://github.com/gsdv/trabant"
+
+  depends_on macos: ">= :sequoia"
+
+  app "Trabant.app"
+
+  zap trash: [
+    "~/Library/Application Support/Trabant",
+    "~/Library/Preferences/me.gsdv.Trabant.plist",
+  ]
+end


### PR DESCRIPTION
**App name:** Trabant
**App homepage:** https://github.com/gsdv/trabant
**Download URL:** https://github.com/gsdv/trabant/releases/download/v1.0.0/Trabant.dmg

Local macOS HTTP/HTTPS debugging proxy for iOS devices. Captures and inspects network traffic from iPhones and iPads routed through the Mac. Open source, free, no telemetry.

- [x] Cask is not a duplicate of an existing cask
- [x] App is signed and notarized with a Developer ID certificate
- [x] `sha256` is correct
- [x] `depends_on macos` is set correctly
- [x] `zap` stanza includes known app data paths