### PR TITLE
tourbox-console 5.11.2

### DIFF
--- a/Casks/t/tourbox-console.rb
+++ b/Casks/t/tourbox-console.rb
@@ -1,23 +1,24 @@
 cask "tourbox-console" do
-  version "5.11.1"
-  sha256 "b835dc633e37c04bf468d182250459d5978b4288656bf28d2e6334003a17618a"
+  version "5.11.2,260402120540"
+  sha256 "5c908696af3c44d88ffa7e654608a1a65f2d268c1fcd2d7a5a8b4c27df53b931"
 
-  url "https://tourbox-web-files.s3.us-west-2.amazonaws.com/prod/console/TourBoxInstall#{version}.zip",
-      verified: "tourbox-web-files.s3.us-west-2.amazonaws.com/prod/console/"
+  url "https://cdn.tourboxtech.com/prod/console/TourBoxInstall#{version.csv.join("_")}.zip"
   name "TourBox Console"
   desc "Configuration app for TourBox devices"
   homepage "https://www.tourboxtech.com/"
 
   livecheck do
-    url "https://www.tourboxtech.com/tbmall/download/newest?local=US", post_json: {
-      softName: "TourBox Console",
-    }
-    strategy :json do |json|
-      json.dig("result", "normalSoft", "version")
+    url "https://www.tourboxtech.com/tbmall/download/newest?local=US",
+        post_json: {
+          softName: "TourBox Console",
+        }
+    regex(/TourBoxInstall[._-]?v?(\d+(?:[._]\d+)+)/i)
+    strategy :json do |json, regex|
+      json.dig("result", "normalSoft", "macPath")&.[](regex, 1)&.tr("_", ",")
     end
   end
 
-  pkg "TourBoxInstall#{version}/TourBoxInstall#{version}.pkg"
+  pkg "TourBoxInstall#{version.csv.first}/TourBoxInstall#{version.csv.first}.pkg"
 
   uninstall quit:    "com.tourbox.ui.launch",
             pkgutil: "com.tourbox.ui.launch"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`tourbox-console` is autobumped but the workflow failed to update to version 5.11.2 because the URL has changed and the version in the file name now includes an additional numeric suffix. This updates the version, adjusts the `url`, and modifies the `livecheck` block to match the version and suffix from the asset URL in the JSON data.