### PR TITLE
tribler 8.4.2

### DIFF
--- a/Casks/t/tribler.rb
+++ b/Casks/t/tribler.rb
@@ -1,8 +1,18 @@
 cask "tribler" do
-  version "8.3.1"
-  sha256 "6a37959aa4b89464d863ee663be869459faaf1bc38189797fea69a5b9293b719"
+  arch arm: "arm", intel: "i386"
 
-  url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
+  version "8.4.2"
+  sha256 arm:   "7add076282df31f47434b7e1c383491882dba07722f13c0fccec5b5088270cde",
+         intel: "8057a15463abf63ce6834d79a1dec3fde506934704e299ea509909ade96fc6e8"
+
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
+
+  url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}-#{arch}.dmg"
   name "Tribler"
   desc "Privacy enhanced BitTorrent client with P2P content discovery"
   homepage "https://github.com/Tribler/tribler"
@@ -14,7 +24,7 @@ cask "tribler" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  app "Tribler.app"
+  app "tribler-#{version}-#{arch}.app", target: "Tribler.app"
 
   zap trash: [
     "~/.Tribler",
@@ -22,8 +32,4 @@ cask "tribler" do
     "~/Library/Preferences/nl.tudelft.tribler.plist",
     "~/Library/Saved Application State/nl.tudelft.tribler.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`tribler` is autobumped but the workflow failed to update to version 8.4.2 because upstream now offers an ARM version and the Intel version now has an `-i386` suffix. This updates the version and adjusts the cask to handle both the ARM and Intel apps.