### PR TITLE
moonlight: add binary to expose CLI in PATH

### DIFF
--- a/Casks/m/moonlight.rb
+++ b/Casks/m/moonlight.rb
@@ -11,7 +11,7 @@ cask "moonlight" do
   depends_on macos: ">= :big_sur"
 
   app "Moonlight.app"
-  binary "#{appdir}/Moonlight.app/Contents/MacOS/Moonlight"
+  binary "#{appdir}/Moonlight.app/Contents/MacOS/Moonlight", target: "moonlight"
 
   zap trash: [
     "~/Library/Caches/Moonlight Game Streaming Project",

--- a/Casks/m/moonlight.rb
+++ b/Casks/m/moonlight.rb
@@ -11,6 +11,7 @@ cask "moonlight" do
   depends_on macos: ">= :big_sur"
 
   app "Moonlight.app"
+  binary "#{appdir}/Moonlight.app/Contents/MacOS/Moonlight"
 
   zap trash: [
     "~/Library/Caches/Moonlight Game Streaming Project",


### PR DESCRIPTION
Adds a `binary` stanza so that `Moonlight` is symlinked into the Homebrew bin directory and available in `$PATH` after installation.

Example CLI usage:

```bash
Moonlight pair 1.2.3.4 --pin 7777
```