### PR TITLE
Add quickmd cask

### DIFF
--- a/Casks/q/quickmd.rb
+++ b/Casks/q/quickmd.rb
@@ -1,0 +1,23 @@
+cask "quickmd" do
+  version "1.4.1"
+  sha256 "04f3d3cf53c441cfdd0084d2a50d8343effd272b4fcc86ac6f886939861e186f"
+
+  url "https://github.com/b451c/quickmd/releases/download/v#{version}/QuickMD-v#{version}.zip"
+  name "QuickMD"
+  desc "Lightning-fast native macOS Markdown viewer"
+  homepage "https://qmd.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "QuickMD.app"
+
+  zap trash: [
+    "~/Library/Preferences/pl.falami.studio.QuickMD.plist",
+    "~/Library/Saved Application State/pl.falami.studio.QuickMD.savedState",
+  ]
+end

--- a/Casks/q/quickmd.rb
+++ b/Casks/q/quickmd.rb
@@ -2,9 +2,10 @@ cask "quickmd" do
   version "1.4.1"
   sha256 "04f3d3cf53c441cfdd0084d2a50d8343effd272b4fcc86ac6f886939861e186f"
 
-  url "https://github.com/b451c/quickmd/releases/download/v#{version}/QuickMD-v#{version}.zip"
+  url "https://github.com/b451c/quickmd/releases/download/v#{version}/QuickMD-v#{version}.zip",
+      verified: "github.com/b451c/quickmd/"
   name "QuickMD"
-  desc "Lightning-fast native macOS Markdown viewer"
+  desc "Lightning-fast native Markdown viewer"
   homepage "https://qmd.app/"
 
   livecheck do


### PR DESCRIPTION
### Description

Add cask for [QuickMD](https://qmd.app) — a lightning-fast native macOS Markdown viewer.

### Details

- **App name:** QuickMD
- **Homepage:** https://qmd.app
- **App Store:** https://apps.apple.com/app/quickmd/id6757681819
- **GitHub:** https://github.com/b451c/quickmd
- **License:** MIT

### Features
- Native SwiftUI app (no Electron)
- LaTeX math rendering (display and inline)
- Mermaid diagram rendering (flowcharts, sequence, pie, etc.)
- Syntax highlighting for 10+ languages
- 7 color themes
- Find & search, Table of Contents, PDF export
- Zero external dependencies
- Free and open source