### PR TITLE
Update claude-code to 2.1.84

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -2,11 +2,11 @@ cask "claude-code" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.1.81"
-  sha256 arm:          "d014162177fc18bfeb7f93d942130dd964f7424e4101f6ad569de66e6eddca03",
-         x86_64:       "3c63d8173d4a86ab3985aead73c4699e42956d10c2f946179274be76ec657099",
-         x86_64_linux: "047e3f5591d6238b08dd9518729ac335b0e8df1c80fe985e5d7fbda2c18fc281",
-         arm64_linux:  "ccfc3845c8d1a2ded9656a3a517694a844a1b7005b87c784a66f7a60cc58012c"
+  version "2.1.84"
+  sha256 arm:          "c02d911ff13f8ceccb1f6662bf211f3cd9f29d5a46f031c3cc40654eb759aa29",
+         x86_64:       "da5ed2ee1b0bcf65c2088e79bc65388ec85edc41041fc6ca7c27330f2e201085",
+         x86_64_linux: "c6872aa8db94f303bc6a4482664e40d3288dfc989c89ba268473ed32e3055878",
+         arm64_linux:  "5c868174b44439e51c74ff084c306856c41779615250d5bbdaa5d10056362814"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION
stable channel autobumps are blocked:
```
==> claude-code
Current cask version:     2.1.81
Latest livecheck version: 2.1.84
Duplicate pull requests:  claude-code 2.1.84 (https://github.com/Homebrew/homebrew-cask/pull/255969)
```
from: https://github.com/Homebrew/homebrew-cask/actions/runs/23946485278/job/69843722700#step:5:2669

PR that introduced the channel split: https://github.com/Homebrew/homebrew-cask/pull/255221

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
