### PR TITLE
vibeproxy 1.8.129 (new cask)

### DIFF
--- a/Casks/v/vibeproxy.rb
+++ b/Casks/v/vibeproxy.rb
@@ -1,8 +1,8 @@
 cask "vibeproxy" do
-  version "1.8.127"
-  sha256 "1ee554e53e6c921b7b1bd61cd8851a359daf9f5f2f7278cf11a9b6e17f1b4aed"
+  version "1.8.129"
+  sha256 "0b8974246023f3ea0b19b1a70c1105d03e648d8a802fc9a97f6a6de70086f111"
 
-  url "https://github.com/automazeio/vibeproxy/releases/download/v#{version}/VibeProxy-arm64.zip"
+  url "https://github.com/automazeio/vibeproxy/releases/download/v#{version}/VibeProxy-arm64.dmg"
   name "VibeProxy"
   desc "Menu bar app for using AI subscriptions with coding tools"
   homepage "https://github.com/automazeio/vibeproxy"

--- a/Casks/v/vibeproxy.rb
+++ b/Casks/v/vibeproxy.rb
@@ -7,11 +7,6 @@ cask "vibeproxy" do
   desc "Menu bar app for using AI subscriptions with coding tools"
   homepage "https://github.com/automazeio/vibeproxy"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
   depends_on arch: :arm64
   depends_on macos: ">= :ventura"

--- a/Casks/v/vibeproxy.rb
+++ b/Casks/v/vibeproxy.rb
@@ -1,0 +1,22 @@
+cask "vibeproxy" do
+  version "1.8.127"
+  sha256 "1ee554e53e6c921b7b1bd61cd8851a359daf9f5f2f7278cf11a9b6e17f1b4aed"
+
+  url "https://github.com/automazeio/vibeproxy/releases/download/v#{version}/VibeProxy-arm64.zip"
+  name "VibeProxy"
+  desc "Menu bar app for using AI subscriptions with coding tools"
+  homepage "https://github.com/automazeio/vibeproxy"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :ventura"
+
+  app "VibeProxy.app"
+
+  zap trash: "~/Library/Preferences/com.vibeproxy.app.plist"
+end


### PR DESCRIPTION
## Summary

Adds a new official cask for VibeProxy.

## Verification

- [x] The submission is for a stable version.
- [x] `brew audit --cask --online vibeproxy` is error-free.
- [x] `brew style --fix vibeproxy` reports no offenses.
- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new vibeproxy` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask vibeproxy` worked successfully.
- [x] `brew uninstall --cask vibeproxy` worked successfully.

## Notes

- This initial cask is `arm64` only. Upstream currently publishes Intel artifacts as untested while other install docs still say Intel is unsupported.
- `auto_updates true` is included because the app uses Sparkle for in-app updates.
- `zap` is intentionally limited to `~/Library/Preferences/com.vibeproxy.app.plist`. The app also uses `~/.cli-proxy-api`, but that appears to hold user-owned shared auth/config state and is intentionally not removed by `zap`.
- `v1.8.129` is sourced from the signed and notarized `VibeProxy-arm64.dmg`. The matching `VibeProxy-arm64.zip` still fails local signature verification after extraction, so the cask intentionally targets the DMG artifact instead.

## AI Disclosure

- [x] AI was used to assist with generating this PR.

AI helped draft the cask and PR copy. The token, release URL, SHA256, architecture scope, Sparkle auto-update behavior, and `zap` path were manually verified. Homebrew style, audit, and token-based install/uninstall checks were run locally.
