### PR TITLE
autofirma: deprecate

### DIFF
--- a/Casks/a/autofirma.rb
+++ b/Casks/a/autofirma.rb
@@ -22,6 +22,8 @@ cask "autofirma" do
     end
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   # See https://github.com/Homebrew/homebrew-cask/pull/116137#issuecomment-998220031
   installer manual: "AutoFirma_#{version.dots_to_underscores}_#{pkg_arch}.pkg"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `autofirma` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online autofirma` is error-free.
- [ ] `brew style --fix autofirma` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new autofirma` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask autofirma` worked successfully.
- [ ] `brew uninstall --cask autofirma` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Deprecating because the cask fails the macOS gatekeeper check
