### PR TITLE
vimediamanager 0.7a24

### DIFF
--- a/Casks/v/vimediamanager.rb
+++ b/Casks/v/vimediamanager.rb
@@ -1,16 +1,23 @@
 cask "vimediamanager" do
-  version "0.7a23"
-  sha256 "e5c1a6960f60936edc0b07cf4b9fdddbf013fa6840162ab3c4b0aa266a17d570"
+  version "0.7a24,2026_04_01"
+  sha256 "217bec52ba71d7d046ce6b0913652162b5e652112778a3895743962bee451729"
 
-  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version}/vimediamanager.zip"
+  url "https://github.com/vidalvanbergen/ViMediaManager/releases/download/v#{version.csv.first}/ViMediaManager#{"-#{version.csv.second}" if version.csv.second}.zip"
   name "ViMediaManager"
   desc "Manage digital artifacts for your movie, television and anime collections"
   homepage "https://github.com/vidalvanbergen/ViMediaManager"
 
   livecheck do
     url :url
-    regex(/v?(\d+(?:\.\d+)+[a-z]\d+)/i)
-    strategy :github_latest
+    regex(%r{/v?(\d+(?:\.\d+)+[a-z]\d+)/ViMediaManager[._-]v?(\d+(?:[._]\d+)+)\.zip}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
+    end
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`vimediamanager` is autobumped but the workflow failed to update to version 0.7a24 because the zip file name now includes a date. This updates the version, adjusts the URL, and modifies the `livecheck` block to match both the version and date from the asset URL.