### PR TITLE
openrgb 1.0rc2

### DIFF
--- a/Casks/o/openrgb.rb
+++ b/Casks/o/openrgb.rb
@@ -1,24 +1,27 @@
 cask "openrgb" do
   arch arm: "ARM64", intel: "Intel"
 
-  version "0.9,b5f46e3"
-  sha256 arm:   "9d14e4ba253b45d39ddcbc52e63b9f9b6982dcca40492190f4580a6d9ef94de7",
-         intel: "95725d6b7a6ba1893c24e4e347e97293d261ccedd77af9d27ec17d75e2f103a4"
+  version "1.0rc2,0fca93e"
+  sha256 arm:   "0846520bdc6d7bf1abc6eabbf4f44c5e2507761fcf1e1a220e85c138056f33eb",
+         intel: "fb1b000293ecd2981134fdc6b26e9453c9db33977a0442a82605ec4f7ab2e5ef"
 
-  url "https://openrgb.org/releases/release_#{version.csv.first}/OpenRGB_#{version.csv.first}_MacOS_#{arch}_#{version.csv.second}.zip"
+  url "https://codeberg.org/OpenRGB/OpenRGB/releases/download/release_candidate_#{version.csv.first}/OpenRGB_#{version.csv.first}_MacOS_#{arch}_#{version.csv.second}.zip",
+      verified: "codeberg.org/OpenRGB/OpenRGB/"
   name "OpenRGB"
   desc "Open source RGB lighting control that doesn't depend on manufacturer software"
   homepage "https://openrgb.org/"
 
   livecheck do
-    url "https://openrgb.org/releases.html"
-    regex(/href=.*?OpenRGB[._-]v?(\d+(?:\.\d+)+)[._-]MacOS[._-]#{arch}[._-](\h+)\.zip/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    url "https://codeberg.org/OpenRGB/OpenRGB/releases"
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/release_candidate_(\d+(?:\.\d+)*rc\d+)/OpenRGB_.*?_MacOS_#{arch}_(\h+)\.zip}i)
+      next if match.nil?
+
+      "#{match[1]},#{match[2]}"
     end
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  depends_on macos: ">= :big_sur"
 
   app "OpenRGB.app"
 

--- a/Casks/o/openrgb.rb
+++ b/Casks/o/openrgb.rb
@@ -5,6 +5,8 @@ cask "openrgb" do
   sha256 arm:   "0846520bdc6d7bf1abc6eabbf4f44c5e2507761fcf1e1a220e85c138056f33eb",
          intel: "fb1b000293ecd2981134fdc6b26e9453c9db33977a0442a82605ec4f7ab2e5ef"
 
+  # TODO: Remove the `candidate` part of this url when updating to the next
+  # stable version, so we only match stable versions going forward.
   url "https://codeberg.org/OpenRGB/OpenRGB/releases/download/release_candidate_#{version.csv.first}/OpenRGB_#{version.csv.first}_MacOS_#{arch}_#{version.csv.second}.zip",
       verified: "codeberg.org/"
   name "OpenRGB"

--- a/Casks/o/openrgb.rb
+++ b/Casks/o/openrgb.rb
@@ -23,6 +23,8 @@ cask "openrgb" do
 
   depends_on macos: ">= :big_sur"
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   app "OpenRGB.app"
 
   zap trash: [

--- a/Casks/o/openrgb.rb
+++ b/Casks/o/openrgb.rb
@@ -21,9 +21,9 @@ cask "openrgb" do
     end
   end
 
-  depends_on macos: ">= :big_sur"
-
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :big_sur"
 
   app "OpenRGB.app"
 

--- a/Casks/o/openrgb.rb
+++ b/Casks/o/openrgb.rb
@@ -8,7 +8,7 @@ cask "openrgb" do
   # TODO: Remove the `candidate` part of this url when updating to the next
   # stable version, so we only match stable versions going forward.
   url "https://codeberg.org/OpenRGB/OpenRGB/releases/download/release_candidate_#{version.csv.first}/OpenRGB_#{version.csv.first}_MacOS_#{arch}_#{version.csv.second}.zip",
-      verified: "codeberg.org/"
+      verified: "codeberg.org/OpenRGB/OpenRGB/"
   name "OpenRGB"
   desc "Open source RGB lighting control that doesn't depend on manufacturer software"
   homepage "https://openrgb.org/"

--- a/Casks/o/openrgb.rb
+++ b/Casks/o/openrgb.rb
@@ -6,18 +6,18 @@ cask "openrgb" do
          intel: "fb1b000293ecd2981134fdc6b26e9453c9db33977a0442a82605ec4f7ab2e5ef"
 
   url "https://codeberg.org/OpenRGB/OpenRGB/releases/download/release_candidate_#{version.csv.first}/OpenRGB_#{version.csv.first}_MacOS_#{arch}_#{version.csv.second}.zip",
-      verified: "codeberg.org/OpenRGB/OpenRGB/"
+      verified: "codeberg.org/"
   name "OpenRGB"
   desc "Open source RGB lighting control that doesn't depend on manufacturer software"
   homepage "https://openrgb.org/"
 
+  # TODO: Remove the `(?:rc\d*)?` part of this regex when updating to the next
+  # stable version, so we only match stable versions going forward.
   livecheck do
-    url "https://codeberg.org/OpenRGB/OpenRGB/releases"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/release_candidate_(\d+(?:\.\d+)*rc\d+)/OpenRGB_.*?_MacOS_#{arch}_(\h+)\.zip}i)
-      next if match.nil?
-
-      "#{match[1]},#{match[2]}"
+    url "https://openrgb.org/releases.html"
+    regex(/href=.*?OpenRGB[._-]v?(\d+(?:\.\d+)+(?:rc\d*)?)[._-]MacOS[._-]#{arch}[._-](\h+)\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
The previous version (0.9) is broken on Apple Silicon chips, causing crashes or failing to initialize when clicking the "Rescan devices" button. This update restores functionality for macOS ARM64 users.
The binaries have been moved to codeberg, so the download URL has also been updated.


-----
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----