### PR TITLE
font-tex-gyre-adventor 2.609

### DIFF
--- a/Casks/font/font-t/font-tex-gyre-adventor.rb
+++ b/Casks/font/font-t/font-tex-gyre-adventor.rb
@@ -1,20 +1,26 @@
 cask "font-tex-gyre-adventor" do
-  version "2.501"
-  sha256 "9e619eb1c8af5cb55240f8bb865453562a2efd9059dee39d085fb71f7a00f7a2"
+  version "2.609,31_03_2026"
+  sha256 "4cfef1d3df1674d111081d7410fe393185aef719e5d8465314dece308836033e"
 
-  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor/qag#{version.dots_to_underscores}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor/tg_adventor-otf-#{version.csv.first.dots_to_underscores}#{"-#{version.csv.second}" if version.csv.second}.zip"
   name "TeX Gyre Adventor"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor"
 
   livecheck do
-    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
-    regex(%r{Adventor</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+    url :homepage
+    regex(/href=.*?adventor-otf[._-]v?(\d+(?:[._]\d+)+)(?:-(\d+(?:[._]\d+)+))?\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        version = match[0].tr("_", ".")
+        match[1].present? ? "#{version},#{match[1]}" : version
+      end
+    end
   end
 
-  font "qag#{version.dots_to_underscores}otf/texgyreadventor-bold.otf"
-  font "qag#{version.dots_to_underscores}otf/texgyreadventor-bolditalic.otf"
-  font "qag#{version.dots_to_underscores}otf/texgyreadventor-italic.otf"
-  font "qag#{version.dots_to_underscores}otf/texgyreadventor-regular.otf"
+  font "texgyreadventor-bold.otf"
+  font "texgyreadventor-bolditalic.otf"
+  font "texgyreadventor-italic.otf"
+  font "texgyreadventor-regular.otf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`font-tex-gyre-adventor` is autobumped but the workflow failed to update to version 2.609 because the zip file name format has changed and now also includes a date suffix. This updates the version and adjusts the `url`. This modifies the `livecheck` block to check the homepage, as we have to match the asset URL to capture both the version and date suffix.