### PR TITLE
font-tex-gyre-pagella 2.609

### DIFF
--- a/Casks/font/font-t/font-tex-gyre-pagella.rb
+++ b/Casks/font/font-t/font-tex-gyre-pagella.rb
@@ -1,20 +1,26 @@
 cask "font-tex-gyre-pagella" do
-  version "2.501"
-  sha256 "e16078d19860d68a54bcaedc00e35c2a81b396cdc36842700f1d556f89cf8ef2"
+  version "2.609,31_03_2026"
+  sha256 "1fa1284bf30aefa1885ec5ce6c26b24d160104b331b1978a85a2a8b3c781737d"
 
-  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella/qpl#{version.dots_to_underscores}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella/tg_pagella-otf-#{version.csv.first.dots_to_underscores}#{"-#{version.csv.second}" if version.csv.second}.zip"
   name "TeX Gyre Pagella"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella"
 
   livecheck do
-    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
-    regex(%r{Pagella</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+    url :homepage
+    regex(/href=.*?pagella-otf[._-]v?(\d+(?:[._]\d+)+)(?:-(\d+(?:[._]\d+)+))?\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        version = match[0].tr("_", ".")
+        match[1].present? ? "#{version},#{match[1]}" : version
+      end
+    end
   end
 
-  font "qpl#{version.dots_to_underscores}otf/texgyrepagella-bold.otf"
-  font "qpl#{version.dots_to_underscores}otf/texgyrepagella-bolditalic.otf"
-  font "qpl#{version.dots_to_underscores}otf/texgyrepagella-italic.otf"
-  font "qpl#{version.dots_to_underscores}otf/texgyrepagella-regular.otf"
+  font "texgyrepagella-bold.otf"
+  font "texgyrepagella-bolditalic.otf"
+  font "texgyrepagella-italic.otf"
+  font "texgyrepagella-regular.otf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`font-tex-gyre-pagella` is autobumped but the workflow failed to update to version 2.609 because the zip file name format has changed and now also includes a date suffix. This updates the version and adjusts the `url`. This modifies the `livecheck` block to check the homepage, as we have to match the asset URL to capture both the version and date suffix.