### PR TITLE
font-tex-gyre-schola 2.609

### DIFF
--- a/Casks/font/font-t/font-tex-gyre-schola.rb
+++ b/Casks/font/font-t/font-tex-gyre-schola.rb
@@ -1,14 +1,20 @@
 cask "font-tex-gyre-schola" do
-  version "2.005"
-  sha256 "24063368bfdc1046439e290299157621a437294ecbb39a938d2ddb2afa3daaf8"
+  version "2.609,31_03_2026"
+  sha256 "40f76a93a159ba7a76d6fe2ac6a54b7eb480afc94557742505a847c571da13fc"
 
-  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/schola/qcs#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/schola/tg_schola-otf-#{version.csv.first.dots_to_underscores}#{"-#{version.csv.second}" if version.csv.second}.zip"
   name "TeX Gyre Schola"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/schola"
 
   livecheck do
-    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
-    regex(%r{Schola</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+    url :homepage
+    regex(/href=.*?schola-otf[._-]v?(\d+(?:[._]\d+)+)(?:-(\d+(?:[._]\d+)+))?\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        version = match[0].tr("_", ".")
+        match[1].present? ? "#{version},#{match[1]}" : version
+      end
+    end
   end
 
   font "texgyreschola-bold.otf"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`font-tex-gyre-schola` is autobumped but the workflow failed to update to version 2.609 because the zip file name format has changed and now also includes a date suffix. This updates the version and adjusts the `url`. This modifies the `livecheck` block to check the homepage, as we have to match the asset URL to capture both the version and date suffix.