### PR TITLE
paraview 6.1.0

### DIFF
--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -2,12 +2,12 @@ cask "paraview" do
   arch arm: "arm64", intel: "x86_64"
 
   on_arm do
-    version "6.1.0,RC2-MPI-OSX11.0-Python3.12"
-    sha256 "6bdae4083ab11f147ca84c312217a57b8227e77a2b65e43a2aeb8ff39500a8e7"
+    version "6.1.0,MPI-OSX11.0-Python3.12"
+    sha256 "750ada145dcd8c0e4a27803ecda1d8f53599d26a5ca293eef902fb5ff36058bb"
   end
   on_intel do
-    version "6.1.0,RC2-MPI-OSX10.15-Python3.12"
-    sha256 "fcc7964737eb6cadf5a9c82fc9a2b8b3b83e0fbfc7227da22aa354a7ed1c8e44"
+    version "6.1.0,MPI-OSX10.15-Python3.12"
+    sha256 "e34096914c02c6aee5bb4231885317520aebcb2b050bd8adb4dd8f64a9be141c"
   end
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.csv.first.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}-#{arch}.dmg",
@@ -21,15 +21,15 @@ cask "paraview" do
     regex(%r{/v?(?:\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:[.-]\d+)+)(?:[._-](.*?))?[._-](?:#{arch}|universal)\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
-        match[1] ? "#{match[0]},#{match[1]}" : match[0]
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
       end
     end
   end
 
   depends_on macos: ">= :big_sur"
 
-  app "ParaView-#{version.csv.first}-#{version.csv.second.split("-").first}.app"
-  binary "#{appdir}/ParaView-#{version.csv.first}-#{version.csv.second.split("-").first}.app/Contents/MacOS/paraview"
+  app "ParaView-#{version.csv.first}.app"
+  binary "#{appdir}/ParaView-#{version.csv.first}.app/Contents/MacOS/paraview"
 
   zap trash: [
     "~/.config/ParaView",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

For some reason, the `livecheck` block for `paraview` surfaced an RC version recently, even though those shouldn't match due to the regex only matching files in a stable version directory, whereas RCs are kept in a subdirectory (e.g., /v6.1/RCs/ParaView-...). That said, the `livecheck` block isn't matching RC versions at the moment, so it may have been a temporary upstream issue.

That said, autobump is unable to update the cask to the stable 6.1.0 release because the current cask version is seen as newer, as "RC2-" in the second part of the `version` is seen as higher than "MPI-". This updates the version and adjusts the cask accordingly.