### PR TITLE
spacesaver: disable

### DIFF
--- a/Casks/s/spacesaver.rb
+++ b/Casks/s/spacesaver.rb
@@ -8,6 +8,8 @@ cask "spacesaver" do
   desc "Application designed to help you manage and optimize your workspace"
   homepage "https://spacesaver.congdev.com/"
 
+  disable! date: "2026-04-05", because: :no_longer_meets_criteria
+
   depends_on macos: ">= :monterey"
 
   app "SpaceSaver.app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Upstream has removed all releases for `spacesaver` from the GitHub repository and also deleted the tag for 1.0.14 (there are now only tags for 1.0.1, 1.0.2, and 1.0.7). The `README` was updated to point to Gumroad for downloads instead of GitHub releases, so this seems to indicate that upstream has discontinued GitHub releases. The app is offered on Gumroad for free but you still have to "purchase" it with an account, so this isn't a situation that we can handle in the cask. With that in mind, this disables the cask as it's no longer usable due to the current asset URL not working anymore.