### PR TITLE
jamie 5.6.38

### DIFF
--- a/Casks/j/jamie.rb
+++ b/Casks/j/jamie.rb
@@ -1,17 +1,22 @@
 cask "jamie" do
-  version "4.5.0"
-  sha256 "39014fabc16ff77b08c4e333ce3ff9f911dc7b2ea0f3da3cfbf480d978ecd946"
+  version "5.6.38"
+  sha256 "6c44acf0073ccb5d3ad6b781040279cffc3d9d8ba84cf436d2f586ca4b4aa73a"
 
-  url "https://github.com/louismorgner/jamie-release/releases/download/v#{version}/jamie-#{version}-mac.zip",
-      verified: "github.com/louismorgner/jamie-release/"
+  url "https://github.com/meetjamie/releases/releases/download/app-v#{version}/Jamie_universal.app.tar.gz",
+      verified: "github.com/meetjamie/releases/"
   name "Jamie"
   desc "AI-powered meeting notes"
-  homepage "https://meetjamie.ai/"
+  homepage "https://www.meetjamie.ai/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: ">= :sonoma"
 
-  app "jamie.app"
+  app "Jamie.app"
 
   zap trash: "~/Library/Application Support/jamie"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`jamie` is autobumped but the workflow failed to update to version 5.6.38 because livecheck is producing an "Unable to get versions" error due to the GitHub repository being removed. The download button on the first-party website points to the "latest" release in the meetjamie/releases GitHub repository, so that appears to be the new asset source. This updates the version and adjusts the cask accordingly. I've added a `GithubLatest` `livecheck` block as there is a 5.6.39 release that hasn't been marked as "latest" yet, so this approach aligns with the download on the first-party website.