### PR TITLE
netviews: disable

### DIFF
--- a/Casks/n/netviews.rb
+++ b/Casks/n/netviews.rb
@@ -7,10 +7,7 @@ cask "netviews" do
   desc "Network and Wi-Fi diagnostic tool"
   homepage "https://www.netviews.app/"
 
-  livecheck do
-    url "https://www.netviews.app/appcast.xml"
-    strategy :sparkle, &:short_version
-  end
+  disable! date: "2026-04-06", because: :unreachable
 
   auto_updates true
   depends_on macos: ">= :sonoma"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`netviews` is autobumped but the workflow failed to update to version 2.11 because livecheck fails due to www.netviews.app URLs returning a 403 (Forbidden) response in the autobump/CI environment. This also applies to the cask `url` and adding a user agent and/or referer doesn't make a difference, so this is likely an IP address issue. This disables `netviews`, as we're unable to maintain casks that don't work in the CI environment.