### PR TITLE
nuclear 1.32.1

### DIFF
--- a/Casks/n/nuclear.rb
+++ b/Casks/n/nuclear.rb
@@ -1,11 +1,11 @@
 cask "nuclear" do
-  arch arm: "arm64", intel: "x64"
+  arch arm: "aarch64", intel: "x64"
 
-  version "0.6.48"
-  sha256 arm:   "9749225105d3c4c8000ac4060a1a68f25be64999c54c2d786bd5faa1c0a3a619",
-         intel: "6c62adae6e054f2103b5697bdb4510ff4739fee84a9de8b8645df62bde74bbb3"
+  version "1.32.1"
+  sha256 arm:   "8aeaed10bcb8c276e117cbdf5409f5780f6f4446b3c86b70d09761f39937645f",
+         intel: "2df0d607a57b4681f568a9b476c3796f7c34ecc20d5cbc1bda2d23f667d7e355"
 
-  url "https://github.com/nukeop/nuclear/releases/download/v#{version}/nuclear-v#{version}-#{arch}.dmg",
+  url "https://github.com/nukeop/nuclear/releases/download/player%40#{version}/Nuclear_#{version}_#{arch}.dmg",
       verified: "github.com/nukeop/nuclear/"
   name "Nuclear"
   desc "Streaming music player"
@@ -13,12 +13,12 @@ cask "nuclear" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^(?:player@)?v?(\d+(?:\.\d+)+)$/i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  app "nuclear.app"
+  app "Nuclear.app"
 
   zap trash: [
     "~/Library/Application Support/nuclear",

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -45,7 +45,6 @@
   "mullvad-vpn@beta": "any",
   "my-budget": "all",
   "netnewswire@beta": "any",
-  "nuclear": "all",
   "olive": "any",
   "opencloud": "any",
   "openra@playtest": "all",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`nuclear` is autobumped but the workflow failed to update to version 1.32.1 because livecheck produced an "Unable to get versions" error due to upstream removing all tags using a `v0.6.48` format and moving to a `player@1.32.1` format, which the `livecheck` block regex doesn't match. This updates the version and adjusts the cask accordingly. This also removes the cask from the GitHub pre-release allowlist, as the existing releases are not marked as pre-release.