### PR TITLE
font-latin-modern 2.007

### DIFF
--- a/Casks/font/font-l/font-latin-modern.rb
+++ b/Casks/font/font-l/font-latin-modern.rb
@@ -1,14 +1,20 @@
 cask "font-latin-modern" do
-  version "2.006"
-  sha256 "608a6f3de9fbafd70f977fbf21ca32850178dd19b11530385358840c8f291f06"
+  version "2.007,31_03_2026"
+  sha256 "2d8e05083e211ac838a9e306fb5e4856ed37ec15130e185a971e2683a7c5d1a1"
 
-  url "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/Latin_Modern-otf-#{version.csv.first.dots_to_underscores}#{"-#{version.csv.second}" if version.csv.second}.zip"
   name "Latin Modern"
   homepage "https://www.gust.org.pl/projects/e-foundry/latin-modern"
 
   livecheck do
     url "https://www.gust.org.pl/projects/e-foundry/latin-modern/download"
-    regex(/lm(\d+(?:\.\d+)+)otf\.zip/i)
+    regex(/href=.*?Latin[._-]Modern[._-]otf[._-]v?(\d+(?:[._]\d+)+)(?:-(\d+(?:[._]\d+)+))?\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        version = match[0].tr("_", ".")
+        match[1].present? ? "#{version},#{match[1]}" : version
+      end
+    end
   end
 
   font "lmmono10-italic.otf"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`font-latin-modern` is autobumped but the workflow failed to update to version 2.007 because the zip file name changed and now also includes a date suffix, so the `livecheck` block regex does not match it. This updates the version and modifies the `livecheck` block to also capture the date suffix.