### PR TITLE
cadran 1.2.12 (new cask)

### DIFF
--- a/Casks/c/cadran.rb
+++ b/Casks/c/cadran.rb
@@ -1,0 +1,25 @@
+cask "cadran" do
+  version "1.2.12"
+  sha256 "9fdc5fb5806f84949e8318febf29daf47ad7cd86a2a32c07af28384fe5bd57c2"
+
+  url "https://github.com/Ilyomix/Cadran-releases/releases/download/v#{version}/Cadran-#{version}.dmg",
+      verified: "github.com/Ilyomix/Cadran-releases/"
+  name "Cadran"
+  desc "Desktop clock rendered behind your icons"
+  homepage "https://cadranapp.com/"
+
+  livecheck do
+    url "https://github.com/Ilyomix/Cadran-releases/releases/latest/download/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Cadran.app"
+
+  zap trash: [
+    "~/Library/Application Support/Cadran",
+    "~/Library/Preferences/ilyomix.Cadran.plist",
+  ]
+end


### PR DESCRIPTION
## Summary
Adds a new cask for Cadran, a desktop clock app.

## Checks run locally
- `brew style --fix --cask cadran`
- `brew audit --strict --online --new --cask cadran`

## Notes
- Uses the official vendor endpoint `https://cadranapp.com/api/download/latest`.
- App requirement is macOS Sonoma 14.0 or later.

## AI/LLM disclosure
I used OpenAI Codex for drafting assistance this is the first time I attempt to list my app in Homebrew it was asked by some of my users, then manually reviewed the cask following the official documentation and validated the checks above.