### PR TITLE
Add ghost-pepper cask

### DIFF
--- a/Casks/g/ghost-pepper.rb
+++ b/Casks/g/ghost-pepper.rb
@@ -1,0 +1,23 @@
+cask "ghost-pepper" do
+  version "2.0.1"
+  sha256 "a7a902ad97d71088e90c9966b7b2e682e4315182381d07dfdbc27acb02f8dfea"
+
+  url "https://github.com/matthartman/ghost-pepper/releases/download/v#{version}/GhostPepper.dmg"
+  name "Ghost Pepper"
+  desc "Hold-to-talk speech-to-text for macOS, 100% local with WhisperKit"
+  homepage "https://github.com/matthartman/ghost-pepper"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "GhostPepper.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.github.matthartman.ghostpepper.plist",
+  ]
+end


### PR DESCRIPTION
## Description

Add a cask for [Ghost Pepper](https://github.com/matthartman/ghost-pepper), a 100% local hold-to-talk speech-to-text app for macOS.

- Uses WhisperKit and local LLM models (Qwen) for transcription and cleanup
- Hold Control to record, release to transcribe and paste
- No cloud APIs, no data leaves the machine
- MIT license, Apple Silicon (M1+) required, macOS 14.0+
- 311 GitHub stars, active development

The DMG is signed and notarized (Notarized Developer ID).

Livecheck uses the `github_latest` strategy against the releases page.

This contribution was developed with AI assistance (Claude Code).