### PR TITLE
azure-cli-preview 2.85.0 (new cask)

### DIFF
--- a/Casks/a/azure-cli-preview.rb
+++ b/Casks/a/azure-cli-preview.rb
@@ -1,0 +1,27 @@
+cask "azure-cli-preview" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "2.85.0"
+  sha256 arm:   "cbc6b206504091a1cf82a1fb6ae87365f758bf6fd2214d8014cdf32a7fd3a94c",
+         intel: "c1a9c345dd30dd304b175d4691899ee1cbc77be17fe8ea57c236bac2275ad480"
+
+  url "https://github.com/Azure/azure-cli/releases/download/azure-cli-#{version}/azure-cli-#{version}-macos-#{arch}.tar.gz",
+      verified: "github.com/Azure/azure-cli/"
+  name "Azure CLI"
+  desc "Microsoft Azure CLI 2.0"
+  homepage "https://docs.microsoft.com/cli/azure/overview"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on formula: "python@3.13"
+
+  binary "bin/az"
+  bash_completion "completions/bash/az"
+  fish_completion "completions/fish/az.fish"
+  zsh_completion "completions/zsh/_az"
+
+  zap trash: "~/.azure"
+end


### PR DESCRIPTION
Add Azure CLI as a new Homebrew cask (`azure-cli-preview`) for version 2.85.0.

This introduces a cask-based installation (`brew install --cask azure-cli-preview`) that distributes Azure CLI as a pre-built tarball from GitHub Releases, instead of building from source via the existing homebrew-core formula.

### Related PRs
- **Original PR (failed CI):** https://github.com/Homebrew/homebrew-cask/pull/257913 — submitted by `azclibot` as `azure-cli`
- **homebrew-core formula:** https://github.com/Homebrew/homebrew-core/pull/276382 — existing formula-based release (build from source)

### Fixes applied vs PR #257913
1. **Removed `os macos: "macos"` stanza** — the `os` stanza without a `linux:` key caused Homebrew CI to simulate Linux tags, resulting in `sha256: nil` validation error

2. **Renamed token to `azure-cli-preview`** to avoid conflict with the existing `azure-cli` formula in homebrew-core
3. **Added `verified` parameter** to the URL stanza (required when URL domain differs from homepage domain)
4. **Fixed stanza ordering** per Homebrew style requirements