### PR TITLE
paper-design 0.1.11,260407lr7cv5171 (new cask)

### DIFF
--- a/Casks/p/paper-design.rb
+++ b/Casks/p/paper-design.rb
@@ -1,6 +1,6 @@
 cask "paper-design" do
-  version "0.1.10,26031739o5exfj4"
-  sha256 "fee531570bf5bdf07cf431ae1851029aa7a82cd5ab63ee93af958f8eb87cbc16"
+  version "0.1.11,260407lr7cv5171"
+  sha256 "2bc42752c1c4679f9c270213043f9dec6efb743ae2a0c7cdf82f901a4e81da42"
 
   url "https://download.todesktop.com/2601167vjw8xe/Paper%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-arm64.dmg",
       verified: "download.todesktop.com/2601167vjw8xe/"
@@ -28,4 +28,9 @@ cask "paper-design" do
   app "Paper.app"
 
   uninstall quit: "com.todesktop.2601167vjw8xe"
+
+  zap trash: [
+    "~/Library/Application Support/Paper",
+    "~/Library/Preferences/com.todesktop.2601167vjw8xe.plist",
+  ]
 end

--- a/Casks/p/paper-design.rb
+++ b/Casks/p/paper-design.rb
@@ -1,0 +1,31 @@
+cask "paper-design" do
+  version "0.1.10,26031739o5exfj4"
+  sha256 "fee531570bf5bdf07cf431ae1851029aa7a82cd5ab63ee93af958f8eb87cbc16"
+
+  url "https://download.todesktop.com/2601167vjw8xe/Paper%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-arm64.dmg",
+      verified: "download.todesktop.com/2601167vjw8xe/"
+  name "Paper"
+  desc "Design tool for creating interfaces and prototypes"
+  homepage "https://paper.design/"
+
+  livecheck do
+    url "https://download.todesktop.com/2601167vjw8xe/latest-mac.yml"
+    regex(/Paper\s+(\d+(?:\.\d+)+)\s+-\s+Build\s+([a-z0-9]+)-arm64\.dmg/i)
+    strategy :electron_builder do |yaml, regex|
+      yaml["files"]&.map do |item|
+        match = item["url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :monterey"
+
+  app "Paper.app"
+
+  uninstall quit: "com.todesktop.2601167vjw8xe"
+end

--- a/Casks/p/paper-design.rb
+++ b/Casks/p/paper-design.rb
@@ -10,7 +10,7 @@ cask "paper-design" do
 
   livecheck do
     url "https://download.todesktop.com/2601167vjw8xe/latest-mac.yml"
-    regex(/Paper\s+(\d+(?:\.\d+)+)\s+-\s+Build\s+([a-z0-9]+)-arm64\.dmg/i)
+    regex(/Paper\s+v?(\d+(?:\.\d+)+)\s+[._-]\s+Build\s+([a-z\d]+)[._-]arm64\.dmg/i)
     strategy :electron_builder do |yaml, regex|
       yaml["files"]&.map do |item|
         match = item["url"]&.match(regex)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (searched for `paper-design`; no exact prior refusal found).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used Codex to draft the cask.

I manually verified the final cask by having Codex run `brew style --fix paper-design`, `brew audit --cask --new --strict --online paper-design`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask paper-design`, and `brew uninstall --cask paper-design` (with and without zap) and inspecting the outputs.

Codex also launched `Paper.app` and manually audited the leftover files after uninstall to derive the `zap` stanza. I manually verified that these paths were both created at startup and removed once zapped:

- `~/Library/Application Support/Paper`
- `~/Library/Preferences/com.todesktop.2601167vjw8xe.plist`

-----
