### PR TITLE
pluralplay-flclashx 0.3.2 (new cask)

### DIFF
--- a/Casks/p/pluralplay-flclashx.rb
+++ b/Casks/p/pluralplay-flclashx.rb
@@ -1,0 +1,27 @@
+cask "pluralplay-flclashx" do
+  arch arm: "arm64", intel: "amd64"
+
+  version "0.3.2"
+  sha256 arm:   "d96c2e3bbc110f341f6e8f4cef25f66dcb18fc811467f2953478d047723da1ff",
+         intel: "5ac7b2c8c6cf47c5a1a7e2c56e2b6e4a79a13428173afc73183fa413a78e7774"
+
+  url "https://github.com/pluralplay/FlClashX/releases/download/v#{version}/FlClashX-macos-#{arch}.dmg"
+  name "FlClashX"
+  desc "Cross-platform proxy client based on ClashMeta"
+  homepage "https://github.com/pluralplay/FlClashX"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "FlClashX.app"
+
+  zap trash: [
+    "~/Library/Application Support/FlClashX",
+    "~/Library/Caches/com.pluralplay.FlClashX",
+    "~/Library/Preferences/com.pluralplay.FlClashX.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

  ### About this fork submission

  This cask is for `pluralplay/FlClashX`, a fork of `chen08209/FlClash`. I am aware of Homebrew Cask's "Not a fork (usually)" policy and would like to explain why I believe this fork warrants
  inclusion, and why it is submitted under the vendor-prefixed token `pluralplay-flclash` rather than replacing the upstream.

  **Why this fork exists and why it matters**

  FlClashX is a widely used proxy client in the Russian-speaking community, where it is one of the de-facto tools for bypassing network censorship and this tool is open source . It is actively promoted and documented as a
  recommended client by the Remnawave project (https://docs.rw/), a popular open-source Xray/Remna panel used by many VPN providers. Remnawave lists FlClashX among its officially supported clients
  for end users across platforms: https://docs.rw/docs/clients

  The fork exists because the upstream `chen08209/FlClash` does not ship pre-built subscription/config presets and UX tailored to the Xray/Remnawave ecosystem that the Russian community depends on.
  `pluralplay/FlClashX` adds these integrations and is the build that Remnawave's documentation points users to.

  **Notability**

  - 769 stars, 769 watchers on GitHub (well above the 225-star self-submission threshold, and I am not the author)
  - Actively maintained with regular releases
  - Publicly documented and recommended by a third-party project (Remnawave / docs.rw) with its own significant user base.
    Proff links:
    - https://docs.rw/docs/awesome-remnawave
    - https://docs.rw/docs/clients

  - Has a clear public presence beyond "just `brew install`" - users can (and do) download it directly from GitHub Releases and from Remnawave's documentation

  **Naming**

  Per the "Forks and apps with conflicting names" rule, the token is prefixed with the vendor name: `pluralplay-flclash`. This avoids any conflict with a potential future upstream `flclash` cask and
  makes the fork relationship explicit to users.

  **Not replacing upstream**

  I am not asking for this cask to replace a hypothetical upstream `flclash` cask. The upstream is still actively maintained and, if someone later submits it, both can coexist - the vendor prefix
  exists exactly for this reason.

  ### Validation

  - `brew style --cask pluralplay-flclash` - no offenses
  - `brew audit --cask --online --new pluralplay-flclash` - only the expected "GitHub fork" warning, which is the subject of this justification
  - `brew fetch` succeeds for both `arm64` and `amd64` builds; sha256 verified
  - Installed and launched locally on macOS 26.3+; `zap` paths manually verified