### PR TITLE
claude-code@latest: remove outdated caveat

### DIFF
--- a/Casks/c/claude-code@latest.rb
+++ b/Casks/c/claude-code@latest.rb
@@ -33,9 +33,4 @@ cask "claude-code@latest" do
         "~/Library/Caches/claude-cli-nodejs",
       ],
       rmdir: "~/.claude"
-
-  caveats <<~EOS
-    Note: the in-app upgrade command shown in update notifications is hardcoded to
-    "brew upgrade claude-code" rather than "brew upgrade claude-code@latest".
-  EOS
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online claude-code@latest` is error-free.
- [x] `brew style --fix claude-code@latest` reports no offenses.

---

The caveat warning that in-app upgrade notifications are hardcoded to `brew upgrade claude-code` was fixed upstream in [2.1.92](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2192):

> Fixed Homebrew install update prompts to use the cask's release channel (`claude-code` → stable, `claude-code@latest` → latest)

- [x] AI was used to assist with this PR. Used Claude Code to verify the changelog entry and generate the change. Manually reviewed.