### PR TITLE
Add mino cask v0.1.1

### DIFF
--- a/Casks/m/mino.rb
+++ b/Casks/m/mino.rb
@@ -1,0 +1,19 @@
+cask "mino" do
+  version "0.1.1"
+  sha256 "254efc1a641c692592f44fca4e9ef34533b6631301bb483e58bc73cb442cb989"
+
+  url "https://github.com/robinv8/mino/releases/download/v#{version}/Mino-#{version}.dmg"
+  name "Mino"
+  desc "Open-source macOS client for AI agents"
+  homepage "https://robinv8.github.io/mino/"
+
+  depends_on macos: ">= :sonoma"
+
+  app "Mino.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.mino.app",
+    "~/Library/Caches/com.mino.app",
+    "~/Library/Preferences/com.mino.app.plist",
+  ]
+end

--- a/Casks/m/mino.rb
+++ b/Casks/m/mino.rb
@@ -2,9 +2,10 @@ cask "mino" do
   version "0.1.1"
   sha256 "254efc1a641c692592f44fca4e9ef34533b6631301bb483e58bc73cb442cb989"
 
-  url "https://github.com/robinv8/mino/releases/download/v#{version}/Mino-#{version}.dmg"
+  url "https://github.com/robinv8/mino/releases/download/v#{version}/Mino-#{version}.dmg",
+      verified: "github.com/robinv8/mino/"
   name "Mino"
-  desc "Open-source macOS client for AI agents"
+  desc "Open-source client for AI agents"
   homepage "https://robinv8.github.io/mino/"
 
   depends_on macos: ">= :sonoma"


### PR DESCRIPTION
### Description

Add [Mino](https://robinv8.github.io/mino/) — an open-source macOS client for AI agents. Treat agents as contacts, drive everything through conversation.

- **Homepage**: https://robinv8.github.io/mino/
- **Download**: https://github.com/robinv8/mino/releases/download/v0.1.1/Mino-0.1.1.dmg
- **License**: MIT

### Checklist

- [x] Cask is in alphabetical order in `Casks/m/`
- [x] `sha256` matches the DMG
- [x] `homepage` is set
- [x] `zap` stanza included