### PR TITLE
vibe-island 1.0.21 (new cask)

### DIFF
--- a/Casks/v/vibe-island.rb
+++ b/Casks/v/vibe-island.rb
@@ -4,7 +4,7 @@ cask "vibe-island" do
 
   url "https://dl.vibeisland.app/VibeIsland-#{version}.dmg"
   name "Vibe Island"
-  desc "Dynamic Island for AI agents — monitor, approve, and jump back from the notch"
+  desc "Dynamic island AI agent utility"
   homepage "https://vibeisland.app/"
 
   livecheck do

--- a/Casks/v/vibe-island.rb
+++ b/Casks/v/vibe-island.rb
@@ -1,0 +1,27 @@
+cask "vibe-island" do
+  version "1.0.21"
+  sha256 "7d959e6d04bae32912ba7f65751118100116f0369761a14201bbac720f2b7955"
+
+  url "https://dl.vibeisland.app/VibeIsland-#{version}.dmg"
+  name "Vibe Island"
+  desc "Dynamic Island for AI agents — monitor, approve, and jump back from the notch"
+  homepage "https://vibeisland.app/"
+
+  livecheck do
+    url "https://updates.vibeisland.app/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Vibe Island.app"
+
+  uninstall quit: "app.vibeisland.macos"
+
+  zap trash: [
+    "~/Library/Preferences/app.vibeisland.macos.plist",
+    "~/Library/Caches/app.vibeisland.macos",
+    "~/.vibe-island",
+  ]
+end

--- a/Casks/v/vibe-island.rb
+++ b/Casks/v/vibe-island.rb
@@ -20,8 +20,8 @@ cask "vibe-island" do
   uninstall quit: "app.vibeisland.macos"
 
   zap trash: [
-    "~/Library/Preferences/app.vibeisland.macos.plist",
-    "~/Library/Caches/app.vibeisland.macos",
     "~/.vibe-island",
+    "~/Library/Caches/app.vibeisland.macos",
+    "~/Library/Preferences/app.vibeisland.macos.plist",
   ]
 end


### PR DESCRIPTION
## Description

Vibe Island is a macOS Notch status panel that provides a Dynamic Island-style experience for AI coding agents (Claude Code, Codex, Gemini CLI, Cursor Agent, OpenCode, Droid, Qoder, Copilot, CodeBuddy). Users can monitor sessions, approve permission requests, and jump back to the exact terminal tab/pane from the notch.

- Homepage: https://vibeisland.app/
- Sparkle feed: https://updates.vibeisland.app/appcast.xml

## Checklist

- [x] `brew audit --cask --strict --online --new vibe-island` passes
- [x] App is signed with Developer ID (Team: CU3QC9CXTJ) and notarized
- [x] `auto_updates true` set (Sparkle)
- [x] `livecheck` strategy :sparkle pointing at appcast.xml
- [x] `depends_on macos: ">= :sonoma"` matches the app's `LSMinimumSystemVersion`
- [x] `uninstall quit:` and `zap trash:` present
- [x] Stable release (v1.0.21), not beta

## Notes

The DMG is served via Cloudflare at `dl.vibeisland.app`, backed by the public Sparkle feed repo. Verified SHA256 locally matches the formula.