### PR TITLE
neteasemusic 3.1.6

### DIFF
--- a/Casks/n/neteasemusic.rb
+++ b/Casks/n/neteasemusic.rb
@@ -1,8 +1,8 @@
 cask "neteasemusic" do
-  version "3.1.6.3242"
+  version "3.1.6,3242"
   sha256 "c47919f1e2799cdfffc2aacc6d6c4c92d9fa371439046a339a4b1dc132e9691c"
 
-  url "https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_#{version}.dmg",
+  url "https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_#{version.csv.join(".")}.dmg",
       verified:   "d1.music.126.net/",
       user_agent: :fake
   name "NetEase cloud music"
@@ -10,16 +10,14 @@ cask "neteasemusic" do
   desc "Music streaming platform"
   homepage "https://music.163.com/"
 
-  # The upstream download page (https://music.163.com/#/download) uses a POST
-  # request to fetch download link information but livecheck doesn't support
-  # POST requests yet. Additionally, the request parameters are encrypted in a
-  # particular way (see https://github.com/orgs/Homebrew/discussions/5756).
-  # That said, the API endpoint appears to work with a simple `GET` request.
   livecheck do
-    url "https://music.163.com/api/appcustomconfig/get"
-    regex(/NeteaseCloudMusic[._-]Music[._-]official[._-]v?(\d+(?:[._]\d+)+)/i)
-    strategy :json do |json, regex|
-      json.dig("data", "web-new-download", "osx", "downloadUrl")&.[](regex, 1)
+    url "https://music.163.com/api/mac/package/download/latest?arch=arm64&productName=music"
+    strategy :json do |json|
+      version = json.dig("data", "appVer")
+      build = json.dig("data", "buildVer")
+      next if version.blank? || build.blank?
+
+      "#{version},#{build}"
     end
   end
 

--- a/Casks/n/neteasemusic.rb
+++ b/Casks/n/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask "neteasemusic" do
-  version "3.1.5.3236"
-  sha256 "cbc066ea327da5350a42aede1bcd0c6132addc7c2522e5a69823e4b2aae734ff"
+  version "3.1.6.3242"
+  sha256 "c47919f1e2799cdfffc2aacc6d6c4c92d9fa371439046a339a4b1dc132e9691c"
 
   url "https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_#{version}.dmg",
       verified:   "d1.music.126.net/",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
Bump neteasemusic version to 3.1.6.3242