### PR TITLE
keet 4.13.0

### DIFF
--- a/Casks/k/keet.rb
+++ b/Casks/k/keet.rb
@@ -1,11 +1,11 @@
 cask "keet" do
-  arch arm: "Apple-Silicon", intel: "Intel"
+  arch intel: "-Intel"
 
-  version "2.6.0"
-  sha256 arm:   "db417e3639b5b647b9d6991301b1cb6b6ee3706b0aeac03fcb6bca471a6c66d2",
-         intel: "6c2b868d93d6c9176a3912aaa391c1fd3d49d3652ab762ccaf82b1931e4309fc"
+  version "4.13.0"
+  sha256 arm:   "27da264eca14dea4963b25dec62171a5118602e3a258f37ae2bbe9381e7669eb",
+         intel: "1e7d45ec6d4181b41ce8b3be52d13759b913dcbe58662e2987a3af8c20c0d955"
 
-  url "https://static.keet.io/downloads/#{version}/Keet-#{arch}.dmg"
+  url "https://static.keet.io/downloads/#{version}/Keet#{arch}.dmg"
   name "keet"
   desc "Peer-to-peer video and text chat"
   homepage "https://keet.io/"
@@ -16,6 +16,7 @@ cask "keet" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Keet.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`keet` is autobumped but the workflow failed to update to version 4.13.0 because the file name for the ARM dmg is now simply `Keet.dmg` with no `-Apple-Silicon` suffix. This updates the version and adjusts the cask accordingly.