### PR TITLE
quakenotch 3.0.4

### DIFF
--- a/Casks/q/quakenotch.rb
+++ b/Casks/q/quakenotch.rb
@@ -1,8 +1,8 @@
 cask "quakenotch" do
-  version "3.0.2"
-  sha256 "8dfed9099a8632103a5ee90fc19ef16701e90f5bdb47c304c1e2c026b50d78a9"
+  version "3.0.4"
+  sha256 "64d10c58eec10987430b87d93b69729d675b64ace86c85abab45b48ebf969e54"
 
-  url "https://github.com/rohanrhu/QuakeNotch/releases/download/v.#{version}/QuakeNotch.zip",
+  url "https://github.com/rohanrhu/QuakeNotch/releases/download/v#{version}/QuakeNotch.zip",
       verified: "github.com/rohanrhu/QuakeNotch/"
   name "QuakeNotch"
   desc "MacBook Notch utility"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`quakenotch` is autobumped but the workflow failed to update to version 3.0.4 because the `v.3.0.2` tag format was a one-off and the subsequent tags use the expected `v3.0.4` tag format (without a dot after the "v"). this updates the version and adjusts the `url` accordingly.