### PR TITLE
soundswitch 2.10.2 (new cask)

### DIFF
--- a/Casks/s/soundswitch.rb
+++ b/Casks/s/soundswitch.rb
@@ -1,0 +1,25 @@
+cask "soundswitch" do
+  version "2.10.2"
+  sha256 :no_check
+
+  url "https://cdn.inmusicbrands.com/soundswitch/files/SoundSwitchInstaller.pkg",
+      verified: "cdn.inmusicbrands.com/soundswitch/files/"
+  name "SoundSwitch"
+  desc "Lighting control software for DJs"
+  homepage "https://www.soundswitch.com/products"
+
+  livecheck do
+    skip "No version information available"
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  pkg "SoundSwitchInstaller.pkg"
+
+  uninstall pkgutil: "com.soundswitch.SoundSwitch"
+
+  zap trash: [
+    "~/Library/Caches/SoundSwitch",
+    "~/Library/Preferences/com.soundswitch.SoundSwitch.plist",
+  ]
+end


### PR DESCRIPTION
-----

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online soundswitch` is error-free.
- [x] `brew style --fix soundswitch` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [ ] Checked the cask was not already refused.
- [x] `brew audit --cask --new soundswitch` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask soundswitch` worked successfully.
- [x] `brew uninstall --cask soundswitch` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including `zap` stanza paths.

AI was used to help inspect the pkg metadata, draft the cask, and iterate on the uninstall and `zap` stanzas.

Manual verification performed:
- Ran `brew style --fix soundswitch`.
- Ran `brew audit --cask --new soundswitch`.
- Ran `brew audit --cask --online soundswitch`.
- Installed the cask locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask soundswitch`.
- Launched SoundSwitch successfully after installation.
- Uninstalled the cask locally with `brew uninstall --cask soundswitch`.
- Verified real leftover files after uninstall.
- Validated `zap` cleanup with `brew uninstall --zap --force soundswitch`.
- Confirmed the validated `zap` paths were `~/Library/Caches/SoundSwitch` and `~/Library/Preferences/com.soundswitch.SoundSwitch.plist`.

-----
