### PR TITLE
Update claude-code to 2.1.97

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -2,11 +2,11 @@ cask "claude-code" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.1.89"
-  sha256 arm:          "f903a5e53f845b1ac5566296b713193827665f28da16300fdca7539cb0669a7f",
-         x86_64:       "1322c5eecec8047e9cd7114f7d547ef6a9596563d6bbc7e594167d0f8bc8b406",
-         arm64_linux:  "428301f56cf0139e6fbfa55e13be3f0f032ac1eb5ddb8849fbc703ee220c1cca",
-         x86_64_linux: "903cb3c96b314d86856632c8702f5cdf971b804d0b19ef87446573bcd1d7df1c"
+  version "2.1.97"
+  sha256 arm:          "9104eba60ca82c590ababc5eee0d01f2dc5440d7cf2d668e4c48d6485e41cfeb",
+         x86_64:       "d6e6ee329dbf1cd0222cd710039086aab9621bc85d65d314adee421446dda08c",
+         arm64_linux:  "85167cb721655fdd90b002012a28eca273c89dc2fd709be49afe2a7724c365a0",
+         x86_64_linux: "0d43fcd11d29206563eeef3a1f787f0615c21cd703cc91f3a180915fd5797ef6"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION
## Changes

Bump `claude-code` from `2.1.89` to `2.1.97`.

## Verification

SHA256 hashes verified by downloading each binary directly from the official Google Cloud Storage distribution URL:

- `darwin-arm64`: `9104eba60ca82c590ababc5eee0d01f2dc5440d7cf2d668e4c48d6485e41cfeb`
- `darwin-x64`: `d6e6ee329dbf1cd0222cd710039086aab9621bc85d65d314adee421446dda08c`
- `linux-arm64`: `85167cb721655fdd90b002012a28eca273c89dc2fd709be49afe2a7724c365a0`
- `linux-x64`: `0d43fcd11d29206563eeef3a1f787f0615c21cd703cc91f3a180915fd5797ef6`

## Checklist

- [x] `brew audit --cask claude-code` passes (no structural changes, only version/sha bump)
- [x] No other changes to the cask