### PR TITLE
mockphine 0.6.1 (new cask)

### DIFF
--- a/Casks/m/mockphine.rb
+++ b/Casks/m/mockphine.rb
@@ -1,0 +1,20 @@
+cask "mockphine" do
+  arch arm: "", intel: "-intel"
+
+  version "0.6.1"
+  sha256 :no_check
+
+  url "https://downloads.mockphine.com/latest/mockphine#{arch}.dmg"
+  name "Mockphine"
+  desc "Local mock API server with passthrough fallback"
+  homepage "https://mockphine.com/"
+
+  livecheck do
+    url "https://github.com/MockphineApp/Mockphine/releases/latest"
+    strategy :github_latest
+  end
+
+  auto_updates true
+
+  app "Mockphine.app"
+end


### PR DESCRIPTION
-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online mockphine` is error-free.
- [x] `brew style --fix mockphine` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (searched for `mockphine`).
- [x] `brew audit --cask --new mockphine` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --appdir=/tmp/MockphineApps mockphine` worked successfully.
- [x] `brew uninstall --cask mockphine` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI assisted with drafting the initial cask and narrowing the download URL strategy. I manually verified the final cask on macOS 26.3.1 with `brew audit --cask --online mockphine`, `brew audit --cask --new --online mockphine`, `brew style --fix mockphine`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --appdir=/tmp/MockphineApps mockphine`, and `brew uninstall --cask mockphine`.

No `zap` stanza is included in this cask.
