### PR TITLE
guard 1.0.0 (new cask)

### DIFF
--- a/Casks/g/guard.rb
+++ b/Casks/g/guard.rb
@@ -1,0 +1,20 @@
+cask "guard" do
+  version "1.0.0"
+  sha256 "1b108b68bc8d67cffa1dbaa00dfc1ca5b7fe1adfff4b7f3b6ad6d45dfff9fd00"
+
+  url "https://github.com/FaisalFehad/Guard/releases/download/v#{version}/Guard.dmg",
+      verified: "github.com/FaisalFehad/Guard/"
+  name "Guard"
+  desc "Camera access monitor that freezes processes until approved"
+  homepage "https://guard-app.net"
+
+  depends_on macos: ">= :sonoma"
+
+  app "Guard.app"
+
+  zap trash: [
+    "~/Library/Application Support/Guard",
+    "~/Library/LaunchAgents/com.guard-app.mac.plist",
+    "~/Library/Preferences/com.guard-app.mac.plist",
+  ]
+end


### PR DESCRIPTION
## Description

New cask for [Guard](https://guard-app.net) — a camera access monitor for macOS.

Guard sits in the menu bar and monitors camera hardware via CoreMediaIO. When any process tries to access the camera, it freezes the process with SIGSTOP and prompts the user to allow or block.

- **Homepage:** https://guard-app.net
- **Repository:** https://github.com/FaisalFehad/Guard
- **License:** MIT
- **Requires:** macOS 14 (Sonoma)+