### PR TITLE
nomachine-enterprise-client: update checksum

### DIFF
--- a/Casks/n/nomachine-enterprise-client.rb
+++ b/Casks/n/nomachine-enterprise-client.rb
@@ -1,6 +1,6 @@
 cask "nomachine-enterprise-client" do
   version "9.4.14_1"
-  sha256 "1475073dee588d58895ac2944992f7681aa46388bc388d93500d076a86d91354"
+  sha256 "864b5345a9930f09a9d5bad06f0b92735636ca686074ac44b273025ebdd7d6b2"
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine-enterprise-client_#{version}.dmg"
   name "NoMachine Enterprise Client"


### PR DESCRIPTION
Update the nomachine-enterprise-client checksum for version 9.4.14_1 because it does not currently match what is downloaded from the NoMachine website.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

I tried the `brew audit` command, but it failed with an error:
```
$ brew audit --cask --online nomachine-enterprise-client
Error: These casks are not in any locally installed taps!

  nomachine-enterprise-client

You may need to run `brew tap` to install additional taps.
```

I wonder if this is because I'm just doing a drive-by PR?  I haven't actually tried installing the edited cask.  I have tried upgrading the cask without the change in this PR, but it fails after downloading the DMG because the checksum is wrong.  But it's only a checksum change, and I'm hoping that this project has CI that will verify that this change makes the package work again.

Additionally, if adding a new cask:

Not adding a new cask.

-----