### PR TITLE
waterfox: update sha256 checksum

### DIFF
--- a/Casks/w/waterfox.rb
+++ b/Casks/w/waterfox.rb
@@ -1,6 +1,6 @@
 cask "waterfox" do
   version "6.6.11"
-  sha256 "04f4076f41ce5147a276a0bda5ffa3c82ed8d6355942debb3b226a130e4ea739"
+  sha256 "3f654773404e3fe40405beb34625cd35500b244393e3bae8e222c287744d1bea"
 
   url "https://cdn1.waterfox.net/waterfox/releases/#{version}/Darwin_x86_64-aarch64/Waterfox%20#{version}.dmg"
   name "Waterfox"

--- a/Casks/w/waterfox.rb
+++ b/Casks/w/waterfox.rb
@@ -1,6 +1,6 @@
 cask "waterfox" do
   version "6.6.11"
-  sha256 "b16cad06e748e525c0aeb8f6a8a7504608927a80ac9530739053d8521126696b"
+  sha256 "04f4076f41ce5147a276a0bda5ffa3c82ed8d6355942debb3b226a130e4ea739"
 
   url "https://cdn1.waterfox.net/waterfox/releases/#{version}/Darwin_x86_64-aarch64/Waterfox%20#{version}.dmg"
   name "Waterfox"


### PR DESCRIPTION
Updated the sha256 checksum for Waterfox version 6.6.11

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

This is based off an issue BrowserWorks/waterfox#4185

I'd like to apologize in advance if this was done improperly, but I am not a Homebrew/macOS user and cannot run the proper tests. Basing off #226202, I figured the changes made are all that is needed.