### PR TITLE
Archive accidental manual PR

### DIFF
--- a/Casks/j/jiba.rb
+++ b/Casks/j/jiba.rb
@@ -1,6 +1,6 @@
 cask "jiba" do
-  version "1.4.1"
-  sha256 "9be528d460933198cdb33759decb54a7f34cc7c94e8da9b5f9bfb537b1c38bb8"
+  version "1.4.2"
+  sha256 "74254a565bc191f6e445c1f832bd0d1fb7ca113784a131925d43c46e01070ed5"
 
   url "https://hee.ink/updates/stable/JiBA-#{version}.dmg"
   name "JiBA"

--- a/Casks/j/jiba.rb
+++ b/Casks/j/jiba.rb
@@ -1,6 +1,6 @@
 cask "jiba" do
-  version "1.4.2"
-  sha256 "74254a565bc191f6e445c1f832bd0d1fb7ca113784a131925d43c46e01070ed5"
+  version "1.4.3"
+  sha256 "c10dbcd98aedcc1fd432899028bce6198999f3e94f24f994f201d9c5897cc090"
 
   url "https://hee.ink/updates/stable/JiBA-#{version}.dmg"
   name "JiBA"


### PR DESCRIPTION
This pull request was opened manually by mistake during the JiBA 1.4.3 Homebrew update.

It is intentionally kept closed as an archive record.

The actual update should be submitted by Homebrew BrewTestBot through the normal `brew bump-cask-pr` / autobump workflow.