### PR TITLE
intellij-idea-oss 2026.1 (new cask)

### DIFF
--- a/Casks/i/intellij-idea-oss.rb
+++ b/Casks/i/intellij-idea-oss.rb
@@ -1,0 +1,41 @@
+cask "intellij-idea-oss" do
+  arch arm: "-aarch64"
+
+  version "2026.1"
+  sha256 arm:   "248cc39ae85ea176e9b4a5fc0e0f8f67eea2db42ba3d67d75e1a23c3597067b3",
+         intel: "2f04e7bf2666b059d9e1886d9415622bec06c884d9dca9eb131265de936c7cb5"
+
+  url "https://github.com/JetBrains/intellij-community/releases/download/idea%2F#{version}/idea-#{version}#{arch}.dmg"
+  name "IntelliJ IDEA OSS"
+  desc "Open-source edition of IntelliJ IDEA"
+  homepage "https://github.com/JetBrains/intellij-community"
+
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
+  livecheck do
+    url :url
+    regex(/^idea[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
+  app "IntelliJ IDEA CE.app"
+
+  zap trash: [
+    "~/Library/Application Support/JetBrains/IdeaIC#{version.major_minor}",
+    "~/Library/Caches/JetBrains/IdeaIC#{version.major_minor}",
+    "~/Library/Logs/JetBrains/IdeaIC#{version.major_minor}",
+    "~/Library/Preferences/com.jetbrains.intellij.ce.plist",
+    "~/Library/Saved Application State/com.jetbrains.intellij.ce.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI-based chat used to assist with Ruby language syntax, more specifically for livecheck regular expression matching and for URL conditional concatenation.

Tests performed manually:
 - All commands specified above: `audit`, `style`, `install` and `uninstall`
 - Validated file paths with `brew uninstall --zap --force intellij-idea-oss`
 - Validated version resolution with `brew livecheck intellij-idea-oss`

Ensured there is no conflict with IntelliJ IDEA's unified release (distributed on JetBrains' website and also available as cask `intellij-idea`).

-----

This cask is for the open-source release of IntelliJ IDEA, only available on [the official GitHub repo]( https://github.com/JetBrains/intellij-community), and therefore was named `intellij-idea-oss`.

As announced in [a december 2025 blog post](https://blog.jetbrains.com/idea/2025/12/intellij-idea-unified-release/), IntelliJ IDEA has moved to a unified release, replacing previous Community and Ultimate editions. However, these CI builds available on GitHub are not the same as the unified releases obtainable from JetBrains' website or `intellij-idea` cask.

The open-source builds, as detailed in [this blog post](https://blog.jetbrains.com/idea/2025/11/intellij-idea-open-source/) and [the FAQ](https://lp.jetbrains.com/intellij-idea-unified-faq/), are the basis for the new unified release and do not contain any license management, paid features or trial requests for free accounts (migrated users from Community Edition). Other missing features are AI plugins, settings sync, and account management. Plugins can still be installed from the Marketplace, allowing paid or proprietary features to be added on demand.

I have opened an issue a while ago, where we discussed if the original `intellij-idea-ce` should be marked as deprecated or point to these new open-source builds, and the decision was to keep it deprecated as "Community Edition" had officially ceased to exist in the upstream, so Homebrew should follow that.

Therefore, I am proposing we add this new cask as an option for users that value the open-source-only version, such as me, for privacy, ethical or any other reason or preference.