### PR TITLE
xdeck 3.0 (new cask)

### DIFF
--- a/Casks/x/xdeck.rb
+++ b/Casks/x/xdeck.rb
@@ -1,0 +1,18 @@
+cask "xdeck" do
+  version "3.0"
+  sha256 "b3c0d1f264f9bac1dc1be6d9609f3abf66b6f2ea61831f3b0b6884152b07845f"
+
+  url "https://github.com/morishin/XDeck/releases/download/#{version}/XDeck-#{version}.zip"
+  name "XDeck"
+  desc "TweetDeck-style X/Twitter client"
+  homepage "https://github.com/morishin/XDeck"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "XDeck.app"
+end

--- a/Casks/x/xdeck.rb
+++ b/Casks/x/xdeck.rb
@@ -7,11 +7,6 @@ cask "xdeck" do
   desc "TweetDeck-style X/Twitter client"
   homepage "https://github.com/morishin/XDeck"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   depends_on macos: ">= :ventura"
 
   app "XDeck.app"

--- a/Casks/x/xdeck.rb
+++ b/Casks/x/xdeck.rb
@@ -10,4 +10,6 @@ cask "xdeck" do
   depends_on macos: ">= :ventura"
 
   app "XDeck.app"
+
+  zap trash: "~/Library/Containers/me.morishin.XDeck"
 end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online xdeck` is error-free.
- [x] `brew style --fix xdeck` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new xdeck` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask xdeck` worked successfully.
- [x] `brew uninstall --cask xdeck` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Claude Code was used to generate the cask formula and run the audit/style checks. The install and uninstall were verified on the author's machine.*

-----