### PR TITLE
Add eurkey-next 2026.03.22

### DIFF
--- a/Casks/e/eurkey-next.rb
+++ b/Casks/e/eurkey-next.rb
@@ -5,7 +5,7 @@ cask "eurkey-next" do
   url "https://github.com/felixfoertsch/EurKEY-Next/releases/download/#{version}/EurKEY-Next-#{version}.dmg",
       verified: "github.com/felixfoertsch/EurKEY-Next/"
   name "EurKEY Next keyboard layout"
-  desc "The keyboard layout for Europeans, coders, and translators."
+  desc "Keyboard layout for Europeans, coders, and translators"
   homepage "https://eurkey-macos.eu/"
 
   livecheck do

--- a/Casks/e/eurkey-next.rb
+++ b/Casks/e/eurkey-next.rb
@@ -1,0 +1,23 @@
+cask "eurkey-next" do
+  version "2026.03.22"
+  sha256 "c951f9bfcfc426d38991d1bf8e0be1142bb902dddd84f97a575958f08057b243"
+
+  url "https://github.com/felixfoertsch/EurKEY-Next/releases/download/#{version}/EurKEY-Next-#{version}.dmg",
+      verified: "github.com/felixfoertsch/EurKEY-Next/"
+  name "EurKEY Next keyboard layout"
+  desc "The keyboard layout for Europeans, coders, and translators."
+  homepage "https://eurkey-macos.eu/"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  keyboard_layout "EurKEY-Next.bundle"
+
+  # No zap stanza required
+
+  caveats do
+    reboot
+  end
+end

--- a/Casks/e/eurkey-next.rb
+++ b/Casks/e/eurkey-next.rb
@@ -8,11 +8,6 @@ cask "eurkey-next" do
   desc "Keyboard layout for Europeans, coders, and translators"
   homepage "https://eurkey-macos.eu/"
 
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   keyboard_layout "EurKEY-Next.bundle"
 
   # No zap stanza required

--- a/Casks/e/eurkey-next.rb
+++ b/Casks/e/eurkey-next.rb
@@ -8,6 +8,8 @@ cask "eurkey-next" do
   desc "Keyboard layout for Europeans, coders, and translators"
   homepage "https://eurkey-macos.eu/"
 
+  depends_on :macos
+
   keyboard_layout "EurKEY-Next.bundle"
 
   # No zap stanza required


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+eurkey&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
  - Problem: `GitHub fork (not canonical repository)`
  - The project I'm trying to add is a fork of another (unmaintained) project, yet it's now under a different name.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

I want to add a cask for the maintained fork [`eurkey-next`](https://github.com/felixfoertsch/EurKEY-Next) keyboard layout. There is already an existing cask for `eurkey`, but the [original project](https://github.com/jonasdiemer/EurKEY-Mac) is unmaintained, as is an in-between [fork](https://github.com/lbschenkel/EurKEY-Mac) of it. Due to the change in naming of the project, I figured using `eurkey-next` to disambiguate is more appropriate.

Discussion in project: https://github.com/felixfoertsch/EurKEY-Next/issues/18.
