### PR TITLE
hive-app 1.0.104

### DIFF
--- a/Casks/h/hive-app.rb
+++ b/Casks/h/hive-app.rb
@@ -1,9 +1,9 @@
 cask "hive-app" do
   arch arm: "-arm64"
 
-  version "1.0.103"
-  sha256 arm:   "deec1470a0a3131db722f6b69f657eb008c78baaceff4758524ae7d71b5e139c",
-         intel: "1a9b6f74b19a87b5c32bed441f96c4594f20452eca691aa3c860e35cd7dc1623"
+  version "1.0.104"
+  sha256 arm:   "d2fe10b1cb962baff925c3a740cc7793ab3050e6a0467d18bed6af91b039b7e0",
+         intel: "ace955cb4a3a95f0baf5d77c832dfea8d6ba389ffa9c2cfcff3369fd8d5bae06"
 
   url "https://github.com/morapelker/hive/releases/download/v#{version}/Hive-#{version}#{arch}.dmg"
   name "Hive"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Weird thing: this cask is autobumped, but it did appear when running `brew livecheck --eval-all --tap homebrew/cask`, so without the `--autobump` flag. I'll try investigating, since this looks weird to me.