### PR TITLE
Add glint 1.0.0

### DIFF
--- a/Casks/g/glint.rb
+++ b/Casks/g/glint.rb
@@ -1,0 +1,21 @@
+cask "glint" do
+  version "1.0.0"
+  sha256 "390afe63d53f6b2e8132ec560f092aaf8778adea13a8774d1c18bb5726588bea"
+
+  url "https://github.com/blaineam/Glint/releases/download/v#{version}/Glint.dmg",
+      verified: "github.com/blaineam/Glint/"
+  name "Glint"
+  desc "Control external display brightness and volume via DDC from your keyboard"
+  homepage "https://glint.wemiller.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "Glint.app"
+
+  zap trash: "~/Library/Preferences/com.blainemiller.Glint.plist"
+end


### PR DESCRIPTION
## Description

Adds [Glint](https://glint.wemiller.com), a macOS menu bar app that intercepts keyboard brightness and volume media keys and sends DDC/CI commands to external monitors. Control the brightness and volume of all your displays from your keyboard.

- **App name:** Glint
- **Homepage:** https://glint.wemiller.com
- **Source:** https://github.com/blaineam/Glint (MIT License)
- **Signed & notarized** by Apple
- **macOS 13+ (Ventura)**
- **Under 1 MB**, zero dependencies, pure Swift + IOKit

### Checklist
- [x] App is signed and notarized
- [x] DMG hosted on GitHub Releases
- [x] Livecheck configured with `strategy :github_latest`
- [x] `zap` stanza included