### PR TITLE
Add solomd 0.1.8

### DIFF
--- a/Casks/s/solomd.rb
+++ b/Casks/s/solomd.rb
@@ -1,0 +1,27 @@
+cask "solomd" do
+  version "0.1.8"
+  sha256 "76f277a80cd78c64939c9aaa5609c0af22e9daf68873ebaa6176611f0b62c0c5"
+
+  url "https://github.com/zhitongblog/solomd/releases/download/v#{version}/SoloMD_#{version}_universal.dmg",
+      verified: "github.com/zhitongblog/solomd/"
+  name "SoloMD"
+  desc "Lightweight Markdown and plain text editor"
+  homepage "https://solomd.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "SoloMD.app"
+
+  zap trash: [
+    "~/Library/Application Support/app.solomd",
+    "~/Library/Caches/app.solomd",
+    "~/Library/Preferences/app.solomd.plist",
+    "~/Library/Saved Application State/app.solomd.savedState",
+    "~/Library/WebKit/app.solomd",
+  ]
+end


### PR DESCRIPTION
## New Cask: SoloMD

**Name:** SoloMD
**Homepage:** https://solomd.app
**Description:** Lightweight Markdown and plain text editor
**Artifact:** App (SoloMD.app)

### Details

SoloMD is a free, open-source, cross-platform Markdown + plain text editor built with Tauri 2. ~15 MB installer, MIT licensed.

- Live preview, Vim mode, 8 themes
- KaTeX math, Mermaid diagrams
- Export to PDF/DOCX/HTML/PNG
- Clean AI artifacts (strips LLM junk from ChatGPT/Gemini/Perplexity)
- CJK encoding support (GBK/Big5/Shift_JIS auto-detect)

**GitHub:** https://github.com/zhitongblog/solomd (MIT license)
**Downloads:** 500+ (GitHub Releases)