### PR TITLE
Add rephraser 1.0.0

### DIFF
--- a/Casks/r/rephraser.rb
+++ b/Casks/r/rephraser.rb
@@ -1,0 +1,19 @@
+cask "rephraser" do
+  version "1.0.0"
+  sha256 "99fcdb553f02aea3227a11ada38db21e1d34dc60d08eb65e4bb0ff08b2a45c69"
+
+  url "https://github.com/vatsan95/Rephraser/releases/download/v#{version}/Rephraser-macOS.zip"
+  name "Rephraser"
+  desc "On-device AI text rewriter for macOS"
+  homepage "https://vatsan95.github.io/Rephraser/"
+
+  depends_on macos: ">= :sonoma"
+  depends_on arch: :arm64
+
+  app "Rephraser.app"
+
+  zap trash: [
+    "~/Library/Application Support/Rephraser",
+    "~/Library/Preferences/com.rephraser.app.plist",
+  ]
+end


### PR DESCRIPTION
New cask for Rephraser - a free, open-source macOS menu bar app for on-device AI text rephrasing using Apple MLX.

- Homepage: https://vatsan95.github.io/Rephraser/
- GitHub: https://github.com/vatsan95/Rephraser
- Download: GitHub Releases asset
- SHA256 verified
- Requires macOS Sonoma+ and Apple Silicon
- MIT licensed