### PR TITLE
Add origami 0.17.0

### DIFF
--- a/Casks/o/origami.rb
+++ b/Casks/o/origami.rb
@@ -1,0 +1,28 @@
+cask "origami" do
+  version "0.17.0"
+  sha256 "25ac14ab9ad7ee916bc8b44f72c211a295af976e1c7a2f78447a983391d401c1"
+
+  url "https://storage.tryorigami.app/releases/Origami_#{version}_universal.dmg"
+  name "Origami"
+  desc "Project-oriented terminal manager"
+  homepage "https://tryorigami.app/"
+
+  livecheck do
+    url "https://storage.tryorigami.app/releases/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "Origami.app"
+
+  zap trash: [
+    "~/Library/Application Support/app.tryorigami.macos",
+    "~/Library/Caches/app.tryorigami.macos",
+    "~/Library/Preferences/app.tryorigami.macos.plist",
+    "~/Library/WebKit/app.tryorigami.macos",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] \`brew audit --cask --online <cask>\` is error-free.
- [x] \`brew style --fix <cask>\` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] \`brew audit --cask --new <cask>\` worked successfully.
- [x] \`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>\` worked successfully.
- [x] \`brew uninstall --cask <cask>\` worked successfully.

---

[Origami](https://tryorigami.app/) is a project-oriented terminal manager for macOS. Universal binary (arm64 + x86_64), signed with Developer ID Application (Ricardo Bucho, 25C4PU85W9), notarized and stapled. Stable versioned downloads served from \`storage.tryorigami.app\` (Cloudflare R2 + Worker). The app self-updates via \`tauri-plugin-updater\` against \`latest.json\`, hence \`auto_updates true\`. The \`livecheck\` block reads the same JSON.

Zap paths verified against actual macOS data dirs after install:
- \`~/Library/Application Support/app.tryorigami.macos\` — plugin-store JSON (workspaces, settings)
- \`~/Library/Caches/app.tryorigami.macos\` — WebKit cache
- \`~/Library/Preferences/app.tryorigami.macos.plist\` — NSUserDefaults
- \`~/Library/WebKit/app.tryorigami.macos\` — WebKit storage

---

- [x] AI was used to generate or assist with generating this PR. The cask is generated by Origami's release script from a template; I manually verified zap paths against \`~/Library\` on a real install, ran \`brew style\`, \`brew audit --cask --new --online\`, and tested \`brew install --cask\` (to a temp \`--appdir\`) followed by \`brew uninstall --cask\` locally.