### PR TITLE
mace 0.1.0-beta

### DIFF
--- a/Casks/m/mace.rb
+++ b/Casks/m/mace.rb
@@ -1,6 +1,6 @@
 cask "mace" do
-  version "0.0.25-alpha"
-  sha256 "2ab3d22ce1ba65bac32da3c975662219e68a9cebd8b6e584f5ecbc783cbe824d"
+  version "0.1.0-beta"
+  sha256 "729e18a33901b5254369ac93b052d539acff207576489c2fb133865cc2e3c159"
 
   url "https://github.com/MACE-App/MACE/releases/download/v#{version}/M.A.C.E.V#{version}.dmg"
   name "MACE"
@@ -10,7 +10,7 @@ cask "mace" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+(?:-alpha)?)/i)
+    regex(/^v?(\d+(?:\.\d+)+(?:[._-](?:alpha|beta|rc).*)?)$/i)
   end
 
   depends_on macos: ">= :sequoia"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`mace` is autobumped but the workflow failed to update to version 0.1.0-beta because the `livecheck` block regex is only set up to capture an `-alpha` unstable suffix and the end of the regex isn't anchored, so the 0.1.0-beta tag is incorrectly matched as 0.1.0. This updates the version and updates the `livecheck` block regex to account for additional suffixes and anchor the end of the regex.