### PR TITLE
fluidvoice 1.5.12 (new cask)

### DIFF
--- a/Casks/f/fluidvoice.rb
+++ b/Casks/f/fluidvoice.rb
@@ -1,0 +1,29 @@
+cask "fluidvoice" do
+  version "1.5.12"
+  sha256 "c7e306236f0424be72bc76a3519c406bb51ab749778a9f815bcf9e9c1da16e86"
+
+  url "https://github.com/altic-dev/FluidVoice/releases/download/v#{version}/Fluid-oss-#{version}.dmg",
+      verified: "github.com/altic-dev/FluidVoice/"
+  name "FluidVoice"
+  desc "Offline voice-to-text dictation app with AI enhancement"
+  homepage "https://altic.dev/fluid"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "FluidVoice.app"
+
+  zap trash: [
+    "~/Library/Application Support/FluidAudio",
+    "~/Library/Application Support/FluidVoice",
+    "~/Library/Caches/com.FluidApp.app",
+    "~/Library/Caches/FluidAudio",
+    "~/Library/Logs/Fluid",
+    "~/Library/Preferences/com.FluidApp.app.plist",
+  ]
+end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions).
- [x] `brew audit --cask --online fluidvoice` is error-free.
- [x] `brew style --fix fluidvoice` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+fluidvoice&type=pullrequests).
- [x] `brew audit --cask --new fluidvoice` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask fluidvoice` worked successfully.
- [x] `brew uninstall --cask fluidvoice` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

Claude (Anthropic's coding assistant) helped draft the cask from the spokenly cask as a style reference. I manually verified each step on an Apple Silicon Mac running macOS Sequoia 26.3.1:

- Downloaded the DMG from the release asset and confirmed the sha256 matches the value in the cask.
- Ran `brew install --cask ./Casks/f/fluidvoice.rb` (from a local fork) — app installed to `/Applications/FluidVoice.app` cleanly.
- Launched the app, confirmed version `1.5.12` via `defaults read /Applications/FluidVoice.app/Contents/Info CFBundleShortVersionString`.
- Ran `brew uninstall --cask --zap fluidvoice` and confirmed every path in the zap stanza was trashed. The zap list was derived by grepping `~/Library/{Application Support,Caches,Preferences,Logs}` for `Fluid` / `com.FluidApp.app` after running the app (so every path corresponds to something the app actually creates on disk).
- Ran `brew audit --cask --online --new fluidvoice` and `brew style fluidvoice` — both clean.

-----

Resolves user request [altic-dev/FluidVoice#92](https://github.com/altic-dev/FluidVoice/issues/92) (distribute FluidVoice via Homebrew cask).

### Notes

- FluidVoice is an open-source offline dictation app for macOS. Source is at [altic-dev/FluidVoice](https://github.com/altic-dev/FluidVoice); DMG releases are published to that repo under the `Fluid-oss-<version>.dmg` asset name (the companion source repo is called `Fluid-oss`, hence the asset prefix — I used `verified:` on the URL since the path differs from the repo name).
- The DMG is a universal binary (arm64 + x86_64), Developer ID-signed (Team `V4J43B279J`), and runs on Intel Macs too. macOS 15 (Sequoia) is the stated minimum per the app's README.
- `auto_updates true` is set because the app has a built-in updater per its release notes / README.
- `livecheck` uses the `:github_latest` strategy since the project publishes to GitHub Releases and has no Sparkle appcast.