### PR TITLE
renameclick 2.7.5 (new cask)

### DIFF
--- a/Casks/r/renameclick.rb
+++ b/Casks/r/renameclick.rb
@@ -8,7 +8,7 @@ cask "renameclick" do
   url "https://github.com/noemaVision/renameclick/releases/download/v#{version}/RenameClick-#{version}-#{arch}.dmg",
       verified: "github.com/noemaVision/renameclick/"
   name "RenameClick"
-  desc "Desktop application to batch rename files using AI"
+  desc "Local-first AI app for file renaming and organization"
   homepage "https://rename.click/"
 
   livecheck do

--- a/Casks/r/renameclick.rb
+++ b/Casks/r/renameclick.rb
@@ -1,0 +1,23 @@
+cask "renameclick" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.7.5"
+  sha256 arm:   "61e552b461f783542cd5bf8d7ed6e4264958f7f1e61eb8e0234a4f1256d8086e",
+         intel: "17fe19594d58bc6e96ced6b01b1e934598239c542ec5c5e0061dc7982ec989a5"
+
+  url "https://github.com/noemaVision/renameclick/releases/download/v#{version}/RenameClick-#{version}-#{arch}.dmg",
+      verified: "github.com/noemaVision/renameclick/"
+  name "RenameClick"
+  desc "Desktop application to batch rename files using AI"
+  homepage "https://rename.click/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "RenameClick.app"
+end

--- a/Casks/r/renameclick.rb
+++ b/Casks/r/renameclick.rb
@@ -8,7 +8,7 @@ cask "renameclick" do
   url "https://github.com/noemaVision/renameclick/releases/download/v#{version}/RenameClick-#{version}-#{arch}.dmg",
       verified: "github.com/noemaVision/renameclick/"
   name "RenameClick"
-  desc "Local-first AI app for file renaming and organization"
+  desc "Local-first AI app for file renaming and organisation"
   homepage "https://rename.click/"
 
   livecheck do
@@ -20,4 +20,16 @@ cask "renameclick" do
   depends_on macos: ">= :monterey"
 
   app "RenameClick.app"
+
+  zap trash: [
+    "~/Library/Application Support/RenameClick",
+    "~/Library/Caches/com.renameclick.app",
+    "~/Library/Caches/com.renameclick.app.helper",
+    "~/Library/HTTPStorages/com.renameclick.app",
+    "~/Library/Logs/renameclick.log",
+    "~/Library/Preferences/com.renameclick.app.helper.plist",
+    "~/Library/Preferences/com.renameclick.app.plist",
+    "~/Library/Saved Application State/com.renameclick.app.savedState",
+    "~/Library/WebKit/com.renameclick.app",
+  ]
 end


### PR DESCRIPTION
## Summary
- add `renameclick` as a new cask
- use signed and notarized architecture-specific DMGs published from upstream GitHub Releases
- enable `livecheck` via `strategy :github_latest`

## Validation
- `brew style --cask noemaVision/cask/renameclick` ✅
- `brew livecheck --cask --autobump noemaVision/cask/renameclick` ✅ (`2.7.5 ==> 2.7.5`)
- `brew audit --new --cask --online --signing noemaVision/cask/renameclick` ⚠️ failed only on the automatic GitHub notability check

## Notability note
This app has a first-party website at `https://rename.click/` and uses GitHub Releases only to host the macOS binaries. Per the "Exceptions to the notability threshold" section in Homebrew's Acceptable Casks docs, this seems to match the case where a popular app has its own website but a GitHub repository that may not itself appear notable enough.
