### PR TITLE
macshot 4.0.4 (new cask)

### DIFF
--- a/Casks/m/macshot.rb
+++ b/Casks/m/macshot.rb
@@ -1,0 +1,28 @@
+cask "macshot" do
+  version "4.0.4"
+  sha256 "3a25a3d64cf0b462067f1071a4d0d845c3c970e7f11638e3e7f1a5fa7a0dd23f"
+
+  url "https://github.com/sw33tLie/macshot/releases/download/v#{version}/MacShot.dmg"
+  name "macshot"
+  desc "Native screenshot tool inspired by Flameshot"
+  homepage "https://github.com/sw33tLie/macshot"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/sw33tLie/macshot/main/appcast.xml"
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.short_version
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "macshot.app"
+
+  uninstall quit: "com.sw33tlie.macshot.macshot"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.sw33tlie.macshot.macshot",
+    "~/Library/Containers/com.sw33tlie.macshot.macshot",
+  ]
+end

--- a/Casks/m/macshot.rb
+++ b/Casks/m/macshot.rb
@@ -4,7 +4,7 @@ cask "macshot" do
 
   url "https://github.com/sw33tLie/macshot/releases/download/v#{version}/MacShot.dmg"
   name "macshot"
-  desc "Native screenshot tool inspired by Flameshot"
+  desc "Screenshot and screen recording tool"
   homepage "https://github.com/sw33tLie/macshot"
 
   livecheck do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used AI only to help me write a livecheck block using sparkle strategy, since the normal 
`strategy :sparkle, &:short_version`
returned the beta version:

```nushell
brew livecheck --cask fraluc06/tap/macshot
macshot: 4.0.4 ==> 4.0.5-beta.6
```

Otherwise, we could use `strategy :github_latest` to provide a cleaner livecheck block.
The zap stanza was generated with the `brew generate-zap` command after the installation and first opening of the app

-----
