### PR TITLE
syntax-highlight: update version and live check

### DIFF
--- a/Casks/s/syntax-highlight.rb
+++ b/Casks/s/syntax-highlight.rb
@@ -1,24 +1,22 @@
 cask "syntax-highlight" do
-  version "2.1.28"
-  sha256 "a63bf284e53c98b0cd2f906d6feb64ad2978e0e53b9c6d79e744d7a722249aae"
+  version "2.1.30"
+  sha256 "d4b135c9dd8253c1f9f5bb86236c4aa1e996c72c2203ab83fea8fb3a7579156f"
 
-  url "https://github.com/sbarex/SourceCodeSyntaxHighlight/releases/download/#{version}/Syntax.Highlight.zip"
+  url "https://github.com/sbarex/QLSyntaxHighlight/releases/download/#{version}/Syntax.Highlight.zip"
   name "Syntax Highlight"
   desc "Quicklook extension for source files"
-  homepage "https://github.com/sbarex/SourceCodeSyntaxHighlight"
+  homepage "https://github.com/sbarex/QLSyntaxHighlight"
 
   # The Sparkle feed contains `pubDate` values that are in Italian (e.g.
   # mar, 31 dic 2024 18:21:00 +0100), so the `Sparkle` strategy doesn't
   # accurately sort the items by date. We have to work with all the feed items
   # in the `strategy` block, as a way of avoiding the sorting issues.
   livecheck do
-    url "https://sbarex.github.io/SourceCodeSyntaxHighlight/appcast.xml"
+    url "https://sbarex.github.io/QLSyntaxHighlight/appcast.xml"
     strategy :sparkle do |items|
       items.map(&:short_version)
     end
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
Since Syntax Highlight is now notarized, it no longer needs to be disabled.

See https://github.com/sbarex/QLSyntaxHighlight/releases/tag/2.1.30

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
