### PR TITLE
Add gangz1o-clipaste cask

### DIFF
--- a/Casks/g/gangz1o-clipaste.rb
+++ b/Casks/g/gangz1o-clipaste.rb
@@ -1,0 +1,27 @@
+cask "gangz1o-clipaste" do
+  version "1.0.5"
+  sha256 "5e356b7d467d46fd206cd237b602b77780c5e7a51a676e4c15d29a14423c1301"
+
+  url "https://github.com/gangz1o/Clipaste/releases/download/v#{version}/Clipaste-v#{version}.dmg",
+      verified: "github.com/gangz1o/Clipaste/"
+  name "Clipaste"
+  desc "Native clipboard manager"
+  homepage "https://github.com/gangz1o/Clipaste"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Clipaste.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.gangz1o.clipaste",
+    "~/Library/Caches/com.gangz1o.clipaste",
+    "~/Library/Preferences/com.gangz1o.clipaste.plist",
+    "~/Library/Saved Application State/com.gangz1o.clipaste.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary
- add a new `gangz1o-clipaste` cask for Clipaste
- use the GitHub release DMG from `gangz1o/Clipaste`
- mark `auto_updates true` because the app ships Sparkle updates

## Notes
- Token uses `gangz1o-clipaste` because `clipaste` is already occupied by an unrelated existing cask.
- Latest release used for this submission: https://github.com/gangz1o/Clipaste/releases/tag/v1.0.5
- Release artifacts are signed/notarized through the project's release workflow.

## Local validation
- `brew style --cask gangz1o-clipaste` ✅
- `ruby -c Casks/g/gangz1o-clipaste.rb` ✅
- `brew audit --cask --new --strict --online gangz1o-clipaste` could not be completed locally because Homebrew reported an outdated Command Line Tools installation on this machine.
