### PR TITLE
mater 3.0.0

### DIFF
--- a/Casks/m/mater.rb
+++ b/Casks/m/mater.rb
@@ -1,34 +1,15 @@
 cask "mater" do
-  on_arm do
-    version "2.0.3"
-    sha256 "3475eac057163616e5f2ad7d91ff02faeca9bfd267bfc963e78ca284212a20f3"
+  version "3.0.0"
+  sha256 "7aaa096ab307da5123641f9238083c413de3929625cf1ecd1cd080814ce855ff"
 
-    url "https://github.com/jasonlong/mater/releases/download/v#{version}/Mater-#{version}-arm64.dmg"
-
-    depends_on macos: ">= :monterey"
-
-    app "Mater.app"
-  end
-  on_intel do
-    version "1.0.10"
-    sha256 "613dba1cd8ca8dee74b30a456d3d2cb87896020b5305d6ff25f5f324499c4ee7"
-
-    url "https://github.com/jasonlong/mater/releases/download/#{version}/Mater-darwin-x64.zip"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    depends_on macos: ">= :catalina"
-
-    app "Mater-darwin-x64/Mater.app"
-  end
-
+  url "https://github.com/jasonlong/mater/releases/download/v#{version}/Mater-v#{version}-macos.zip"
   name "Mater"
   desc "Menubar pomodoro app"
   homepage "https://github.com/jasonlong/mater"
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  depends_on macos: ">= :sonoma"
+
+  app "Mater.app"
 
   zap trash: [
     "~/Library/Application Support/mater",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`mater` is autobumped but the workflow failed to update to version 3.0.0 because the app has been rewritten and upstream now publishes only a single universal binary in a zip file using a different file name format. This updates the version and adjusts the cask accordingly.