### PR TITLE
xnviewmp: remove auto_updates

### DIFF
--- a/Casks/x/xnviewmp.rb
+++ b/Casks/x/xnviewmp.rb
@@ -1,8 +1,8 @@
 cask "xnviewmp" do
   version "1.10.5"
-  sha256 :no_check
+  sha256 "9972b02570b93b33d5b26c8aad8fcaaa947f9679762c768e762f0a44e6aa8ef4"
 
-  url "https://download.xnview.com/XnViewMP-mac.dmg"
+  url "https://download.xnview.com/old_versions/XnView_MP/XnView_MP-#{version}-mac.dmg"
   name "XnViewMP"
   desc "Photo viewer, image manager, image resiser and more"
   homepage "https://www.xnview.com/en/xnviewmp/"

--- a/Casks/x/xnviewmp.rb
+++ b/Casks/x/xnviewmp.rb
@@ -12,8 +12,6 @@ cask "xnviewmp" do
     regex(/\[XnViewMP\].*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  auto_updates true
-
   app "XnViewMP.app"
 
   zap trash: "~/Library/Saved Application State/com.xnview.XnView.savedState"


### PR DESCRIPTION
- [x] Submission is for a stable version or documented exception.
- [x] `brew audit --cask --online xnviewmp` is error-free.
- [x] `brew style --fix xnviewmp` reports no offenses.

---

XnViewMP's "Check for Updates" feature only redirects the user to the XnView downloads page (`https://www.xnview.com/en/xnview-mp/?update=1#downloads`) — it does not perform the download or installation. Per the Cask Cookbook, `auto_updates true` requires that the app "does the download and installation for you", so this stanza does not apply.

References: https://newsgroup.xnview.com/viewtopic.php?p=212752#p212752

---

- [x] AI-assisted: Claude Code was used to make the edit, run audits, and open the PR. Change was manually verified against the Cask Cookbook policy definition.