### PR TITLE
ua-connect 1.9.3 (new cask)

### DIFF
--- a/Casks/u/ua-connect.rb
+++ b/Casks/u/ua-connect.rb
@@ -1,0 +1,40 @@
+cask "ua-connect" do
+  version "1.9.3,3637"
+  sha256 "870d19bb16c98799599c930232745ffebf9adb23bfbfe19900ec4c9fb51d0099"
+
+  url "https://builds.uaudio.com/apps/UA_Connect/UA_Connect_#{version.csv.first.dots_to_underscores}_#{version.csv.second}_Mac.dmg"
+  name "UA Connect"
+  desc "Software installer and device manager for Universal Audio products"
+  homepage "https://www.uaudio.com/pages/download-ua-connect"
+
+  livecheck do
+    url "https://www.uaudio.com/apps/uaconnect/mac/installer"
+    regex(%r{/UA[._-]Connect[._-]v?(\d+(?:[._]\d+)+)[._-](\d+)(?:[._-]Mac)?\.dmg}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1].tr("_", ".")},#{match[2]}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "UA Connect.app"
+
+  uninstall launchctl: "com.uaudio.bsd.helper",
+            quit:      "com.uaudio.ua-connect",
+            delete:    [
+              "/Library/LaunchDaemons/com.uaudio.bsd.helper.plist",
+              "/Library/PrivilegedHelperTools/com.uaudio.bsd.helper",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/UA Connect",
+    "~/Library/Application Support/Universal Audio/UA Connect",
+    "~/Library/Logs/UA Connect",
+    "~/Library/Logs/Universal Audio/UA Connect.log",
+    "~/Library/Preferences/com.uaudio.ua-connect.plist",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.3.

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assisted with drafting the cask and livecheck logic, plus verification steps. I manually reviewed the final cask, verified the download URL, checksum, bundle identifier, install/uninstall behavior, and kept the `zap` stanza limited to the app-specific `~/Library/Application Support/Universal Audio/UA Connect` path after checking for additional runtime-created UA Connect files in this environment.

-----
