### PR TITLE
claude-code: remove outdated caveat

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -31,12 +31,4 @@ cask "claude-code" do
         "~/Library/Caches/claude-cli-nodejs",
       ],
       rmdir: "~/.claude"
-
-  caveats <<~EOS
-    This cask tracks the stable release channel. In-app update notifications
-    default to the latest channel regardless. To align notifications with this
-    cask, set the auto-update channel to "stable" via /config or in
-    ~/.claude/settings.json:
-      https://code.claude.com/docs/en/setup#configure-release-channel
-  EOS
 end


### PR DESCRIPTION
The caveat stanza was added in #255221 to warn users that in-app update notifications defaulted to the `latest` channel even when using the `claude-code` (stable) cask.

claude-code 2.1.92 fixed this: update notifications now use the release channel that matches the installed cask (`claude-code` → stable, `claude-code@latest` → latest). The caveat is no longer accurate.

The equivalent caveat was already removed from `claude-code@latest` in #258072.

Closes anthropics/claude-code#41140

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code was used to identify the fix in the 2.1.92 binary and prepare the diff. The audit and style checks were run manually to verify correctness.

-----