### PR TITLE
freecad: fix sha256 and remove deprecation

### DIFF
--- a/Casks/f/freecad.rb
+++ b/Casks/f/freecad.rb
@@ -2,7 +2,7 @@ cask "freecad" do
   arch arm: "arm64", intel: "x86_64"
 
   version "1.1.1"
-  sha256 arm:   "c3fcc95c1dae309e7971d04b32aa4b3feb326d21652f46848ac2d420b3887880",
+  sha256 arm:   "fbcab489c3d37057c2283e298ef2d50c4930cc988fb331ea7df3ad75879e3949",
          intel: "bcbe4c74abb454a05728d84185a64d9d191a8f2c53d3a58dc2e33be597e3cf36"
 
   on_arm do
@@ -25,8 +25,6 @@ cask "freecad" do
     url :url
     strategy :github_latest
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "FreeCAD.app"
 

--- a/audit_exceptions/signing_audit_skiplist.json
+++ b/audit_exceptions/signing_audit_skiplist.json
@@ -1,6 +1,7 @@
 {
   "ai-studio": "all",
   "empoche": "intel",
+  "freecad": "intel",
   "icon-composer": "intel",
   "readdle-spark": "intel",
   "plover": "intel"


### PR DESCRIPTION
Upstream released a new notarized version of `FreeCAD_1.1.1-macOS-arm64-py311.dmg`. The sha256 has been updated according to the upstream [asset](https://github.com/FreeCAD/FreeCAD/releases/download/1.1.1/FreeCAD_1.1.1-macOS-arm64-py311.dmg-SHA256.txt).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Hand coded.

-----
