### PR TITLE
djstudio 4.1.5: fix arm64 SHA-256 mismatch

### DIFF
--- a/Casks/d/djstudio.rb
+++ b/Casks/d/djstudio.rb
@@ -3,7 +3,7 @@ cask "djstudio" do
   livecheck_arch = on_arch_conditional arm: "-apple"
 
   version "4.1.5"
-  sha256 arm:   "b79010d45b1d344b2d81b5f90c1175a17dd0bd0eb625adbd901e48e807e64d85",
+  sha256 arm:   "c095fd02764fc18e012699020ca194586a9b4dcf5cf4157b0920a3c90403bc51",
          intel: "653a6d7e9d78f034e17da879b3118f4b4983895ea5f7edb16ffa1ead081d97e1"
 
   url "https://download.dj.studio/DJ.Studio-#{version}#{arch}.dmg"


### PR DESCRIPTION
The arm64 DMG hash in the cask did not match the file served at download time. Likely cause: file was replaced on the server or served stale via CDN cache. Correct hash verified by downloading, auditing, and installing the cask locally.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI was used to generate a commit message only