### PR TITLE
google-gemini 1.45.6.217 (new cask)

### DIFF
--- a/Casks/g/google-gemini.rb
+++ b/Casks/g/google-gemini.rb
@@ -16,7 +16,8 @@ cask "google-gemini" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sequoia"
+  depends_on arch:  :arm64,
+             macos: ">= :sequoia"
 
   app "Gemini.app"
 

--- a/Casks/g/google-gemini.rb
+++ b/Casks/g/google-gemini.rb
@@ -1,0 +1,46 @@
+cask "google-gemini" do
+  version "1.45.6.217"
+  sha256 :no_check
+
+  url "https://dl.google.com/release2/j33ro/release/Gemini.dmg",
+      verified: "dl.google.com/"
+  name "Gemini"
+  desc "Native desktop AI assistant from Google"
+  homepage "https://gemini.google/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist do |items|
+      items["com.google.GeminiMacOS"]&.version
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "Gemini.app"
+
+  uninstall quit: [
+    "com.google.GeminiMacOS",
+    "com.google.GeminiMacOS.launcher",
+  ]
+
+  zap launchctl: [
+        "com.google.GoogleUpdater.wake.system",
+        "com.google.keystone.agent",
+        "com.google.keystone.daemon",
+        "com.google.keystone.system.agent",
+        "com.google.keystone.system.xpcservice",
+        "com.google.keystone.xpcservice",
+      ],
+      pkgutil:   "com.google.pkg.Keystone",
+      trash:     [
+        "~/Library/Application Support/com.google.GeminiMacOS",
+        "~/Library/Application Support/com.google.GeminiMacOS.launcher",
+        "~/Library/Caches/com.google.GeminiMacOS",
+        "~/Library/Caches/com.google.GeminiMacOS.launcher",
+        "~/Library/Google/GoogleSoftwareUpdate/Actives/com.google.GeminiMacOS",
+        "~/Library/HTTPStorages/com.google.GeminiMacOS",
+        "~/Library/Preferences/com.google.GeminiMacOS.plist",
+      ]
+end

--- a/Casks/g/google-gemini.rb
+++ b/Casks/g/google-gemini.rb
@@ -16,8 +16,8 @@ cask "google-gemini" do
   end
 
   auto_updates true
-  depends_on arch:  :arm64,
-             macos: ">= :sequoia"
+  depends_on macos: ">= :sequoia"
+  depends_on arch: :arm64
 
   app "Gemini.app"
 


### PR DESCRIPTION
Adds a new cask for [Google Gemini](https://gemini.google/mac/) - Google's native macOS desktop app for the Gemini AI assistant.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Used Claude Code with my own [skill](https://skills.sh/connorads/dotfiles/homebrew-cask-authoring) to scaffold and validate the cask. The agent ran `brew style --fix`, `brew audit --cask --online --new`, `brew install --cask`, `brew uninstall --cask`, and `brew uninstall --zap --cask`, and I read the output of each.

I manually installed the app, signed in, and used it. The agent then scanned `~/Library` while the app was in use to derive accurate zap paths. I ran `brew uninstall --zap` while the app was running, which surfaced that the helper process (`com.google.GeminiMacOS.launcher`) survived the quit, so both bundle IDs were added to `uninstall quit:`. I reinstalled to confirm zap removed session data (signed out as expected), then zapped again while running to confirm both processes terminate cleanly and all trash paths are removed.
