### PR TITLE
solomd 0.1.10 (new cask)

### DIFF
--- a/Casks/s/solomd.rb
+++ b/Casks/s/solomd.rb
@@ -1,0 +1,27 @@
+cask "solomd" do
+  version "0.1.10"
+  sha256 "a526439dad4b007cca034d097740ad91d316bb73601344a3f55fb416d21177a8"
+
+  url "https://github.com/zhitongblog/solomd/releases/download/v#{version}/SoloMD_#{version}_universal.dmg",
+      verified: "github.com/zhitongblog/solomd/"
+  name "SoloMD"
+  desc "Lightweight Markdown and plain text editor"
+  homepage "https://solomd.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "SoloMD.app"
+
+  zap trash: [
+    "~/Library/Application Support/app.solomd",
+    "~/Library/Caches/app.solomd",
+    "~/Library/Preferences/app.solomd.plist",
+    "~/Library/Saved Application State/app.solomd.savedState",
+    "~/Library/WebKit/app.solomd",
+  ]
+end


### PR DESCRIPTION
Update SoloMD to v0.1.10. See release notes: https://github.com/zhitongblog/solomd/releases/tag/v0.1.10