### PR TITLE
android-platform-tools: update sha256

### DIFF
--- a/Casks/a/android-platform-tools.rb
+++ b/Casks/a/android-platform-tools.rb
@@ -2,8 +2,8 @@ cask "android-platform-tools" do
   os macos: "darwin", linux: "linux"
 
   version "37.0.0"
-  sha256 arm:          "48ac88ab066da4939f8232c451173b1e1295f9e5d248ee50b89b495b39b7f79f",
-         x86_64:       "48ac88ab066da4939f8232c451173b1e1295f9e5d248ee50b89b495b39b7f79f",
+  sha256 arm:          "094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7",
+         x86_64:       "094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7",
          x86_64_linux: "198ae156ab285fa555987219af237b31102fefe8b9d2bc274708a8d4f2865a07",
          arm64_linux:  "198ae156ab285fa555987219af237b31102fefe8b9d2bc274708a8d4f2865a07"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

I have got a sha256 mismatch error during upgrading the `android-platform-tools`:
```
brew upgrade --force                       
✔︎ JSON API formula.jws.json                                                                                   Downloaded   32.0MB/ 32.0MB
✔︎ JSON API cask.jws.json                                                                                      Downloaded   15.4MB/ 15.4MB
==> Upgrading 1 outdated package:
android-platform-tools 36.0.2 -> 37.0.0
==> Fetching downloads for: android-platform-tools
✘ Cask android-platform-tools (37.0.0)                                                                        Verifying    16.4MB/ 16.4MB
Error: Cask reports different checksum:     48ac88ab066da4939f8232c451173b1e1295f9e5d248ee50b89b495b39b7f79f
       SHA-256 checksum of downloaded file: 094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7
Some casks with `auto_updates true` or `version :latest` may still require `--greedy`,
`HOMEBREW_UPGRADE_GREEDY` or `HOMEBREW_UPGRADE_GREEDY_CASKS` to be upgraded.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Upgrading android-platform-tools
  36.0.2 -> 37.0.0
==> Purging files for version 37.0.0 of Cask android-platform-tools
Error: android-platform-tools: SHA-256 mismatch
Expected: 48ac88ab066da4939f8232c451173b1e1295f9e5d248ee50b89b495b39b7f79f
  Actual: 094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7
```
I downloaded this zip on another server at another region (VPS@japan), calculated the sum:
```
$ wget https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip
--2026-04-16 13:21:20--  https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip
Resolving dl.google.com (dl.google.com)... 142.251.23.91, 142.251.23.93, 142.251.23.136, ...
Connecting to dl.google.com (dl.google.com)|142.251.23.91|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 16442240 (16M) [application/zip]
Saving to: ‘platform-tools_r37.0.0-darwin.zip’

platform-tools_r37. 100%[===================>]  15.68M  41.9MB/s    in 0.4s    

2026-04-16 13:21:21 (41.9 MB/s) - ‘platform-tools_r37.0.0-darwin.zip’ saved [16442240/16442240]


$ sha256sum platform-tools_r37.0.0-darwin.zip 
094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7  platform-tools_r37.0.0-darwin.zip
```
The sum is still `094a1395683c509fd4d48667da0d8b5ef4d42b2abfcd29f2e8149e2f989357c7`, so I believe there's an update from the upstream.