### PR TITLE
t3-code@nightly 0.0.21-nightly.20260417.58 (new cask)

### DIFF
--- a/Casks/t/t3-code@nightly.rb
+++ b/Casks/t/t3-code@nightly.rb
@@ -1,0 +1,44 @@
+cask "t3-code@nightly" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.0.18-nightly.20260416.46"
+  sha256 arm:   "30ab881b47070f3459e0063820e31e45bf661d0de51d1174d8ab185bd86d98a8",
+         intel: "4649a696758336d790d2ce794678b503397b2b36a354753644993ba06c933bc9"
+
+  url "https://github.com/pingdotgg/t3code/releases/download/nightly-v#{version}/T3-Code-#{version}-#{arch}.dmg",
+      verified: "github.com/pingdotgg/t3code/"
+  name "T3 Code Nightly"
+  desc "Minimal GUI for AI code agents"
+  homepage "https://t3.codes/"
+
+  livecheck do
+    url "https://github.com/pingdotgg/t3code/releases"
+    regex(/^nightly-v?(\d+(?:\.\d+)+-nightly\.\d{8}\.\d+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next unless release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "t3-code"
+  depends_on macos: ">= :monterey"
+
+  app "T3 Code (Nightly).app"
+
+  zap trash: [
+    "~/.t3/userdata",
+    "~/Library/Application Support/T3 Code (Alpha)",
+    "~/Library/Application Support/t3code",
+    "~/Library/Caches/com.t3tools.t3code",
+    "~/Library/HTTPStorages/com.t3tools.t3code",
+    "~/Library/Preferences/com.t3tools.t3code.plist",
+    "~/Library/Saved Application State/com.t3tools.t3code.savedState",
+  ]
+end

--- a/Casks/t/t3-code@nightly.rb
+++ b/Casks/t/t3-code@nightly.rb
@@ -1,9 +1,9 @@
 cask "t3-code@nightly" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.0.18-nightly.20260416.46"
-  sha256 arm:   "30ab881b47070f3459e0063820e31e45bf661d0de51d1174d8ab185bd86d98a8",
-         intel: "4649a696758336d790d2ce794678b503397b2b36a354753644993ba06c933bc9"
+  version "0.0.21-nightly.20260417.58"
+  sha256 arm:   "cdc6dca37ec8546e0d1cdb97c7f5d6cc803cebd9e402719c5c2912934470d5b2",
+         intel: "b658af8136c3f1315f001825cb05e1371d21747a7194ff21862f5dce36694b4d"
 
   url "https://github.com/pingdotgg/t3code/releases/download/nightly-v#{version}/T3-Code-#{version}-#{arch}.dmg",
       verified: "github.com/pingdotgg/t3code/"
@@ -27,7 +27,6 @@ cask "t3-code@nightly" do
   end
 
   auto_updates true
-  conflicts_with cask: "t3-code"
   depends_on macos: ">= :monterey"
 
   app "T3 Code (Nightly).app"

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -63,6 +63,7 @@
   "storyboarder": "all",
   "strawberry-wallpaper": "all",
   "telegram-desktop@beta": "any",
+  "t3-code@nightly": "all",
   "thaw@beta": "any",
   "themeengine": "all",
   "transmission@beta": "any",


### PR DESCRIPTION
Adds a nightly channel cask for T3 Code using the current nightly release:

- token: `t3-code@nightly`
- version: `0.0.21-nightly.20260417.58`
- upstream nightly tag: `nightly-v0.0.21-nightly.20260417.58`

This also adds `t3-code@nightly` to `audit_exceptions/github_prerelease_allowlist.json`, since the nightly channel is intentionally published from GitHub prereleases.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Install notes:

- I validated the original full roundtrip locally on the first nightly revision in this PR: `brew uninstall --cask t3-code`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask sscotth/homebrew-cask/t3-code@nightly`, `brew uninstall --cask t3-code@nightly`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask t3-code`.
- After reviewer feedback, I removed `conflicts_with cask: "t3-code"`, and verified that the cask no longer fails immediately on a cask conflict check. A local install attempt on the updated nightly now proceeds until the normal artifact collision check for an already-present `/Applications/T3 Code (Nightly).app`.
- This machine also had a preexisting standalone `/Applications/T3 Code (Nightly).app` that was not managed by Homebrew. I temporarily moved it aside during earlier validation and restored it afterward so the machine returned to its prior app layout.
- No `--zap` actions were used during validation.

Additional verification:

- `brew livecheck --cask sscotth/homebrew-cask/t3-code@nightly` returned `0.0.21-nightly.20260417.58`.
- Verified the DMG mounts and contains `T3 Code (Nightly).app`.
- Verified zap paths against upstream runtime paths in `apps/desktop/src/main.ts` and branding/build logic in the upstream repo.

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI usage details:

- Used Codex to draft the cask, compute nightly DMG SHA-256 values, update the GitHub prerelease allowlist, remove the `conflicts_with` stanza after maintainer feedback, and run `brew style`, `brew audit --new --cask`, `brew audit --cask --online`, and `brew livecheck`.
- Manually verified the nightly release tag/date, checked that no prior `t3-code@nightly` PR was already open or refused, mounted the DMG to confirm the app bundle name, and verified the zap paths against upstream app storage path logic.
