### PR TITLE
Add vocamac cask

### DIFF
--- a/Casks/v/vocamac.rb
+++ b/Casks/v/vocamac.rb
@@ -1,0 +1,29 @@
+cask "vocamac" do
+  version "0.6.0"
+  sha256 "38b79d439ea095a159fe01932d976b42801809eda4da1b7d197172b0f49f3320"
+
+  url "https://github.com/jatinkrmalik/vocamac/releases/download/v#{version}/VocaMac-#{version}-arm64.zip",
+      verified: "github.com/jatinkrmalik/vocamac/"
+  name "VocaMac"
+  desc "Local voice-to-text dictation using WhisperKit"
+  homepage "https://vocamac.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+  depends_on arch: :arm64
+
+  app "VocaMac.app"
+
+  uninstall quit: "com.vocamac.app"
+
+  zap trash: [
+    "~/Library/Application Support/VocaMac",
+    "~/Library/Caches/com.vocamac.app",
+    "~/Library/Preferences/com.vocamac.app.plist",
+  ]
+end


### PR DESCRIPTION
## Description

VocaMac is a native macOS menu bar application for local voice-to-text dictation, powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit) (CoreML-based on-device speech recognition).

- **Homepage:** https://vocamac.com/
- **GitHub:** https://github.com/jatinkrmalik/vocamac
- **Developer ID signed and notarized** by Apple
- **Apple Silicon (arm64)** only
- Requires **macOS 13 (Ventura)** or later
- License: AGPL-3.0

### Key Features

- 100% local/offline speech-to-text — no data leaves the device
- System-wide text injection (types transcribed text wherever the cursor is)
- Push-to-talk and double-tap toggle modes
- Runs entirely in the menu bar (no dock icon)

### Cask token note

The token `vocamac` contains "mac" — this is the product's actual name ("VocaMac"), not a generic platform reference. Similar to existing casks like `macwhisper`, `maccy`, `mac-mouse-fix`, etc.

### Verification

- `brew audit --cask vocamac` passes cleanly ✅
- `brew style vocamac.rb` — no offenses ✅
- SHA-256 verified against published checksums