### PR TITLE
dyalog 20.0.52760

### DIFF
--- a/Casks/d/dyalog.rb
+++ b/Casks/d/dyalog.rb
@@ -1,18 +1,30 @@
 cask "dyalog" do
-  version "19.0.50027"
-  sha256 "3f033230380f15cff1d2d6bff2e9d6c74057320c81da1435d41ba2a88b2a1b03"
+  arch arm: "arm"
 
-  url "https://www.dyalog.com/uploads/php/download.dyalog.com/download.php?file=#{version.major_minor}/mac_64_#{version}_unicode.pkg"
+  on_arm do
+    version "20.0.52760"
+    sha256 "44813e8814427a0612c8f4f954a9ffb5f83f25ca3eda9eb048fc042a056d7e52"
+
+    livecheck do
+      url "https://www.dyalog.com/download-zone.htm?p=download"
+      regex(%r{href=.*?/mac#{arch}_64_(\d+(?:\.\d+)+)_unicode\.pkg}i)
+    end
+  end
+  on_intel do
+    version "19.0.50027"
+    sha256 "3f033230380f15cff1d2d6bff2e9d6c74057320c81da1435d41ba2a88b2a1b03"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+
+  url "https://www.dyalog.com/uploads/php/download.dyalog.com/download.php?file=#{version.major_minor}/mac#{arch}_64_#{version}_unicode.pkg"
   name "Dyalog APL"
   desc "APL-based development environment"
   homepage "https://www.dyalog.com/"
 
-  livecheck do
-    url "https://www.dyalog.com/download-zone.htm?p=download"
-    regex(%r{href=.*?/mac_64_(\d+(?:\.\d+)+)_unicode\.pkg}i)
-  end
-
-  pkg "mac_64_#{version}_unicode.pkg"
+  pkg "mac#{arch}_64_#{version}_unicode.pkg"
 
   uninstall pkgutil: "com.dyalog.pkg.dyalog#{version.major_minor.no_dots}"
 


### PR DESCRIPTION
Dyalog 19 had two versions, one for Intel and one for Apple Silicon. The `dyalog` cask only supported the Intel version. Dyalog 20 only supports Apple Silicon. This PR adds support for Apple Silicon updating the `livecheck` for this and skipping the `livecheck` for Intel. It uses the latest version of Dyalog 19 for Intel and the latest version of Dyalog 20 for Apple Silicon.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
