### PR TITLE
xit 1.0b18

### DIFF
--- a/Casks/x/xit.rb
+++ b/Casks/x/xit.rb
@@ -1,42 +1,58 @@
 cask "xit" do
-  on_big_sur :or_older do
-    version "1.0b16"
-    sha256 "0e9897d16a5a613a4da9861c907e1f0922df446cc88628e13271793a6c94b229"
+  on_sequoia :or_older do
+    on_big_sur :or_older do
+      version "1.0b16"
+      sha256 "0e9897d16a5a613a4da9861c907e1f0922df446cc88628e13271793a6c94b229"
 
-    url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.zip"
+      url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.zip"
 
-    livecheck do
-      skip "Legacy version"
+      livecheck do
+        skip "Legacy version"
+      end
+
+      app "Xit.app"
+
+      caveats do
+        requires_rosetta
+      end
     end
+    on_monterey :or_newer do
+      arch arm: "-arm"
 
-    app "Xit.app"
+      version "1.0b17"
+      sha256 arm:   "6b44a102747811e0373737e24104902dc1d8aaf8801fc83c0e77622bab1b12fa",
+             intel: "7b25b255a1af84261321b40ac08c31311bbff73a13be2c523862863be0bba620"
 
-    caveats do
-      requires_rosetta
+      url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit#{arch}.#{version}.zip"
+
+      livecheck do
+        skip "Legacy version"
+      end
+
+      app "Xit#{arch} #{version}/Xit.app"
     end
   end
-  on_monterey :or_newer do
-    arch arm: "-arm"
+  on_tahoe :or_newer do
+    version "1.0b18"
+    sha256 "f5fa3306e8d64d1ac63b773cac5e05d1716b73e4845d9c466480a22c1f7949f3"
 
-    version "1.0b17"
-    sha256 arm:   "6b44a102747811e0373737e24104902dc1d8aaf8801fc83c0e77622bab1b12fa",
-           intel: "7b25b255a1af84261321b40ac08c31311bbff73a13be2c523862863be0bba620"
-
-    url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit#{arch}.#{version}.zip"
+    url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.#{version}.zip"
 
     livecheck do
       url :url
       regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
     end
 
-    disable! date: "2026-09-01", because: :fails_gatekeeper_check
+    depends_on arch: :arm64
 
-    app "Xit#{arch} #{version}/Xit.app"
+    app "Xit.app"
   end
 
   name "Xit"
   desc "GUI for the git version control system"
   homepage "https://github.com/Uncommon/Xit"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`xit` is autobumped but the workflow failed to update to version 1.0b18 because the file name format has changed. This requires manual changes anyway, as this version is ARM-only and only supports macOS 26 Tahoe or later. This updates the version and restructures the on_os blocks. These changes pass `brew style` and `brew audit` but check my work to make sure I've approached this correctly.