### PR TITLE
Add lockpaw 1.0.7

### DIFF
--- a/Casks/l/lockpaw.rb
+++ b/Casks/l/lockpaw.rb
@@ -1,0 +1,25 @@
+cask "lockpaw" do
+  version "1.0.7"
+  sha256 "c4af376d581b366f62832b8214ddfc04d5ba711e313d30e6d73b17ae7154525f"
+
+  url "https://github.com/sorkila/lockpaw/releases/download/v#{version}/Lockpaw.dmg",
+      verified: "github.com/sorkila/lockpaw/"
+  name "Lockpaw"
+  desc "Cover your screen while AI agents keep running"
+  homepage "https://getlockpaw.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Lockpaw.app"
+
+  zap trash: [
+    "~/Library/Caches/com.eriknielsen.lockpaw",
+    "~/Library/HTTPStorages/com.eriknielsen.lockpaw",
+    "~/Library/Preferences/com.eriknielsen.lockpaw.plist",
+  ]
+end


### PR DESCRIPTION
- [x] `brew audit --new --online --strict --token-conflicts {{cask_file}}` is error-free.
- [x] `brew style {{cask_file}}` is error-free.
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).

Lockpaw is a macOS menu bar screen guard — lock/unlock your screen with a hotkey while AI agents keep running in the background. Open source (MIT), signed, notarized, and distributed via GitHub Releases with a Sparkle auto-update feed.

- Homepage: https://getlockpaw.com/
- Source: https://github.com/sorkila/lockpaw
- License: MIT