### PR TITLE
graalvm-jdk: update livecheck

### DIFF
--- a/Casks/g/graalvm-jdk.rb
+++ b/Casks/g/graalvm-jdk.rb
@@ -2,24 +2,20 @@ cask "graalvm-jdk" do
   arch arm: "aarch64", intel: "x64"
 
   on_arm do
-    version "25.0.2,10"
+    version "25.0.2"
     sha256 "48584aa5ae0f4df088d63da7bfdf415858ea3407385fb4f559bc4d7e1b300151"
 
     livecheck do
-      url "https://java.oraclecloud.com/currentJavaReleases"
-      regex(/(?:jdk[._-])?(\d+(?:\.\d+)*)(?:-\d+)?\+(\d+)/i)
-      strategy :json do |json, regex|
-        json["items"]&.map do |item|
-          match = item["releaseFullVersion"]&.match(regex)
-          next if match.blank?
-
-          "#{match[1]},#{match[2]}"
-        end
+      url "https://www.oracle.com/a/tech/docs/graalvm-downloads.json"
+      strategy :json do |json|
+        json.filter_map do |_, category|
+          category["Releases"]&.keys
+        end.flatten
       end
     end
   end
   on_intel do
-    version "25.0.1,8"
+    version "25.0.1"
     sha256 "a762ca1d9a163e32790b9286f3af4c16369729ff27999d8dbab60d7be16cff2f"
 
     livecheck do
@@ -33,8 +29,13 @@ cask "graalvm-jdk" do
   desc "GraalVM from Oracle"
   homepage "https://www.graalvm.org/"
 
-  # FIXME: Change 11 back to #{version.csv.second} on the next release
-  artifact "graalvm-jdk-#{version.csv.first}+#{version.csv.second}.1", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"
+  depends_on :macos
+
+  # The archive contains a versioned directory with a numeric suffix that can't
+  # be identified upstream, so we rename it something generic
+  rename "graalvm-jdk-*", "graalvm-jdk"
+
+  artifact "graalvm-jdk", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"
 
   # No zap stanza required
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`graalvm-jdk` is autobumped and the workflow is mistakenly trying to update to version 26 but 25.0.2 remains the latest version of GraalVM. This is occurring because the `livecheck` block checks Java releases rather than GraalVM releases specifically. This updates the `livecheck` block to check the `graalvm-downloads.json` file that's used to create the download links on the upstream download page (https://www.oracle.com/downloads/graalvm-downloads.html). This data source doesn't provide a numeric suffix (e.g., -10) and it's not used in the archive file name version, so this updates the cask versions to omit the secondary version number.

This also adds a `rename` call to rename the directory in the archive file (e.g., graalvm-jdk-25.0.2+10.1) to a generic "graalvm-jdk" that we can reliably target in the `artifact` call. This accounts for the fact that we don't know the numeric suffix and also addresses the existing issue where the numeric suffix that we were using didn't contain the full version (e.g., 10 instead of 10.1), so part of the version suffix was hardcoded instead and this requires manual changes when updating the cask.

Lastly, this adds `depends_on :macos`, as the cask is macOS-only but
doesn't have a specific macOS version requirement. This DSL change isn't in a brew release yet, so we can't merge this PR until that happens.