### PR TITLE
Add flux-markdown

### DIFF
--- a/Casks/f/flux-markdown.rb
+++ b/Casks/f/flux-markdown.rb
@@ -1,0 +1,49 @@
+cask "flux-markdown" do
+  version "1.25.310"
+  sha256 "27b1c1c60085274ecd1107be0f6c4645d8a9864073f5f3bf4b2b4014fccb1882"
+
+  url "https://github.com/xykong/flux-markdown/releases/download/v#{version}/FluxMarkdown.dmg"
+  name "FluxMarkdown"
+  desc "Markdown previews in Finder QuickLook with diagrams and math"
+  homepage "https://github.com/xykong/flux-markdown"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  app "FluxMarkdown.app"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-cr", "#{appdir}/FluxMarkdown.app"],
+                   sudo: false
+
+    lsregister = "/System/Library/Frameworks/CoreServices.framework" \
+                 "/Frameworks/LaunchServices.framework/Support/lsregister"
+    system_command lsregister,
+                   args: ["-f", "#{appdir}/FluxMarkdown.app"],
+                   sudo: false
+
+    system_command "/usr/bin/qlmanage",
+                   args: ["-r"],
+                   sudo: false
+
+    system_command "/usr/bin/pluginkit",
+                   args: ["-a", "#{appdir}/FluxMarkdown.app/Contents/PlugIns/MarkdownPreview.appex"],
+                   sudo: false
+  end
+
+  zap trash: [
+    "~/Library/Application Scripts/com.xykong.Markdown",
+    "~/Library/Application Scripts/com.xykong.Markdown.QuickLook",
+    "~/Library/Containers/com.xykong.Markdown",
+    "~/Library/Containers/com.xykong.Markdown.QuickLook",
+  ]
+
+  caveats <<~EOS
+    If the QuickLook extension does not work immediately:
+      1. Run 'qlmanage -r' in Terminal.
+      2. Restart Finder (Force Quit > Finder > Relaunch).
+  EOS
+end


### PR DESCRIPTION
## flux-markdown

- **Name:** FluxMarkdown
- **Homepage:** https://github.com/xykong/flux-markdown
- **Desc:** Markdown previews in Finder QuickLook with diagrams and math
- **Stars:** 600+
- **License:** GPL-3.0

**Checklist:**
- [x] I have read the [contribution guidelines](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md)
- [x] `brew style --cask flux-markdown` passes (0 offenses)
- [x] `brew audit --cask --online flux-markdown` passes
- [x] Verified install works locally

**About:**
FluxMarkdown is a macOS QuickLook extension for Markdown files with 600+ GitHub stars.
It supports Mermaid diagrams, KaTeX math, GitHub Flavored Markdown (including Alerts), syntax highlighting for 40+ languages, interactive TOC, and PDF/HTML export.

**postflight explanation:**
- `xattr -cr`: removes quarantine attribute so the app opens without Gatekeeper warning on first launch
- `lsregister -f`: registers the app with Launch Services for file association
- `qlmanage -r`: refreshes the QuickLook daemon cache so the extension activates immediately without requiring a logout/login
- `pluginkit -a`: registers the embedded QuickLook extension, works in headless/non-GUI installs where `open --register-only` would fail