### PR TITLE
iina: fix URL version scheme

### DIFF
--- a/Casks/i/iina.rb
+++ b/Casks/i/iina.rb
@@ -1,8 +1,8 @@
 cask "iina" do
   version "1.4.2,164"
-  sha256 "2e0fd89fbba1c92a6c115171e5b51904883bb497fbe513a6961d080fbab08ff6"
+  sha256 "804e3368518f19039ebfbc3d698e1fabc9cd20f15fc4e42de635456cdf6a7f58"
 
-  url "https://dl-portal.iina.io/IINA.v#{version.csv.first}.dmg"
+  url "https://dl-portal.iina.io/IINA.v#{version.csv.first}-build#{version.csv.second}.dmg"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"


### PR DESCRIPTION
This commits fixes the URL version scheme set in this cask as build 164, which was released later to address a minor issue (reference: https://github.com/iina/iina/releases/tag/v1.4.2-build164) points to another URL which is not being taken care of by the cask's config. Considering the naming of the app archive takes the git tag the app is being built on, this PR will definitely cause issues as soon as a new release comes out, requiring a revert.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
