### PR TITLE
Add lite-edit cask

### DIFF
--- a/Casks/l/lite-edit.rb
+++ b/Casks/l/lite-edit.rb
@@ -1,0 +1,18 @@
+cask "lite-edit" do
+  version "1.1.3"
+  sha256 "ccb9d007f4d4cc2fdbf57f5a073362d500fcdfd311bc8a871a3e961aa6bc53b6"
+
+  url "https://github.com/arietan/lite-edit/releases/download/v#{version}/LiteEdit.dmg"
+  name "LiteEdit"
+  desc "Lightweight, fast code editor"
+  homepage "https://github.com/arietan/lite-edit"
+
+  depends_on macos: ">= :ventura"
+
+  app "LiteEdit.app"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/LiteEdit_*.plist",
+    "~/Library/Preferences/com.liteedit.app.plist",
+  ]
+end


### PR DESCRIPTION
### Description

Adds a new cask for [LiteEdit](https://github.com/arietan/lite-edit), a lightweight, fast code editor for macOS built with Swift and AppKit.

- **Version:** 1.1.3
- **macOS requirement:** >= 13 (Ventura)
- **Homepage:** https://github.com/arietan/lite-edit

### Notes

- `zap` paths verified by installing the app and inspecting `~/Library/` (bundle ID is `com.liteedit.app`)
- Resolves https://github.com/arietan/lite-edit/issues/4 (brew install --cask lite-edit was documented but the cask didn't exist)
