### PR TITLE
font-devicons 2.0.1

### DIFF
--- a/Casks/font/font-d/font-devicons.rb
+++ b/Casks/font/font-d/font-devicons.rb
@@ -1,13 +1,13 @@
 cask "font-devicons" do
-  version "1.8.0"
-  sha256 "d8d2dc243ca42897a082ffe32a22cab53cdd148cf87b24162cf450ccfc12fece"
+  version "2.0.1"
+  sha256 "0b68b1350516e2222827b74d826a635c9e6cb288d3baec12d11f85af3a5fb906"
 
-  url "https://github.com/vorillaz/devicons/archive/refs/tags/#{version}.tar.gz",
-      verified: "github.com/vorillaz/devicons/"
+  url "https://registry.npmjs.org/devicons/-/devicons-#{version}.tgz",
+      verified: "registry.npmjs.org/devicons/"
   name "Devicons"
-  homepage "https://vorillaz.github.io/devicons/"
+  homepage "https://devicons.io/"
 
-  font "devicons-#{version}/fonts/devicons.ttf"
+  font "package/dist/devicons.ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`font-devicons` is autobumped but the workflow failed to update to version 2.0.1 because it uses a `devicons-v2.0.1` tag in the GitHub repository instead of the existing v1.2.3 format. However, this would have failed anyway because the repository no longer contains the ttf file as before. The upstream website suggests that users should install the `devicons` npm package and that does contain the ttf file. This updates the version and switches the cask to use the npm tarball instead.