### PR TITLE
mujoco 3.7.0 (new cask)

### DIFF
--- a/Casks/m/mujoco.rb
+++ b/Casks/m/mujoco.rb
@@ -9,11 +9,17 @@ cask "mujoco" do
   homepage "https://mujoco.org/"
 
   livecheck do
-    url "https://github.com/google-deepmind/mujoco"
+    url :url
     strategy :github_latest
   end
 
   depends_on macos: ">= :big_sur"
 
   app "MuJoCo.app"
+
+  zap trash: [
+    "~/Library/Caches/org.mujoco.mujoco",
+    "~/Library/Preferences/org.mujoco.mujoco.plist",
+    "~/Library/Saved Application State/org.mujoco.mujoco.savedState",
+  ]
 end

--- a/Casks/m/mujoco.rb
+++ b/Casks/m/mujoco.rb
@@ -1,0 +1,19 @@
+cask "mujoco" do
+  version "3.7.0"
+  sha256 "da863520e171c1a3c8005810529058b8c9bb7bc0b51a54731d12b614053c5c2e"
+
+  url "https://github.com/google-deepmind/mujoco/releases/download/#{version}/mujoco-#{version}-macos-universal2.dmg",
+      verified: "github.com/google-deepmind/mujoco/releases/download/"
+  name "MuJoCo"
+  desc "General purpose physics engine"
+  homepage "https://mujoco.org/"
+
+  livecheck do
+    url "https://github.com/google-deepmind/mujoco"
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "MuJoCo.app"
+end

--- a/Casks/m/mujoco.rb
+++ b/Casks/m/mujoco.rb
@@ -3,15 +3,10 @@ cask "mujoco" do
   sha256 "da863520e171c1a3c8005810529058b8c9bb7bc0b51a54731d12b614053c5c2e"
 
   url "https://github.com/google-deepmind/mujoco/releases/download/#{version}/mujoco-#{version}-macos-universal2.dmg",
-      verified: "github.com/google-deepmind/mujoco/releases/download/"
+      verified: "github.com/google-deepmind/mujoco/"
   name "MuJoCo"
   desc "General purpose physics engine"
   homepage "https://mujoco.org/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
## Summary
Add a MuJoCo cask for the official macOS release DMG.

## Verification
Built and tested locally on macOS 26.4.1.
- `brew style --cask homebrew/cask/mujoco`
- `brew audit --cask --new homebrew/cask/mujoco`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask mujoco`
- `brew uninstall --cask mujoco`

## AI Disclosure
AI-assisted with OpenAI gpt-5.4-mini. I manually reviewed the cask and verified the install/uninstall flow.