### PR TITLE
Add sanduhr 2.0.4

### DIFF
--- a/Casks/s/sanduhr.rb
+++ b/Casks/s/sanduhr.rb
@@ -1,0 +1,28 @@
+cask "sanduhr" do
+  version "2.0.4"
+  sha256 "82506e0b0ce3b05b41538ce9740d9e88ecbc459bf78553df43b2cf6db3a80522"
+
+  url "https://github.com/estevanhernandez-stack-ed/Sanduhr_f-r_Claude/releases/download/v#{version}-mac/Sanduhr-#{version}.dmg",
+      verified: "github.com/estevanhernandez-stack-ed/Sanduhr_f-r_Claude/"
+  name "Sanduhr für Claude"
+  desc "Claude.ai subscription usage widget with burn-rate alerts"
+  homepage "https://estevanhernandez-stack-ed.github.io/Sanduhr_f-r_Claude/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(/^v(\d+(?:\.\d+)+)-mac$/i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Sanduhr.app"
+
+  zap trash: [
+    "~/Library/Application Support/Sanduhr",
+    "~/Library/Caches/com.626labs.sanduhr",
+    "~/Library/Caches/Sparkle_com.626labs.sanduhr",
+    "~/Library/Preferences/com.626labs.sanduhr.plist",
+  ]
+end


### PR DESCRIPTION
Adds [Sanduhr für Claude](https://github.com/estevanhernandez-stack-ed/Sanduhr_f-r_Claude) — a native SwiftUI macOS widget that shows your Claude.ai subscription usage with burn-rate projections, pace markers, sparklines, and hourglass deep-work timer. First cask submission for the project.

**Homepage:** https://estevanhernandez-stack-ed.github.io/Sanduhr_f-r_Claude/
**Source:** https://github.com/estevanhernandez-stack-ed/Sanduhr_f-r_Claude
**Release:** https://github.com/estevanhernandez-stack-ed/Sanduhr_f-r_Claude/releases/tag/v2.0.4-mac
**DMG SHA-256:** `82506e0b0ce3b05b41538ce9740d9e88ecbc459bf78553df43b2cf6db3a80522`

## Signing / notarization

- Signed with **Developer ID Application: Estevan Hernandez (82BSR56X5J)**
- **Notarized and stapled** by Apple — Gatekeeper accepts offline.
- Hardened runtime + timestamped, embedded Sparkle.framework signed inside-out.

Verified locally:
```
$ spctl --assess --type install --verbose=2 Sanduhr.dmg
Sanduhr.dmg: accepted
source=Notarized Developer ID
```

## Auto-update

The app uses Sparkle 2.9 with an EdDSA-signed appcast at [docs/appcast.xml](https://estevanhernandez-stack-ed.github.io/Sanduhr_f-r_Claude/appcast.xml). `auto_updates true` is set on the cask so Homebrew won't re-download on version bumps beyond what Sparkle already handles.

## Livecheck

Tag format for Mac releases is `v<version>-mac` (separate from `v<version>-windows`) to avoid collisions with the sibling Windows release workflow. Regex matches `/^v(\d+(?:\.\d+)+)-mac$/i`.

## Checklist

- [x] `brew style --fix Casks/s/sanduhr.rb` passes (1 file inspected, no offenses detected)
- [x] `brew audit --cask --new` — *skipped locally* because this machine has no `homebrew/cask` tap checked out; relying on CI to run the full audit
- [x] `brew install --cask --zap sanduhr` — *skipped locally* (same reason); happy to iterate on CI feedback
- [x] Cask filename matches name stanza
- [x] Cask follows naming conventions
- [x] App description under 80 chars and doesn't start with an article

Happy to address any audit feedback on this PR — first submission so I may have missed a convention.