### PR TITLE
voicebox 0.5.0 (new cask)

### DIFF
--- a/Casks/v/voicebox.rb
+++ b/Casks/v/voicebox.rb
@@ -1,0 +1,30 @@
+cask "voicebox" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.4.5"
+  sha256 arm:   "6491af9c293554f3dbeece196ca33a2c83bae0435882a059d3709594a0595a15",
+         intel: "83c15fa28c25e7f93f08469a5ba22c5a29c4e20072bcfbab6c21a0dfa20a35a7"
+
+  url "https://github.com/jamiepine/voicebox/releases/download/v#{version}/Voicebox_#{version}_#{arch}.dmg",
+      verified: "github.com/jamiepine/voicebox/"
+  name "Voicebox"
+  desc "Local, offline text-to-speech with voice cloning"
+  homepage "https://voicebox.sh/"
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Voicebox.app"
+
+  zap trash: [
+    "~/Library/Application Support/sh.voicebox.app",
+    "~/Library/Application Support/voicebox",
+    "~/Library/Caches/sh.voicebox.app",
+    "~/Library/Caches/voicebox",
+    "~/Library/Preferences/sh.voicebox.app.plist",
+    "~/Library/Preferences/voicebox.plist",
+    "~/Library/Saved Application State/sh.voicebox.app.savedState",
+    "~/Library/WebKit/sh.voicebox.app",
+    "~/Library/WebKit/voicebox",
+  ]
+end

--- a/Casks/v/voicebox.rb
+++ b/Casks/v/voicebox.rb
@@ -1,0 +1,30 @@
+cask "voicebox" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.5.0"
+  sha256 arm:   "1ef6d28d17b96e1b331340831bf59ea2dd3c526dbbdcadb3d2b90f186e9b3070",
+         intel: "a8af27b0b21e68c795c3c67358f070c4684c2a74ea586974de65579d2ddb87b5"
+
+  url "https://github.com/jamiepine/voicebox/releases/download/v#{version}/Voicebox_#{version}_#{arch}.dmg",
+      verified: "github.com/jamiepine/voicebox/"
+  name "Voicebox"
+  desc "Local, offline text-to-speech with voice cloning"
+  homepage "https://voicebox.sh/"
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "Voicebox.app"
+
+  zap trash: [
+    "~/Library/Application Support/sh.voicebox.app",
+    "~/Library/Application Support/voicebox",
+    "~/Library/Caches/sh.voicebox.app",
+    "~/Library/Caches/voicebox",
+    "~/Library/Preferences/sh.voicebox.app.plist",
+    "~/Library/Preferences/voicebox.plist",
+    "~/Library/Saved Application State/sh.voicebox.app.savedState",
+    "~/Library/WebKit/sh.voicebox.app",
+    "~/Library/WebKit/voicebox",
+  ]
+end


### PR DESCRIPTION
Voicebox (https://voicebox.sh) is an open-source local text-to-speech desktop app with voice cloning and seven on-device TTS engines (Chatterbox, Qwen3-TTS, Kokoro, HumeAI TADA, Qwen CustomVoice, LuxTTS, Chatterbox Multilingual). Everything runs locally, no cloud. Tauri-based, signed and notarized macOS binary.

Repo: https://github.com/jamiepine/voicebox. 21k+ stars, 400k+ release downloads. Users asked for a brew install path in https://github.com/jamiepine/voicebox/issues/516.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version). (v0.4.3, tagged semver release)
- [x] `brew audit --cask --online voicebox` is error-free.
- [x] `brew style --fix voicebox` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+voicebox&type=pullrequests).
- [x] `brew audit --cask --new voicebox` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask voicebox` worked successfully.
- [x] `brew uninstall --cask voicebox` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

Claude wrote the initial cask file. Manual verification performed:

- SHA-256 hashes computed locally via `shasum -a 256` on both DMGs downloaded fresh from the v0.4.3 release.
- Notarization confirmed twice: once by mounting each DMG and running `spctl -a -t exec -vv Voicebox.app` on the contained .app, and once on the brew-installed `/Applications/Voicebox.app`. Both return `accepted, source=Notarized Developer ID`.
- Install / uninstall verified end-to-end locally. `brew install --cask` placed the app at `/Applications/Voicebox.app`, `brew list --cask` listed it, and `brew uninstall --cask voicebox` cleanly removed it.
- `zap` paths verified against a real Voicebox install. Running `find ~/Library -iname '*voicebox*'` surfaced that the app writes to both `sh.voicebox.app` (primary bundle id) and `voicebox` (WKWebView + Tauri productName fallback) variants under Application Support, Caches, Preferences, and WebKit. Both variants are captured in the zap stanza.