### PR TITLE
navicat-premium-lite: add official language variants

### DIFF
--- a/Casks/n/navicat-premium-lite.rb
+++ b/Casks/n/navicat-premium-lite.rb
@@ -2,7 +2,53 @@ cask "navicat-premium-lite" do
   version "17.3.10"
   sha256 :no_check
 
-  url "https://dn.navicat.com/download/navicat#{version.major}_premium_lite_en.dmg"
+  language "zh-CN" do
+    "cs"
+  end
+  language "zh-SG" do
+    "cs"
+  end
+  language "zh-HK" do
+    "ct"
+  end
+  language "zh-MO" do
+    "ct"
+  end
+  language "zh-TW" do
+    "ct"
+  end
+  language "ja" do
+    "jp"
+  end
+  language "fr" do
+    "fr"
+  end
+  language "de" do
+    "de"
+  end
+  language "es" do
+    "es"
+  end
+  language "pl" do
+    "pl"
+  end
+  language "ko" do
+    "kr"
+  end
+  language "ru" do
+    "ru"
+  end
+  language "id" do
+    "id"
+  end
+  language "th" do
+    "th"
+  end
+  language "en", default: true do
+    "en"
+  end
+
+  url "https://dn.navicat.com/download/navicat#{version.major}_premium_lite_#{language}.dmg"
   name "Navicat Premium Lite"
   desc "Database administration and development tool"
   homepage "https://www.navicat.com/products/navicat-premium-lite"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
Map Homebrew locales to Navicat's official localized DMG names and keep
  English as the default download.

  Add support for Simplified and Traditional Chinese regional locales, plus
  Japanese, French, German, Spanish, Polish, Korean, Russian, Indonesian, and
  Thai.

  Added mappings:
  - `zh-CN`, `zh-SG` -> `cs`
  - `zh-HK`, `zh-MO`, `zh-TW` -> `ct`
  - `ja` -> `jp`
  - `fr`
  - `de`
  - `es`
  - `pl`
  - `ko` -> `kr`
  - `ru`
  - `id`
  - `th`

  Verification:
  - Verified the vendor-hosted URLs on the existing cask URL pattern:
    `https://dn.navicat.com/download/navicat17_premium_lite_<code>.dmg`
  - Confirmed `HTTP 200` for:
    `en`, `cs`, `ct`, `jp`, `fr`, `de`, `es`, `pl`, `kr`, `ru`, `id`, `th`

  Notes:
  - This follows Homebrew's guidance to use the `language` stanza for
  localized casks.
  - US English remains the default language.
  - I was not able to complete `brew audit --cask --online navicat-premium-
  lite` locally because the local Homebrew bundler environment failed while
  resolving `sorbet-runtime`.
  - AI was used to help draft this cask change and PR text. I manually
  verified the locale mappings and vendor-hosted download URLs.