### PR TITLE
puremac 2.1.0

### DIFF
--- a/Casks/p/puremac.rb
+++ b/Casks/p/puremac.rb
@@ -1,6 +1,6 @@
 cask "puremac" do
-  version "2.0.0"
-  sha256 "7f7f8ff16a23dfddc332a22054a4083184efadddd553b0e24fde1c68c6709d48"
+  version "2.1.0"
+  sha256 "4a582397b08a90eaded222556e2ade89c17a0ef61cf7ad34058ecec7ec54cae9"
 
   url "https://github.com/momenbasel/PureMac/releases/download/v#{version}/PureMac-#{version}.zip"
   name "PureMac"

--- a/Casks/p/puremac.rb
+++ b/Casks/p/puremac.rb
@@ -1,6 +1,6 @@
 cask "puremac" do
   version "2.1.0"
-  sha256 "4a582397b08a90eaded222556e2ade89c17a0ef61cf7ad34058ecec7ec54cae9"
+  sha256 "d979b9e5a270ead5566698a01e5065a1a12804c69f1d4898eed2781a1250bacf"
 
   url "https://github.com/momenbasel/PureMac/releases/download/v#{version}/PureMac-#{version}.zip"
   name "PureMac"


### PR DESCRIPTION
- [x] `brew readall --os=ventura --arch=arm` is error-free.
- [x] `brew style --fix` reports no offenses.
- [x] `brew audit --cask --online --new --signing puremac` passes (signing step expected to warn; cask is ad-hoc-signed - consistent with the existing 2.0.0 version).

Release notes: https://github.com/momenbasel/PureMac/releases/tag/v2.1.0

Highlights relevant to users:
- Five security fixes closing reported data-loss vectors in the app uninstaller and scheduled-clean path.
- Version-mismatch bug fixed (2.0.0 DMG previously reported 1.0.1 (3) in About; 2.1.0 now reports 2.1.0 (5) consistently).
- Home tab pinned in the sidebar; Installed Apps table is sortable; sidebar width capped.