### PR TITLE
Add sideloadly cask

### DIFF
--- a/Casks/sideloadly.rb
+++ b/Casks/sideloadly.rb
@@ -1,0 +1,17 @@
+cask "sideloadly" do
+  version "0.60.0"
+  sha256 "428d062af1ca819712fb12cb0ace25fa49c80d9735c73cda3cbaf09ffcd63212"
+
+  url "https://sideloadly.io/SideloadlySetup.dmg"
+  name "Sideloadly"
+  desc "Sideload apps on iOS, Apple Silicon Macs, and Apple TV without jailbreak"
+  homepage "https://sideloadly.io/"
+
+  app "Sideloadly.app"
+
+  zap trash: [
+    "~/Library/Application Support/Sideloadly",
+    "~/Library/Preferences/io.sideloadly.daemon.plist",
+    "~/Library/Preferences/io.sideloadly.sideloadly.plist",
+  ]
+end


### PR DESCRIPTION
Add `sideloadly` cask - a tool to sideload apps onto iOS devices without jailbreak.

## Verification

- [x] `brew audit --cask sideloadly` passes
- [x] `brew install --cask sideloadly` works