### PR TITLE
hop 0.1.6 (new cask)

### DIFF
--- a/Casks/h/hop.rb
+++ b/Casks/h/hop.rb
@@ -1,0 +1,22 @@
+cask "hop" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.1.6"
+  sha256 arm:   "80d4a872d39262ec02721eaf9f2cb2e65737533393e7792a59df3f8a09844695",
+         intel: "124e73279f3c63bfb7de1dedaf54fe17378b6ab98e48e358641010c8c977eab4"
+
+  url "https://github.com/golbin/hop/releases/download/v#{version}/HOP-macos-#{arch}.dmg",
+      verified: "github.com/golbin/hop/"
+  name "HOP"
+  desc "View and edit HWP documents"
+  homepage "https://golbin.github.io/hop/"
+
+  app "HOP.app"
+
+  zap trash: [
+    "~/Library/Application Support/net.golbin.hop",
+    "~/Library/Caches/net.golbin.hop",
+    "~/Library/Logs/net.golbin.hop",
+    "~/Library/WebKit/net.golbin.hop",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Open source version of Korean document editor.
The repo age is under 30 days but hopefully added for Korean users. This is a very interesting project as an open source version of a document editor that has long been exclusively supplied in Korea.