### PR TITLE
Fix Paratype fonts URLs

### DIFF
--- a/Casks/font/font-p/font-pt-astra-sans.rb
+++ b/Casks/font/font-p/font-pt-astra-sans.rb
@@ -2,7 +2,7 @@ cask "font-pt-astra-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://api.paratype.com/api/editions/ofl/download/52180",
+  url "https://api.paratype.com/api/download/ofl/pack/3759",
       referer: "https://www.paratype.com/"
   name "PT Astra Sans"
   homepage "https://www.paratype.com/fonts/pt/pt-astra-sans"

--- a/Casks/font/font-p/font-pt-astra-serif.rb
+++ b/Casks/font/font-p/font-pt-astra-serif.rb
@@ -2,7 +2,7 @@ cask "font-pt-astra-serif" do
   version :latest
   sha256 :no_check
 
-  url "https://api.paratype.com/api/editions/ofl/download/52179",
+  url "https://api.paratype.com/api/download/ofl/pack/3760",
       referer: "https://www.paratype.com/"
   name "PT Astra Serif"
   homepage "https://www.paratype.com/fonts/pt/pt-astra-serif"

--- a/Casks/font/font-p/font-pt-root-ui.rb
+++ b/Casks/font/font-p/font-pt-root-ui.rb
@@ -2,7 +2,7 @@ cask "font-pt-root-ui" do
   version :latest
   sha256 :no_check
 
-  url "https://api.paratype.com/api/editions/ofl/download/100278",
+  url "https://api.paratype.com/api/download/ofl/pack/3758",
       referer: "https://www.paratype.com/"
   name "PT Root UI"
   homepage "https://www.paratype.com/fonts/pt/pt-root-ui"

--- a/Casks/font/font-p/font-pt-serif.rb
+++ b/Casks/font/font-p/font-pt-serif.rb
@@ -2,7 +2,7 @@ cask "font-pt-serif" do
   version :latest
   sha256 :no_check
 
-  url "https://api.paratype.com/api/editions/ofl/download/52194",
+  url "https://api.paratype.com/api/download/ofl/pack/3761",
       referer: "https://www.paratype.com/"
   name "PT Serif"
   homepage "https://www.paratype.com/fonts/pt/pt-serif"


### PR DESCRIPTION
In PRs #259139 and #259530, the URLs for the PT Mono and PT Sans fonts were fixed. This PR contains updates for all the remaining Paratype fonts.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
