### PR TITLE
Add sideloadly cask

### DIFF
--- a/Casks/s/sideloadly.rb
+++ b/Casks/s/sideloadly.rb
@@ -1,0 +1,19 @@
+cask "sideloadly" do
+  version "0.60.0"
+  sha256 :no_check
+
+  url "https://sideloadly.io/SideloadlySetup.dmg"
+  name "Sideloadly"
+  desc "Sideload apps on iOS, Apple Silicon Macs, and Apple TV without jailbreak"
+  homepage "https://sideloadly.io/"
+
+  app "Sideloadly.app"
+
+  caveats "Sideloadly requires Rosetta 2 to be installed."
+
+  zap trash: [
+    "~/Library/Application Support/Sideloadly",
+    "~/Library/Preferences/io.sideloadly.daemon.plist",
+    "~/Library/Preferences/io.sideloadly.sideloadly.plist",
+  ]
+end


### PR DESCRIPTION
## Description

Add `sideloadly` cask - a tool to sideload apps on iOS, Apple Silicon Macs, and Apple TV without jailbreak.

## Verification

- [x] \`brew audit --new --online sideloadly\` passes (or warnings only)
- [x] \`brew style --fix sideloadly\` passes

## Checks

- Rosetta caveat added per audit
- \`sha256 :no_check\` used (unversioned URL)
- Signature verification fails (unsigned app - standard for sideloading tools)