### PR TITLE
inmusic-software-center 1.38.0

### DIFF
--- a/Casks/i/inmusic-software-center.rb
+++ b/Casks/i/inmusic-software-center.rb
@@ -1,9 +1,9 @@
 cask "inmusic-software-center" do
-  version "1.37.1"
-  sha256 "95f27c881167596337070d434a8470157512d1db0b28b5e77b5d8b07242cf0fd"
+  version "1.38.0"
+  sha256 "ab6946229cd1f0e61d65c24e362c156365ec78a9d5bae4927fcac0a2c05b7d2c"
 
-  url "https://cdn.inmusicbrands.com/SI04/#{version.no_dots}/inMusic%20Software%20Center-darwin-universal-#{version}.zip",
-      verified: "cdn.inmusicbrands.com/SI04/"
+  url "https://cdn.inmusicbrands.com/Software/SI04/inMusic%20Software%20Center-darwin-universal-#{version}.zip",
+      verified: "cdn.inmusicbrands.com/Software/SI04/"
   name "inMusic Software Center"
   desc "Administration tool for inMusic brand creative software"
   homepage "https://www.airmusictech.com/downloads/"
@@ -14,7 +14,7 @@ cask "inmusic-software-center" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "inMusic Software Center.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`inmusic-software-center` is autobumped but the workflow failed to update to version 1.38.0 because the asset URL path now starts with /Software/SI04/ instead of /SI04/ followed by the dotless version. This updates the version and adjusts the `url` accordingly.