### PR TITLE
krita 5.3.1.1

### DIFF
--- a/Casks/k/krita.rb
+++ b/Casks/k/krita.rb
@@ -1,8 +1,8 @@
 cask "krita" do
-  version "5.3.1"
-  sha256 "7992f864e55b8cad4901b89c9c98d25565a05153d6f52a08820aceff6a1af438"
+  version "5.3.1.1"
+  sha256 "3f4061a776151454a967fcb38b29b9549277cbe2c4c1d05b2ffc55e94aad7cd6"
 
-  url "https://download.kde.org/stable/krita/#{version}/krita-#{version}-signed.dmg",
+  url "https://download.kde.org/stable/krita/#{version.major_minor_patch}/krita-#{version}-signed.dmg",
       verified: "download.kde.org/stable/krita/"
   name "Krita"
   desc "Free and open-source painting and sketching program"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`krita` is autobumped but the workflow failed to update to version 5.3.1.1 because this version has four numeric parts but the path only uses the major/minor/patch. This updates the version and adjusts the `url` accordingly.