### PR TITLE
1password-cli: Generate/install completions

### DIFF
--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -29,8 +29,7 @@ cask "1password-cli" do
   binary "op"
 
   generate_completions_from_executable "op", "completion",
-                                       shells:    [:bash, :zsh, :fish, :pwsh],
-                                       base_name: "op"
+                                       shells: [:bash, :zsh, :fish, :pwsh]
 
   zap trash: "~/.op"
 end

--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -28,5 +28,9 @@ cask "1password-cli" do
 
   binary "op"
 
+  generate_completions_from_executable "op", "completion",
+                                       shells:    [:bash, :zsh, :fish, :pwsh],
+                                       base_name: "op"
+
   zap trash: "~/.op"
 end

--- a/Casks/1/1password-cli@beta.rb
+++ b/Casks/1/1password-cli@beta.rb
@@ -28,5 +28,9 @@ cask "1password-cli@beta" do
 
   binary "op"
 
+  generate_completions_from_executable "op", "completion",
+                                       shells:    [:bash, :zsh, :fish, :pwsh],
+                                       base_name: "op"
+
   zap trash: "~/.config/op"
 end

--- a/Casks/1/1password-cli@beta.rb
+++ b/Casks/1/1password-cli@beta.rb
@@ -29,8 +29,7 @@ cask "1password-cli@beta" do
   binary "op"
 
   generate_completions_from_executable "op", "completion",
-                                       shells:    [:bash, :zsh, :fish, :pwsh],
-                                       base_name: "op"
+                                       shells: [:bash, :zsh, :fish, :pwsh]
 
   zap trash: "~/.config/op"
 end


### PR DESCRIPTION
Generate the tab completions for `op` using newly available `generate_completions_from_executable` from https://github.com/Homebrew/brew/pull/21781. Verified that the completions are generated & working as expected :)

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.