### PR TITLE
flirc: update homepage URL

### DIFF
--- a/Casks/f/flirc.rb
+++ b/Casks/f/flirc.rb
@@ -5,7 +5,7 @@ cask "flirc" do
   url "https://flirc.com/software/flirc-usb/GUI/release/mac/Flirc-#{version}.dmg"
   name "Flirc"
   desc "IR USB receiver configurator"
-  homepage "https://flirc.com/"
+  homepage "https://flirc.tv/"
 
   livecheck do
     url "https://flirc.com/software/release/gui/mac/appcast.xml"

--- a/Casks/f/flirc.rb
+++ b/Casks/f/flirc.rb
@@ -2,7 +2,8 @@ cask "flirc" do
   version "3.27.19"
   sha256 "da00f51a8b64f1e7fbb75bc229e715428efe5059d06607fe5571a4e1bc011454"
 
-  url "https://flirc.com/software/flirc-usb/GUI/release/mac/Flirc-#{version}.dmg"
+  url "https://flirc.com/software/flirc-usb/GUI/release/mac/Flirc-#{version}.dmg",
+      verified: "flirc.com/"
   name "Flirc"
   desc "IR USB receiver configurator"
   homepage "https://flirc.tv/"


### PR DESCRIPTION
The flirc.com domain now 301 redirects to flirc.tv. Updated the homepage URL to point directly to the new domain.

Ref: #172732

Note: This PR was created with AI/LLM assistance (Claude). All changes have been reviewed and verified manually.