### PR TITLE
Add vibesdj 0.10.3

### DIFF
--- a/Casks/v/vibesdj.rb
+++ b/Casks/v/vibesdj.rb
@@ -1,0 +1,29 @@
+cask "vibesdj" do
+  version "0.10.3"
+  sha256 "be75708d6397ec9e4f1993c115425f17d94db4a97bf7c716e0b1dd5d73e7ef5b"
+
+  url "https://github.com/benmdg/vibes-releases/releases/download/v#{version}/Vibes_#{version}_aarch64.dmg",
+      verified: "github.com/benmdg/vibes-releases/"
+  name "Vibes"
+  desc "DJ library organizer that sorts tracks by mood, energy, and technique"
+  homepage "https://vibesdj.io/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :big_sur"
+
+  app "Vibes.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.benmdg.vibes",
+    "~/Library/Caches/com.benmdg.vibes",
+    "~/Library/Logs/com.benmdg.vibes",
+    "~/Library/Preferences/com.benmdg.vibes.plist",
+    "~/Library/Saved Application State/com.benmdg.vibes.savedState",
+  ]
+end


### PR DESCRIPTION
## Description

Vibes is a DJ library organizer that sorts tracks by mood, energy, and technique. Native desktop app (Apple Silicon), auto-updating via built-in Tauri updater, position as a preparation-workflow alternative to Rekordbox / Serato DJ / Engine DJ / Lexicon DJ.

- **Homepage:** https://vibesdj.io/
- **Releases (public mirror):** https://github.com/benmdg/vibes-releases
- **License:** Commercial (Proprietary)
- **Platform:** macOS 11+ (Apple Silicon only — no Intel DMG is built)

## Checklist

- [x] Cask name `vibesdj` is unique in `Casks/v/`
- [x] `brew style --fix Casks/v/vibesdj.rb` passes (no offenses)
- [x] SHA256 matches the real v0.10.3 DMG on GitHub Releases (verified with `shasum -a 256`)
- [x] `auto_updates true` (app ships Tauri's built-in updater)
- [x] `depends_on arch: :arm64` (no Intel DMG exists — confirmed from the release workflow)
- [x] `depends_on macos: \">= :big_sur\"` (actual hardware minimum for Apple Silicon)
- [x] `livecheck` uses `:github_latest` against the `url`
- [x] `zap` cleans ~/Library/{Application Support,Caches,Logs,Preferences,Saved Application State}/com.benmdg.vibes

## Notability

Commercial desktop app with a live public-facing site (https://vibesdj.io/), pricing, and a consistent release cadence on GitHub (see https://github.com/benmdg/vibes-releases/releases). Positioned as a library-preparation tool beside — not replacing — live-DJ software like Rekordbox, Serato DJ, Engine DJ, and Lexicon DJ.

## Signing note

The app is ad-hoc signed (not Apple notarized). Homebrew's quarantine strip on cask install covers this — the user gets no Gatekeeper dialog on `brew install --cask vibesdj` followed by launch. The Tauri updater signs its own update tarballs (minisign) separately from macOS codesigning.