### PR TITLE
winbox: add Linux support

### DIFF
--- a/Casks/w/winbox.rb
+++ b/Casks/w/winbox.rb
@@ -1,8 +1,32 @@
 cask "winbox" do
-  version "4.1"
-  sha256 "45715942a89261d4b14cf5edb13c73d65458c853bdef6d1dfc9da500259cacb2"
+  os linux: "_Linux"
 
-  url "https://download.mikrotik.com/routeros/winbox/#{version}/WinBox.dmg"
+  version "4.1"
+
+  url "https://download.mikrotik.com/routeros/winbox/#{version}/WinBox#{os}.dmg"
+  on_macos do
+    sha256 "45715942a89261d4b14cf5edb13c73d65458c853bdef6d1dfc9da500259cacb2"
+
+    depends_on macos: ">= :monterey"
+
+    app "WinBox.app"
+
+    zap trash: [
+      "~/Library/Application Support/MikroTik/WinBox",
+      "~/Library/Caches/MikroTik/WinBox",
+      "~/Library/Saved Application State/com.mikrotik.winbox.savedState",
+    ]
+  end
+  on_linux do
+    sha256 "28d35b661c321f5b618936546b7edf6593292549ed4a9584788dadff39a54d8f"
+
+    depends_on arch: :x86_64
+
+    binary "WinBox", target: "winbox"
+
+    zap trash: "#{ENV.fetch("HOMEBREW_XDG_DATA_HOME", "~/.local/share")}/MikroTik/WinBox"
+  end
+
   name "WinBox"
   desc "Administration tool for MikroTik RouterOS"
   homepage "https://mikrotik.com/"
@@ -11,14 +35,4 @@ cask "winbox" do
     url "https://upgrade.mikrotik.com/routeros/winbox/LATEST.#{version.major}"
     regex(/v?(\d+(?:\.\d+)+((?:beta|rc)\d+)?)/i)
   end
-
-  depends_on macos: ">= :monterey"
-
-  app "WinBox.app"
-
-  zap trash: [
-    "~/Library/Application Support/MikroTik/WinBox",
-    "~/Library/Caches/MikroTik/WinBox",
-    "~/Library/Saved Application State/my.example.com.savedState",
-  ]
 end

--- a/Casks/w/winbox.rb
+++ b/Casks/w/winbox.rb
@@ -1,8 +1,32 @@
 cask "winbox" do
-  version "4.1"
-  sha256 "45715942a89261d4b14cf5edb13c73d65458c853bdef6d1dfc9da500259cacb2"
+  os linux: "_Linux"
 
-  url "https://download.mikrotik.com/routeros/winbox/#{version}/WinBox.dmg"
+  version "4.1"
+
+  url "https://download.mikrotik.com/routeros/winbox/#{version}/WinBox#{os}.dmg"
+  on_macos do
+    sha256 "45715942a89261d4b14cf5edb13c73d65458c853bdef6d1dfc9da500259cacb2"
+
+    depends_on macos: :monterey
+
+    app "WinBox.app"
+
+    zap trash: [
+      "~/Library/Application Support/MikroTik/WinBox",
+      "~/Library/Caches/MikroTik/WinBox",
+      "~/Library/Saved Application State/com.mikrotik.winbox.savedState",
+    ]
+  end
+  on_linux do
+    sha256 "28d35b661c321f5b618936546b7edf6593292549ed4a9584788dadff39a54d8f"
+
+    depends_on arch: :x86_64
+
+    binary "WinBox", target: "winbox"
+
+    zap trash: "#{ENV.fetch("HOMEBREW_XDG_DATA_HOME", "~/.local/share")}/MikroTik/WinBox"
+  end
+
   name "WinBox"
   desc "Administration tool for MikroTik RouterOS"
   homepage "https://mikrotik.com/"
@@ -11,14 +35,4 @@ cask "winbox" do
     url "https://upgrade.mikrotik.com/routeros/winbox/LATEST.#{version.major}"
     regex(/v?(\d+(?:\.\d+)+((?:beta|rc)\d+)?)/i)
   end
-
-  depends_on macos: :monterey
-
-  app "WinBox.app"
-
-  zap trash: [
-    "~/Library/Application Support/MikroTik/WinBox",
-    "~/Library/Caches/MikroTik/WinBox",
-    "~/Library/Saved Application State/my.example.com.savedState",
-  ]
 end

--- a/Casks/w/winbox.rb
+++ b/Casks/w/winbox.rb
@@ -1,9 +1,9 @@
 cask "winbox" do
-  os linux: "_Linux"
+  os macos: ".dmg", linux: "_Linux.zip"
 
   version "4.1"
 
-  url "https://download.mikrotik.com/routeros/winbox/#{version}/WinBox#{os}.dmg"
+  url "https://download.mikrotik.com/routeros/winbox/#{version}/WinBox#{os}"
   on_macos do
     sha256 "45715942a89261d4b14cf5edb13c73d65458c853bdef6d1dfc9da500259cacb2"
 


### PR DESCRIPTION
MikroTik's WinBox is available for Linux.
This amends the `winbox` cask to download and install that Linux version.

I wrote and tested this under Ubuntu 26.04.

(There also was a bogus path to the savedState file for the macOS zap stanza, I took the liberty to fix that too.)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
