### PR TITLE
rustcast 0.7.6 (new cask)

### DIFF
--- a/Casks/r/rustcast.rb
+++ b/Casks/r/rustcast.rb
@@ -5,7 +5,7 @@ cask "rustcast" do
   url "https://github.com/RustCastLabs/rustcast/releases/download/v#{version}/Rustcast-universal-macos.app.zip"
   name "Rustcast"
   desc "Application and utility launcher"
-  homepage "https://github.com/unsecretised/rustcast"
+  homepage "https://rustcast.app"
 
   livecheck do
     url :url
@@ -16,4 +16,13 @@ cask "rustcast" do
   depends_on macos: ">= :big_sur"
 
   app "target/release/macos/Rustcast.app"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/rustcast_*.plist",
+    "~/Library/Logs/DiagnosticReports/rustcast-*.ips",
+    "~/Library/Preferences/com.*.rustcast.plist",
+    "~/Library/Preferences/rustcast.plist",
+    "~/.config/rustcast/config.toml",
+    "/tmp/rustcast.log",
+  ]
 end

--- a/Casks/r/rustcast.rb
+++ b/Casks/r/rustcast.rb
@@ -1,0 +1,23 @@
+cask "rustcast" do
+
+  version "0.7.6"
+
+  sha256 "f02b117bf7c2f2c7709c13963c768896684fe7e4fbfd44892ad5c730ac522b78"
+
+  url "https://github.com/RustCastLabs/rustcast/releases/download/v#{version}/Rustcast-universal-macos.app.zip"
+
+  name "Rustcast"
+  desc "Utility tooling popup window for your system"
+  homepage "https://github.com/unsecretised/rustcast"
+
+  depends_on macos: ">= :big_sur"
+
+  auto_updates true
+
+  app "target/release/macos/Rustcast.app"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+end

--- a/Casks/r/rustcast.rb
+++ b/Casks/r/rustcast.rb
@@ -4,12 +4,12 @@ cask "rustcast" do
 
   url "https://github.com/RustCastLabs/rustcast/releases/download/v#{version}/Rustcast-universal-macos.app.zip"
   name "Rustcast"
-  desc "Utility tooling popup window for your system"
+  desc "Application and utility launcher"
   homepage "https://github.com/unsecretised/rustcast"
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/r/rustcast.rb
+++ b/Casks/r/rustcast.rb
@@ -1,23 +1,19 @@
 cask "rustcast" do
-
   version "0.7.6"
-
   sha256 "f02b117bf7c2f2c7709c13963c768896684fe7e4fbfd44892ad5c730ac522b78"
 
   url "https://github.com/RustCastLabs/rustcast/releases/download/v#{version}/Rustcast-universal-macos.app.zip"
-
   name "Rustcast"
   desc "Utility tooling popup window for your system"
   homepage "https://github.com/unsecretised/rustcast"
-
-  depends_on macos: ">= :big_sur"
-
-  auto_updates true
-
-  app "target/release/macos/Rustcast.app"
 
   livecheck do
     url :url
     strategy :github_latest
   end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "target/release/macos/Rustcast.app"
 end

--- a/Casks/r/rustcast.rb
+++ b/Casks/r/rustcast.rb
@@ -3,7 +3,7 @@ cask "rustcast" do
   sha256 "f02b117bf7c2f2c7709c13963c768896684fe7e4fbfd44892ad5c730ac522b78"
 
   url "https://github.com/RustCastLabs/rustcast/releases/download/v#{version}/Rustcast-universal-macos.app.zip",
-      verified: "github.com/RustCastLabs/rustcast/releases/download"
+      verified: "github.com/RustCastLabs/rustcast/releases/download/"
   name "Rustcast"
   desc "Application and utility launcher"
   homepage "https://rustcast.app/"

--- a/Casks/r/rustcast.rb
+++ b/Casks/r/rustcast.rb
@@ -2,10 +2,11 @@ cask "rustcast" do
   version "0.7.6"
   sha256 "f02b117bf7c2f2c7709c13963c768896684fe7e4fbfd44892ad5c730ac522b78"
 
-  url "https://github.com/RustCastLabs/rustcast/releases/download/v#{version}/Rustcast-universal-macos.app.zip"
+  url "https://github.com/RustCastLabs/rustcast/releases/download/v#{version}/Rustcast-universal-macos.app.zip",
+      verified: "github.com/RustCastLabs/rustcast/releases/download"
   name "Rustcast"
   desc "Application and utility launcher"
-  homepage "https://rustcast.app"
+  homepage "https://rustcast.app/"
 
   livecheck do
     url :url
@@ -18,11 +19,11 @@ cask "rustcast" do
   app "target/release/macos/Rustcast.app"
 
   zap trash: [
+    "/tmp/rustcast.log",
+    "~/.config/rustcast/config.toml",
     "~/Library/Application Support/CrashReporter/rustcast_*.plist",
     "~/Library/Logs/DiagnosticReports/rustcast-*.ips",
     "~/Library/Preferences/com.*.rustcast.plist",
     "~/Library/Preferences/rustcast.plist",
-    "~/.config/rustcast/config.toml",
-    "/tmp/rustcast.log",
   ]
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online rustcast` is error-free.
- [x] `brew style --fix rustcast` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new rustcast` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask rustcast` worked successfully.
- [x] `brew uninstall --cask rustcast` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

- AI was used for fixing the Rubocop issues. 

-----
