### PR TITLE
iplay 1.2.14,319 (new cask)

### DIFF
--- a/Casks/i/iplay.rb
+++ b/Casks/i/iplay.rb
@@ -4,7 +4,7 @@ cask "iplay" do
 
   url "https://artifact.saltpi.cn/build/iPlay/macOS/latest.dmg"
   name "iPlay"
-  desc "Multi-platform multimedia player"
+  desc "Multimedia player"
   homepage "https://iplay.saltpi.cn/"
 
   livecheck do

--- a/Casks/i/iplay.rb
+++ b/Casks/i/iplay.rb
@@ -1,0 +1,28 @@
+cask "iplay" do
+  version "1.2.14"
+  sha256 :no_check
+
+  url "https://artifact.saltpi.cn/build/iPlay/macOS/latest.dmg"
+  name "iPlay"
+  desc "Multi-platform multimedia player"
+  homepage "https://iplay.saltpi.cn/"
+
+  livecheck do
+    url "https://artifact.saltpi.cn/build/iPlay/macOS/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "iPlay.app"
+
+  zap trash: [
+    "~/Library/Application Support/top.ourfor.app.iPlayClient",
+    "~/Library/Caches/top.ourfor.app.iPlayClient",
+    "~/Library/HTTPStorages/top.ourfor.app.iPlayClient",
+    "~/Library/Preferences/top.ourfor.app.iPlayClient.plist",
+    "~/Library/Saved Application State/top.ourfor.app.iPlayClient.savedState",
+    "~/Library/WebKit/top.ourfor.app.iPlayClient",
+  ]
+end


### PR DESCRIPTION
-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.
I used Gemini CLI to search for the app information, calculate the SHA256, verify the bundle identifier from the DMG, and generate the cask file. I manually verified the download URL, the version string, and the bundle ID by mounting the DMG. I then created a local tap to run `brew audit`, `brew install`, and `brew uninstall` successfully, adjusting the cask to use `sha256 :no_check` for its unversioned URL per Homebrew recommendations.
