### PR TITLE
rockxy 0.11.0

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,20 +1,19 @@
 cask "rockxy" do
-  version "0.10.0,13"
-  sha256 "a376fd1bf603e5dcb147fa065e3ce7a78f06dff75b5c8d8b1a17ba0e17d35e26"
+  version "0.11.0,14"
+  sha256 "aae7d91e4b6565ea3cf2fe8e10777e694e13e06c4f07de2f6dad55d52631f831"
 
-  url "https://github.com/LocNguyenHuu/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
-      verified: "github.com/LocNguyenHuu/Rockxy/"
+  url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
+      verified: "github.com/RockxyApp/Rockxy/"
   name "Rockxy"
   desc "HTTP proxy"
   homepage "https://rockxy.io/"
 
   livecheck do
-    url "https://github.com/LocNguyenHuu/Rockxy/releases/latest/download/manifest.json"
-    strategy :json do |json|
-      "#{json["appVersion"]},#{json["appBuild"]}"
-    end
+    url "https://raw.githubusercontent.com/RockxyApp/Rockxy/main/appcast.xml"
+    strategy :sparkle
   end
 
+  auto_updates true
   depends_on macos: ">= :sonoma"
 
   app "Rockxy.app"


### PR DESCRIPTION
Updates Rockxy to 0.11.0 build 14.

- Migrates release URLs from `LocNguyenHuu/Rockxy` to canonical `RockxyApp/Rockxy`.
- Uses the notarized public Rockxy DMG and SHA-256 from the public release.
- Keeps one public cask: `rockxy`; Pro unlock remains in-app licensing.
- Adds `auto_updates true` for Sparkle-enabled Rockxy releases.

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run rockxy`

Disclosure: this PR was prepared with AI assistance and reviewed through the release automation.
