### PR TITLE
Add splynek 1.5.3

### DIFF
--- a/Casks/s/splynek.rb
+++ b/Casks/s/splynek.rb
@@ -1,0 +1,28 @@
+# typed: strict
+# frozen_string_literal: true
+
+cask "splynek" do
+  version "1.5.3"
+  sha256 "4fe61bab5ee2eb847d789c7f8b2245bf6b180936ec231241284f20b968c0e6cb"
+
+  url "https://github.com/Splynek/splynek/releases/download/v#{version}/Splynek-#{version}.dmg",
+      verified: "github.com/Splynek/"
+  name "Splynek"
+  desc "Multi-interface download aggregator with BitTorrent v2"
+  homepage "https://splynek.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "Splynek.app"
+
+  zap trash: [
+    "~/Library/Application Support/Splynek",
+    "~/Library/HTTPStorages/app.splynek.Splynek",
+    "~/Library/Preferences/app.splynek.Splynek.plist",
+  ]
+end


### PR DESCRIPTION
## Add new cask: Splynek 1.5.3

Splynek is a native macOS download manager that aggregates multiple
network interfaces (Wi-Fi + Ethernet + iPhone tether) and adds two
on-device audit features for installed apps:

- **Sovereignty** — maps installed Mac apps to their country-of-origin
  + curated European or open-source alternatives (1,150+ catalogued).
- **Trust** — surfaces public-record concerns from Apple App Store
  privacy labels, EU regulator decisions, NVD CVEs, and HIBP breaches.

Pure Swift, zero third-party dependencies, MIT-licensed core, ~$29
one-time IAP for Pro features. Notarised + stapled by Apple.

### After making changes

- [x] `brew audit --new --cask splynek` ran (style: clean; full audit deferred to CI)
- [x] `brew style --fix splynek` ran clean

### Stable URL + SHA-256

- DMG: https://github.com/Splynek/splynek/releases/download/v1.5.3/Splynek-1.5.3.dmg
- SHA-256: `4fe61bab5ee2eb847d789c7f8b2245bf6b180936ec231241284f20b968c0e6cb`
- Notarised by Developer ID Application: Paulo Moura (58C6YC5GB5), stapled

### Project links

- Homepage: https://splynek.app/
- Source: https://github.com/Splynek/splynek (MIT)
- Releases: https://github.com/Splynek/splynek/releases

Maintainer ready to fix any audit findings — info@splynek.app.