### PR TITLE
claude-code@latest: revert to 2.1.119

### DIFF
--- a/Casks/c/claude-code@latest.rb
+++ b/Casks/c/claude-code@latest.rb
@@ -2,11 +2,11 @@ cask "claude-code@latest" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.1.120"
-  sha256 arm:          "fad8faf49c7b1b454c38d785b75e17edbdadc7ffaf450b31349aafc6560b8ef6",
-         x86_64:       "ad68f225e96db8b7d12d0c31f0343bc3227ea2886ecefae2f483cb32310b0004",
-         x86_64_linux: "12c0d6eb6d39dc2597fd131d8ea4f12ed8bf25b47dadd9173878e6d025959c9f",
-         arm64_linux:  "a6d0d25946c32a24b4e04471af70845a45428ca069fb3b489345f2a683262279"
+  version "2.1.119"
+  sha256 arm:          "31db3444309d5d0f8b85e8782e2dcd86f31f7e48c1a1e83d69b09268c7b4f9a2",
+         x86_64:       "52b3b75cfe80c626982b2ffb3a6ce1c797824f257dc275cf0a3c32c202b6a3df",
+         x86_64_linux: "cca43053f062949495596b11b6fd1b59cf79102adb13bacbe66997e6fae41e4a",
+         arm64_linux:  "382aa73ea4b07fd8d698e3159b5ef9e1b8739fae7505ba8ddd28b8a6a62819ce"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#261154

This version was broken and was removed.

You can see when it was added here:
https://github.com/anthropics/claude-code/commit/c3933441f09efb3429934c2213ee29f21a55cf74

Then they later removed it from the changelog https://github.com/anthropics/claude-code/commit/7e936457e4e3899460b2be2f2b9b9f0b0174e859

I believe this regression is likely why they pulled the update: https://github.com/anthropics/claude-code/issues/53085