### PR TITLE
muse-hub 3.0.2 (new cask)

### DIFF
--- a/Casks/m/muse-hub.rb
+++ b/Casks/m/muse-hub.rb
@@ -1,0 +1,26 @@
+cask "muse-hub" do
+  version "3.0.2"
+  sha256 :no_check
+  url "https://muse-cdn.com/Muse_Hub.pkg"
+  name "Muse Hub"
+  desc "Platform for indy music & audio tools"
+  homepage "https://www.musehub.com/"
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  pkg "Muse_Hub.pkg"
+
+  uninstall quit:    "com.muse.musehub",
+            pkgutil: "com.muse.hub.pkg"
+
+  zap trash: [
+    "~/Library/Application Support/Muse Hub",
+    "~/Library/Caches/com.muse.musehub",
+    "~/Library/Caches/SentryCrash/Muse Hub",
+    "~/Library/Logs/com.muse.musehub",
+    "~/Library/Logs/Muse Hub",
+    "~/Library/HTTPStorages/com.muse.musehub.binarycookies",
+    "~/Library/Preferences/com.muse.musehub.plist",
+    "~/Library/HTTPStorages/com.muse.musehub",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----


------

## muse-hub

Muse Hub is a platform for managing and installing Muse Group's
music and audio tools (Audacity, MuseScore, etc.).

- Homepage: https://www.musehub.com/
- URL: https://muse-cdn.com/Muse_Hub.pkg
- Version: 3.0.2

### Checklist
- [x] brew install --cask tested and working
- [x] brew uninstall --cask tested and working
- [ ] brew audit: blocked locally by rubydex build failure on Intel
      (Homebrew bug, not cask-related)
- [ ] brew style: same blockage as above

GitHub CI should be able to run both cleanly.