### PR TITLE
wox 2.0.3 (new cask)

### DIFF
--- a/Casks/w/wox.rb
+++ b/Casks/w/wox.rb
@@ -12,7 +12,7 @@ cask "wox" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   depends_on macos: ">= :big_sur"

--- a/Casks/w/wox.rb
+++ b/Casks/w/wox.rb
@@ -7,7 +7,7 @@ cask "wox" do
 
   url "https://github.com/Wox-launcher/Wox/releases/download/v#{version}/wox-mac-#{arch}.dmg"
   name "Wox"
-  desc "Cross-platform launcher that simply works"
+  desc "Launcher tool"
   homepage "https://github.com/Wox-launcher/Wox"
 
   livecheck do

--- a/Casks/w/wox.rb
+++ b/Casks/w/wox.rb
@@ -1,0 +1,23 @@
+cask "wox" do
+  arch arm: "arm64", intel: "amd64"
+
+  version "2.0.3"
+  sha256 arm:   "30b2f9b462c121e17336fb7e9ed0c028289bc97f4935923d6bea30ac48562498",
+         intel: "f7ed97ef9f7b2d65a076cd337448607e4aaabd9462835f81990482dcb93f97f5"
+
+  url "https://github.com/Wox-launcher/Wox/releases/download/v#{version}/wox-mac-#{arch}.dmg"
+  name "Wox"
+  desc "Cross-platform launcher that simply works"
+  homepage "https://github.com/Wox-launcher/Wox"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Wox.app"
+
+  zap trash: "~/.wox"
+end


### PR DESCRIPTION
Adds Wox, a cross-platform launcher for macOS, Windows, and Linux.

Project:
- Official repository: https://github.com/Wox-launcher/Wox
- Stable release: https://github.com/Wox-launcher/Wox/releases/tag/v2.0.3
- License: GPL-3.0
- Notability: 26k+ GitHub stars and 2k+ forks
- Existing upstream tap: https://github.com/Wox-launcher/homebrew-wox

I tested:
- brew audit --cask --new --online --strict wox
- brew install --cask ./Casks/w/wox.rb
- brew uninstall --cask wox
- brew livecheck --cask ./Casks/w/wox.rb


I used ChatGPT/Codex to draft the cask and reviewed the final changes manually.