### PR TITLE
Add `depends on :macos` to more casks 

### DIFF
--- a/Casks/c/chatty.rb
+++ b/Casks/c/chatty.rb
@@ -13,6 +13,8 @@ cask "chatty" do
     strategy :github_latest
   end
 
+  depends_on :macos
+
   suite "Chatty"
 
   preflight do

--- a/Casks/c/crushftp.rb
+++ b/Casks/c/crushftp.rb
@@ -13,6 +13,8 @@ cask "crushftp" do
     regex(/href=.*?CrushFTP(\d+)\.zip/i)
   end
 
+  depends_on :macos
+
   suite "CrushFTP#{version}"
 
   # No zap stanza required

--- a/Casks/d/digital.rb
+++ b/Casks/d/digital.rb
@@ -12,6 +12,8 @@ cask "digital" do
     strategy :github_latest
   end
 
+  depends_on :macos
+
   suite "Digital"
 
   zap trash: "~/.digital.cfg"

--- a/Casks/r/renpy.rb
+++ b/Casks/r/renpy.rb
@@ -12,6 +12,8 @@ cask "renpy" do
     regex(/href=.*?renpy[._-]v?(\d+(?:\.\d+)+)[._-]sdk\.dmg/i)
   end
 
+  depends_on :macos
+
   suite "renpy-#{version}-sdk"
 
   zap trash: [

--- a/Casks/s/server-box.rb
+++ b/Casks/s/server-box.rb
@@ -7,6 +7,8 @@ cask "server-box" do
   desc "App for monitoring server status with SSH terminal, SFTP, Container management"
   homepage "https://github.com/lollipopkit/flutter_server_box"
 
+  depends_on :macos
+
   app "Server Box.app"
 
   zap trash: "~/Library/Containers/com.lollipopkit.toolbox"

--- a/Casks/t/tolaria.rb
+++ b/Casks/t/tolaria.rb
@@ -15,6 +15,7 @@ cask "tolaria" do
   end
 
   depends_on arch: :arm64
+  depends_on :macos
 
   app "Tolaria.app"
 

--- a/Casks/x/xonotic.rb
+++ b/Casks/x/xonotic.rb
@@ -12,6 +12,8 @@ cask "xonotic" do
     regex(%r{href=.*?/xonotic[._-]v?(\d+(?:\.\d+)+)\.zip}i)
   end
 
+  depends_on :macos
+
   suite "Xonotic"
 
   zap trash: "~/Library/Application Support/xonotic"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

This is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/260975, adding `depends_on :macos` to casks using `suite` (which I wasn't sure was macOS-only but have since confirmed it's in `Cask::Artifact::MACOS_ONLY_ARTIFACTS`) and casks using `app` that were added after the aforementioned PR.