### PR TITLE
Avoid multi-argument `depends_on` calls

### DIFF
--- a/Casks/t/topaz-gigapixel.rb
+++ b/Casks/t/topaz-gigapixel.rb
@@ -13,8 +13,8 @@ cask "topaz-gigapixel" do
   end
 
   auto_updates true
-  depends_on arch:  :arm64,
-             macos: ">= :monterey"
+  depends_on arch: :arm64
+  depends_on macos: ">= :monterey"
 
   pkg "TopazGigapixel-#{version}.pkg"
 

--- a/Casks/t/topaz-video.rb
+++ b/Casks/t/topaz-video.rb
@@ -13,8 +13,8 @@ cask "topaz-video" do
   end
 
   auto_updates true
-  depends_on arch:  :arm64,
-             macos: ">= :big_sur"
+  depends_on arch: :arm64
+  depends_on macos: ">= :big_sur"
 
   pkg "TopazVideo-#{version}.pkg"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

In homebrew-core and homebrew-cask, `depends_on` calls only use a single argument. The only exceptions are found in `topaz-gigapixel` and `topaz-video`, where the `arch` and `macos` arguments are passed to one `depends_on` call. I noticed these outliers when searching through casks recently, so this updates the files to use separate `depends_on` calls for the sake of consistency.