### PR TITLE
r-app 4.6.0

### DIFF
--- a/Casks/r/r-app.rb
+++ b/Casks/r/r-app.rb
@@ -14,18 +14,27 @@ cask "r-app" do
     pkg "R-#{version}.pkg"
   end
   on_big_sur :or_newer do
-    version "4.5.3"
-    sha256 arm:   "8c1d5005547926425037ffa7d9062099231e033022275648625b32791dd43eb5",
-           intel: "690aac1b9405f0d5b2c7ab16f17dc4d5801464bb11066828fd3dbc28fdd06878"
+    sha256 arm:   "549f9a06d9816b515fa1adff13c4aefd64a27887bb888caa6279b61059e757da",
+           intel: "995ce5d5282ce4aee22ca4484d9674d75d6e3752b626ad5f1fc62ce04bc27b50"
 
-    url "https://cloud.r-project.org/bin/macosx/big-sur-#{arch}/base/R-#{version}-#{arch}.pkg"
+    on_arm do
+      version "4.6.0,sonoma"
+    end
+    on_intel do
+      version "4.6.0,big-sur"
+    end
+
+    url "https://cloud.r-project.org/bin/macosx/#{version.csv.second}-#{arch}/base/R-#{version.csv.first}-#{arch}.pkg"
 
     livecheck do
       url "https://cloud.r-project.org/bin/macosx/"
-      regex(/href=.*?R[._-]v?(\d+(?:\.\d+)*)([._-]#{arch})?\.pkg/i)
+      regex(%r{href=["'].*?/?([^/]+)[._-]#{arch}/base/R[._-]v?(\d+(?:\.\d+)*)(?:[._-]#{arch})?\.pkg}i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+      end
     end
 
-    pkg "R-#{version}-#{arch}.pkg"
+    pkg "R-#{version.csv.first}-#{arch}.pkg"
   end
 
   name "R"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`r-app` is autobumped but the workflow failed to update to version 4.6.0 because the cask `url` hardcodes the macOS version in the path but the ARM path uses `sonoma-arm64` in this version and Intel is still `big-sur-x86_64`. This updates the version and modifies the `livecheck` block to capture the macOS version as the second part of the version, as this is variable information that can change between versions and differ based on arch.