### PR TITLE
tolaria 2026.4.27

### DIFF
--- a/Casks/t/tolaria.rb
+++ b/Casks/t/tolaria.rb
@@ -1,8 +1,11 @@
 cask "tolaria" do
-  version "2026.4.25"
-  sha256 "3ae52b2d920b8595259fee3d8cc6ef44a2d022677364536f9d46e6be77e6c7cf"
+  arch arm: "Silicon", intel: "Intel"
 
-  url "https://github.com/refactoringhq/tolaria/releases/download/stable-v#{version}/Tolaria_#{version}_aarch64.dmg",
+  version "2026.4.27"
+  sha256 arm:   "2755e88cfc8109ca21d497ed7f29f48698080b7b6a4dfce24ef0450bc7fc97a0",
+         intel: "10a3f220fbc290fcec96d5e1aa1e58e61721a1ced64598bfc58158f70c0fa218"
+
+  url "https://github.com/refactoringhq/tolaria/releases/download/stable-v#{version}/Tolaria_#{version}_macOS_#{arch}.dmg",
       verified: "github.com/refactoringhq/tolaria/"
   name "Tolaria"
   desc "Markdown knowledgebase manager"
@@ -10,11 +13,10 @@ cask "tolaria" do
 
   livecheck do
     url :url
-    regex(/stable-v?(\d+(?:\.\d+)+)/i)
+    regex(/^stable[._-]v?(\d+(?:\.\d+)+)$/i)
     strategy :github_latest
   end
 
-  depends_on arch: :arm64
   depends_on :macos
 
   app "Tolaria.app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`tolaria` is autobumped but the workflow failed to update to version 2026.4.27 because the arch suffix has changed with this version, as they now offer both ARM and Intel dmg files. This updates the version and adjusts the cask accordingly.