### PR TITLE
rockxy 0.12.0

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.11.0,14"
-  sha256 "aae7d91e4b6565ea3cf2fe8e10777e694e13e06c4f07de2f6dad55d52631f831"
+  version "0.12.0,15"
+  sha256 "12d11850736d6ca41e94619777f290041b8e894e004d378947295b67e9d7ec85"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.12.0 build 15.

- Migrates release URLs from `LocNguyenHuu/Rockxy` to canonical `RockxyApp/Rockxy`.
- Uses the notarized public Rockxy DMG and SHA-256 from the public release.
- Keeps one public cask: `rockxy`; Pro unlock remains in-app licensing.
- Adds `auto_updates true` for Sparkle-enabled Rockxy releases.

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`

Disclosure: this PR was prepared with AI assistance and reviewed through the release automation.
