### PR TITLE
Update keka macOS dependency

### DIFF
--- a/Casks/k/keka.rb
+++ b/Casks/k/keka.rb
@@ -15,7 +15,7 @@ cask "keka" do
 
   auto_updates true
   conflicts_with cask: "keka@beta"
-  depends_on :macos
+  depends_on macos: ">= :catalina"
 
   app "Keka.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)


### PR DESCRIPTION
## Changes

- Updates the Keka cask macOS dependency from an unversioned macOS requirement to an explicit minimum version.

## Why

The unversioned `depends_on :macos` requirement can prevent this cask from being installed in some environments. Using an explicit `depends_on macos: ">= :catalina"` constraint lets Homebrew evaluate the supported macOS range consistently using the oldest macOS version currently accepted by Homebrew's cask DSL.

## Testing

- `ruby -c Casks/k/keka.rb`

`brew audit --cask keka` and `brew style --cask keka` could not be completed locally because this machine's Nix-managed Homebrew installation attempts to write to a read-only `/nix/store` path.
