### PR TITLE
bump do-not-disturb to 2.0.0

### DIFF
--- a/Casks/d/do-not-disturb.rb
+++ b/Casks/d/do-not-disturb.rb
@@ -1,33 +1,26 @@
 cask "do-not-disturb" do
-  version "1.3.0"
-  sha256 "000e3ce8f5abd1313bbb603c401a1be0b5cf4f11644d36f1d5d382745079fdc3"
+  version "2.0.0"
+  sha256 "3ea3b66705e2a373c734435981e74908361cfcd0957591d9e0aa8ac94df2cf2f"
 
-  url "https://github.com/objective-see/DoNotDisturb/releases/download/#{version}/DoNotDisturb_#{version}.zip",
+  url "https://github.com/objective-see/DoNotDisturb/releases/download/v#{version}/DoNotDisturb_#{version}.zip",
       verified: "github.com/objective-see/DoNotDisturb/"
   name "Do Not Disturb"
   desc "Open-source physical access (aka 'evil maid') attack detector"
   homepage "https://objective-see.org/products/dnd.html"
 
-  deprecate! date: "2024-11-16", because: :unmaintained
-  disable! date: "2025-11-16", because: :unmaintained
-
   depends_on :macos
 
   installer script: {
-    executable: "#{staged_path}/Do Not Disturb Installer.app/Contents/MacOS/Do Not Disturb Installer",
+    executable: "#{staged_path}/DoNotDisturb Installer.app/Contents/MacOS/DoNotDisturb Installer",
     args:       ["-install"],
     sudo:       true,
   }
 
   uninstall script: {
-    executable: "#{staged_path}/Do Not Disturb Installer.app/Contents/MacOS/Do Not Disturb Installer",
+    executable: "#{staged_path}/DoNotDisturb Installer.app/Contents/MacOS/DoNotDisturb Installer",
     args:       ["-uninstall"],
     sudo:       true,
   }
 
   # No zap stanza required
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/d/do-not-disturb.rb
+++ b/Casks/d/do-not-disturb.rb
@@ -10,12 +10,8 @@ cask "do-not-disturb" do
 
   depends_on :macos
 
-  # running the configure script doesn't prompt the user to setup full disk access
-  # (and the binary doesn't prompt for it), so the installation is "broken."
-  # the alternative is to run the configure script, but have a caveat telling the user
-  # to do the full disk access dance.
-  #
-  # a manual installer seemed unfortunate but preferable.
+  # the installer is interactive, running the configure script directly doesn't produce a
+  # working install.
   installer manual: "DoNotDisturb Installer.app"
 
   uninstall script: {

--- a/Casks/d/do-not-disturb.rb
+++ b/Casks/d/do-not-disturb.rb
@@ -10,14 +10,16 @@ cask "do-not-disturb" do
 
   depends_on :macos
 
-  installer script: {
-    executable: "#{staged_path}/DoNotDisturb Installer.app/Contents/MacOS/DoNotDisturb Installer",
-    args:       ["-install"],
-    sudo:       true,
-  }
+  # running the configure script doesn't prompt the user to setup full disk access
+  # (and the binary doesn't prompt for it), so the installation is "broken."
+  # the alternative is to run the configure script, but have a caveat telling the user
+  # to do the full disk access dance.
+  #
+  # a manual installer seemed unfortunate but preferable.
+  installer manual: "DoNotDisturb Installer.app"
 
   uninstall script: {
-    executable: "#{staged_path}/DoNotDisturb Installer.app/Contents/MacOS/DoNotDisturb Installer",
+    executable: "#{staged_path}/DoNotDisturb Installer.app/Contents/Resources/configure.sh",
     args:       ["-uninstall"],
     sudo:       true,
   }


### PR DESCRIPTION
-----

The use (or not) of AI in [PR 261337](https://github.com/Homebrew/homebrew-cask/pull/261337/) isn't the real/only problem.  The download URL is wrong, Do Not Disturb Version 2.0 has a different install mechanism so the installer stanza doesn't work.

This formula falls back on a manual installer - which isn't great - but seemed better than the alternative of a caveat telling the user to grant full disk access.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
