### PR TITLE
rockxy 0.12.2

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.12.1,18"
-  sha256 "ec6eae50ccfd1f73952ce783e29fbb4fdbc876f81898bf79aa31cb8d291b21bd"
+  version "0.12.2,19"
+  sha256 "bafab61a3a33e84f48a0aedad58d042e66a292c69322db3436942b917c2b5187"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.12.2 build 19.

- Migrates release URLs from `LocNguyenHuu/Rockxy` to canonical `RockxyApp/Rockxy`.
- Uses the notarized public Rockxy DMG and SHA-256 from the public release.
- Keeps one public cask: `rockxy`; Pro unlock remains in-app licensing.
- Adds `auto_updates true` for Sparkle-enabled Rockxy releases.

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`

Disclosure: this PR was prepared with AI assistance and reviewed through the release automation.
