### PR TITLE
Revert "1password-cli: Generate/install completions"

### DIFF
--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -28,8 +28,5 @@ cask "1password-cli" do
 
   binary "op"
 
-  generate_completions_from_executable "op", "completion",
-                                       shells: [:bash, :zsh, :fish, :pwsh]
-
   zap trash: "~/.op"
 end

--- a/Casks/1/1password-cli@beta.rb
+++ b/Casks/1/1password-cli@beta.rb
@@ -28,8 +28,5 @@ cask "1password-cli@beta" do
 
   binary "op"
 
-  generate_completions_from_executable "op", "completion",
-                                       shells: [:bash, :zsh, :fish, :pwsh]
-
   zap trash: "~/.config/op"
 end


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#260829 due to https://github.com/Homebrew/homebrew-cask/issues/261697