### PR TITLE
buhobarx 1.3.0 (new cask)

### DIFF
--- a/Casks/b/buhobarx.rb
+++ b/Casks/b/buhobarx.rb
@@ -1,0 +1,28 @@
+cask "buhobarx" do
+  version "1.3.0,22"
+  sha256 "c6b84daa7ea3d3ddd2b8310057c0f5966179184b15b659fb98152f04fce0f28e"
+
+  url "https://drbuho.net/buhobarx/buhobarx_b#{version.csv.second}.dmg",
+      verified: "drbuho.net/"
+  name "BuhoBarX"
+  desc "Menu bar icon organiser"
+  homepage "https://www.drbuho.com/buhobarx"
+
+  livecheck do
+    url "https://drbuho.net/buhobarx/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "BuhoBarX.app"
+
+  zap trash: [
+    "~/Library/Caches/com.drbuho.BuhoBarX",
+    "~/Library/Caches/SentryCrash/BuhoBarX",
+    "~/Library/HTTPStorages/com.drbuho.BuhoBarX",
+    "~/Library/Logs/BuhoBarX",
+    "~/Library/Preferences/com.drbuho.BuhoBarX.plist",
+  ]
+end


### PR DESCRIPTION
After making changes to the cask:

- [x] `brew audit --cask --new --online buhobarx` is error-free.
- [x] `brew style --fix Casks/b/buhobarx.rb` reports no offenses.

For new casks:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=buhobarx&type=issues).
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask buhobarx` worked successfully.
- [x] `brew uninstall --cask buhobarx` worked successfully.

If a check is not applicable, please replace the `[ ]` with `[~]`.

If using AI, the [AI Acceptable Use Policy](https://docs.brew.sh/AI-Acceptable-Use-Policy) must be followed.

- [x] AI tools were used to assist with this PR. Personally reviewed, tested, and verified all changes including zap stanza paths.

Built and tested locally on macOS Sequoia 15.7.