### PR TITLE
buhobarx 1.3.0 (new cask)

### DIFF
--- a/Casks/b/buhobarx.rb
+++ b/Casks/b/buhobarx.rb
@@ -1,0 +1,28 @@
+cask "buhobarx" do
+  version "1.3.0,22"
+  sha256 "c6b84daa7ea3d3ddd2b8310057c0f5966179184b15b659fb98152f04fce0f28e"
+
+  url "https://drbuho.net/buhobarx/buhobarx_b#{version.csv.second}.dmg",
+      verified: "drbuho.net/"
+  name "BuhoBarX"
+  desc "Menu bar icon organiser"
+  homepage "https://www.drbuho.com/buhobarx"
+
+  livecheck do
+    url "https://drbuho.net/buhobarx/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "BuhoBarX.app"
+
+  zap trash: [
+    "~/Library/Caches/com.drbuho.BuhoBarX",
+    "~/Library/Caches/SentryCrash/BuhoBarX",
+    "~/Library/HTTPStorages/com.drbuho.BuhoBarX",
+    "~/Library/Logs/BuhoBarX",
+    "~/Library/Preferences/com.drbuho.BuhoBarX.plist",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online buhobarx` is error-free.
- [x] `brew style --fix buhobarx` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new buhobarx` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask buhobarx` worked successfully.
- [x] `brew uninstall --cask buhobarx` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assisted with drafting the cask scaffolding (sha256, version regex, livecheck sparkle strategy, zap stanza). I personally reviewed every stanza, then verified the cask end-to-end on macOS 26.4.1:

  - Ran `brew audit --cask --online buhobarx` and `brew style --fix buhobarx` — both clean.
  - Installed via `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask buhobarx`, launched the app, signed in to a BuhoBarX Pro account, granted Screen Recording + Accessibility permissions, exercised drag-and-drop reordering of menu bar items, and toggled the "Click Empty Status Bar Space" setting so preferences are written.
  - Ran `find ~/Library -iname "*buho*" -o -iname "*drbuho*"` to enumerate every path the app actually creates, then compared against the `zap trash:` list — all 5 listed paths exist, and no other app-specific paths were found.
  - Ran `brew uninstall --cask --zap buhobarx` and re-ran the same `find` to confirm every listed path is removed.