### PR TITLE
rockxy 0.14.0

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.13.0,21"
-  sha256 "17a03e0503121d90bba9768cac86329a94cde7e397b97ea9884f2b8724b3e539"
+  version "0.14.0,22"
+  sha256 "c628c2c1e5a53140f7bd1ac1857edd7f5ba35e52bb06f21d1e34f69ef57337fb"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.14.0 build 22.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.14.0/Rockxy-0.14.0-22.dmg
- SHA-256: c628c2c1e5a53140f7bd1ac1857edd7f5ba35e52bb06f21d1e34f69ef57337fb
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`

Disclosure: this PR was prepared with AI assistance and reviewed through the release automation.
