### PR TITLE
kotlin-lsp 262.4739.0

### DIFF
--- a/Casks/k/kotlin-lsp.rb
+++ b/Casks/k/kotlin-lsp.rb
@@ -1,15 +1,21 @@
 cask "kotlin-lsp" do
-  arch arm: "aarch64", intel: "x64"
-  os macos: "mac", linux: "linux"
+  arch arm: "-aarch64"
 
-  version "262.2310.0"
-  sha256 arm:          "11560eb4ecd766204363848cc5ee84b51c0fd03fbfd4bbedaba0f00af74309c7",
-         intel:        "a4ccf591664cfef6a12f21a690d23bad26b92de62ed34674491b915f25f95bf5",
-         arm64_linux:  "1f8c814dfa9d64a9fba32b83a6fa0279cbc48e7240ef0ce922c7db2f39f0d35c",
-         x86_64_linux: "c004242158f4b5e1d917ddd848e6f6a279484fa58a3e2bce8846b807d1ad16b1"
+  version "262.4739.0"
+  sha256 arm:          "1b745743ce22ad92681a1bc3b1046803e942a6e1f36e04fb85ae9a40334a2f1e",
+         intel:        "6f06efe7a10f94b9c8a028c4efeb6c7e1769f47a01edfb74450acf30ab5665e4",
+         arm64_linux:  "625870ae091c6d0dee25514d545c708a6ea50d7cbb5154aaf1aa9123ccff338b",
+         x86_64_linux: "46971110c9b8a3360ce3fdf5437467f4c447dad37ad73dbf81d64af6779e4105"
 
-  url "https://download-cdn.jetbrains.com/kotlin-lsp/#{version}/kotlin-lsp-#{version}-#{os}-#{arch}.zip",
-      verified: "download-cdn.jetbrains.com/kotlin-lsp/"
+  on_macos do
+    url "https://download-cdn.jetbrains.com/kotlin-lsp/#{version}/kotlin-server-#{version}#{arch}.sit",
+        verified: "download-cdn.jetbrains.com/kotlin-lsp/"
+  end
+  on_linux do
+    url "https://download-cdn.jetbrains.com/kotlin-lsp/#{version}/kotlin-server-#{version}#{arch}.tar.gz",
+        verified: "download-cdn.jetbrains.com/kotlin-lsp/"
+  end
+
   name "Kotlin LSP"
   desc "Official Kotlin Language Server"
   homepage "https://github.com/Kotlin/kotlin-lsp"
@@ -19,7 +25,7 @@ cask "kotlin-lsp" do
     strategy :github_latest
   end
 
-  binary "kotlin-lsp.sh", target: "kotlin-lsp"
+  binary "kotlin-server-#{version}/kotlin-lsp.sh", target: "kotlin-lsp"
 
   # No zap stanza required
 end

--- a/Casks/k/kotlin-lsp.rb
+++ b/Casks/k/kotlin-lsp.rb
@@ -1,5 +1,6 @@
 cask "kotlin-lsp" do
   arch arm: "-aarch64"
+  os macos: "sit", linux: "tar.gz"
 
   version "262.4739.0"
   sha256 arm:          "1b745743ce22ad92681a1bc3b1046803e942a6e1f36e04fb85ae9a40334a2f1e",
@@ -7,15 +8,8 @@ cask "kotlin-lsp" do
          arm64_linux:  "625870ae091c6d0dee25514d545c708a6ea50d7cbb5154aaf1aa9123ccff338b",
          x86_64_linux: "46971110c9b8a3360ce3fdf5437467f4c447dad37ad73dbf81d64af6779e4105"
 
-  on_macos do
-    url "https://download-cdn.jetbrains.com/kotlin-lsp/#{version}/kotlin-server-#{version}#{arch}.sit",
-        verified: "download-cdn.jetbrains.com/kotlin-lsp/"
-  end
-  on_linux do
-    url "https://download-cdn.jetbrains.com/kotlin-lsp/#{version}/kotlin-server-#{version}#{arch}.tar.gz",
-        verified: "download-cdn.jetbrains.com/kotlin-lsp/"
-  end
-
+  url "https://download-cdn.jetbrains.com/kotlin-lsp/#{version}/kotlin-server-#{version}#{arch}.#{os}",
+      verified: "download-cdn.jetbrains.com/kotlin-lsp/"
   name "Kotlin LSP"
   desc "Official Kotlin Language Server"
   homepage "https://github.com/Kotlin/kotlin-lsp"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`kotlin-lsp` is autobumped but the workflow failed to update to version 262.4739.0 because upstream now uses the archive type to denote the OS for the standalone archive (`.sit` for macOS, `.tar.gz` for Linux, and `.zip` for Windows). The arch suffix is also omitted for x64 and only included for arm64. This updates the version and adjusts the cask accordingly.

I've used on_os blocks to handle the file extension difference between macOS and Linux, as using an `os` call to conditionally set the file extension (in interpolate it in one `url`) felt a bit weird.

I'm creating this as a draft for now, as `brew audit` will error because it tries to check `kotlin-lsp.sh` using `lipo` and predictably fails. We have some logic in `Cask::Audit.audit_rosetta` that should account for that situation but it doesn't seem to be working as expected, so I'm looking into it.