### PR TITLE
zed 1.0.0, zed@preview 1.1.2

### DIFF
--- a/Casks/z/zed.rb
+++ b/Casks/z/zed.rb
@@ -1,9 +1,9 @@
 cask "zed" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "0.233.10"
-  sha256 arm:   "9bfda8ebe4d17c9cb95f5a1861bcc06a52b73077b34dd7214b1ef2be53a8b546",
-         intel: "da8d0a128752c9b382d452e1fe06a3e849a60eb4e3f9bd839733e8cc99d59cf2"
+  version "1.0.0"
+  sha256 arm:   "1b889d3cbc244275f7c65da3f6d3edc130e8c23a68db2456938eed41bc7e6c95",
+         intel: "b2c9b0e44ac24b827b77d07d9837b7b18bee6025dc4a3146858b2f72b55c31fb"
 
   url "https://zed.dev/api/releases/stable/#{version}/Zed-#{arch}.dmg"
   name "Zed"

--- a/Casks/z/zed@preview.rb
+++ b/Casks/z/zed@preview.rb
@@ -1,9 +1,9 @@
 cask "zed@preview" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "0.234.0"
-  sha256 arm:   "c54eb020ec64907613adb87896ebfed2b0ef12ff0d3b74c9b57d56833d41fa0b",
-         intel: "3027d55653fcce141ecf683cf9245f9273208624740a990c5e9562596928db08"
+  version "1.1.2"
+  sha256 arm:   "e23ea43d4d4789ee565491b9b162bf9561df8763af0e2f4081a23973c655d2ab",
+         intel: "84ebb2d6564532fc10a8f60ae504f253bc1ad120186e578073e2732b70cb1ca6"
 
   url "https://zed.dev/api/releases/preview/#{version}/Zed-#{arch}.dmg"
   name "Zed Preview"
@@ -11,7 +11,7 @@ cask "zed@preview" do
   homepage "https://zed.dev/"
 
   livecheck do
-    url "https://zed.dev/api/releases/latest?asset=Zed.dmg&preview=1&os=macos&arch=#{arch}"
+    url "https://cloud.zed.dev/releases/preview/latest/asset?asset=zed&os=macos&arch=#{arch}"
     strategy :json do |json|
       json["version"]
     end


### PR DESCRIPTION
## zed 1.0.0

- Update version from `0.233.10` to `1.0.0`
- Update sha256 for arm and intel

## zed@preview 1.1.2

- Update version from `0.234.0` to `1.1.2`
- Update sha256 for arm and intel
- Fix livecheck URL to use `cloud.zed.dev` endpoint (old URL returned outdated version `1.0.0`)