### PR TITLE
gcc-aarch64-embedded: fix variable issues

### DIFF
--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -3,9 +3,12 @@ cask "gcc-aarch64-embedded" do
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
   arch arm: "arm64", intel: "x86_64"
 
+  pkg_version = nil
+  gcc_version = nil
   on_arm do
     version "15.2.rel1"
     pkg_version = "15.2.rel1"
+    gcc_version = "15.2.1"
     sha256 "a616eb0a32738cbddc7b8653a20abbddc487712714d57ac993b8987a7451dbce"
 
     livecheck do
@@ -16,8 +19,6 @@ cask "gcc-aarch64-embedded" do
 
     binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-gstack"
   end
-  pkg_version = nil
-  gcc_version = nil
   on_intel do
     version "14.2.rel1"
     pkg_version = "14.2.rel1"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Like `gcc-arm-embedded` (https://github.com/Homebrew/homebrew-cask/pull/261124), `gcc-aarch64-embedded` conditionally sets `pkg_version` and `gcc_version` variables within on_arch blocks but the variables are only declared in the outer scope after the `on_arm` block and before the `on_intel` block, so this causes errors on ARM (like https://github.com/Homebrew/homebrew-cask/issues/261912). Further, the `on_arm` block doesn't define `gcc_version` but there is an unconditional `binary` call that interpolates `gcc_version`, so that fails as well. This binary is also present in the ARM version, so we should set `gcc_version` in the `on_arm` block as well. This updates the cask to address both of these issues.