### PR TITLE
dialpad: use `pkg` installer

### DIFF
--- a/Casks/d/dialpad.rb
+++ b/Casks/d/dialpad.rb
@@ -2,11 +2,9 @@ cask "dialpad" do
   arch arm: "arm64", intel: "x64"
 
   version "2603.3.5"
-  sha256 arm:   "feca9d65f049ad8a1c32060ededcdcaf5a6ebe03a3fda3dee95d9662cf6bc236",
-         intel: "2f5a1711e7572c6b6007121cd195e0f6f5f8f19f7b1e4586bfea0765effbcfa2"
+  sha256 :no_check
 
-  url "https://storage.googleapis.com/dialpad_native/osx/#{arch}/Dialpad.#{version}.zip",
-      verified: "storage.googleapis.com/dialpad_native/osx/#{arch}"
+  url "https://download.dialpad.com/osx/#{arch}/dialpad.pkg"
   name "Dialpad"
   desc "Cloud communication platform"
   homepage "https://dialpad.com/download"
@@ -20,7 +18,9 @@ cask "dialpad" do
 
   depends_on macos: ">= :monterey"
 
-  app "Dialpad.app"
+  pkg "dialpad.pkg"
+
+  uninstall pkgutil: "com.dialpad.Dialpad.pkg"
 
   zap trash: [
     "~/Library/Application Support/Dialpad",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Opening this PR as a discussional piece for https://github.com/Homebrew/homebrew-cask/issues/261889#issuecomment-4345387498.
The advantage is that it will no longer show the warning that the application was not downloaded from the vendor's website. The downside is that the installation/uninstallation of `pkg` files is more cumbersome, takes longer, and we can no longer use a checksum here.

As far as I can tell there is now additional negative in installing the `app` directly other than the dismissable warning message. Which generally speaking is true, because the application wasn't being fetched and installed from the upstream's preferred location, but from the auto-update location.