### PR TITLE
Update claude-devtools from 0.4.13 to 0.4.15

### DIFF
--- a/Casks/c/claude-devtools.rb
+++ b/Casks/c/claude-devtools.rb
@@ -1,9 +1,9 @@
 cask "claude-devtools" do
-  arch arm: "-arm64"
+  arch arm: "-arm64", intel: "-x64"
 
-  version "0.4.13"
-  sha256 arm:   "61a5ed9409bfc7bd48340936a154fdc8088e8dbc1772b18736d5dc35505d009f",
-         intel: "8dbad9db18e38e22223feb1995a1d5fdb66e892e93675b6a6adb14d7ef1f04d8"
+  version "0.4.15"
+  sha256 arm:   "a50b00867921bdc9795b0f0cfbdd624fe2ff00262e4250e07aac36afd8aed7bb",
+         intel: "4396c731119765c3d0fa4758de92bd2caf8ea6bc58bd2adfaf3e0829781c068a"
 
   url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}#{arch}.dmg"
   name "Claude DevTools"


### PR DESCRIPTION
- Bump `claude-devtools` from 0.4.13 to 0.4.15.
- Add `intel: "-x64"` because upstream now suffixes the x64 dmg with `-x64` (previously unsuffixed). The unsuffixed default name was leading Apple Silicon users to install the x64 build and run it under Rosetta. URL template stays the same — interpolation does the work via the new `arch` value.

Verified locally: `brew style --fix` clean; both arm64 and x64 dmg URLs return HTTP 200; sha256 values match the actual release artifacts.