### PR TITLE
maestro 0.15.4

### DIFF
--- a/Casks/m/maestro.rb
+++ b/Casks/m/maestro.rb
@@ -1,11 +1,11 @@
 cask "maestro" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.15.3"
-  sha256 arm:   "5bc05f63c211fa0d33f14d2e16fcf1ab59e8ff25830b896865c5154d1c5bb061",
-         intel: "22e3f0f739787018e6702c04c48e1ca4c4f98586d7c66358c13bacf46780378f"
+  version "0.15.4,0.15.4-RC"
+  sha256 arm:   "92861629e5a29ae5dfa0d4828eb51ff9dc883c8a7f9ac8d677ee18a410d8fbc6",
+         intel: "d31ccd3d5ebbb788a6577c839094ce83c018f037bca130504fb7ce93fee1f4f1"
 
-  url "https://github.com/pedramamini/Maestro/releases/download/v#{version}/Maestro-#{version}-#{arch}-mac.dmg",
+  url "https://github.com/pedramamini/Maestro/releases/download/v#{version.csv.second || version.csv.first}/Maestro-#{version.csv.second || version.csv.first}-#{arch}-mac.dmg",
       verified: "github.com/pedramamini/Maestro/"
   name "Maestro"
   desc "AI agent command center"
@@ -13,7 +13,14 @@ cask "maestro" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/v?(\d+(?:\.\d+)+(?:-RC)?)/i)
+    strategy :github_latest do |json, regex|
+      version = json["name"]&.[](regex, 1)
+      tag_version = json["tag_name"]&.[](regex, 1)
+      next if version.blank? || tag_version.blank?
+
+      (version == tag_version) ? tag_version : "#{version},#{tag_version}"
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Version `0.15.4-RC` is tagged as the latest release and is available on the first-party download page. However, the homepage lists the version as `0.15.4`.
This PR updates the cask to correct this labeling issue.
