### PR TITLE
screenkite 1.2.1 (new cask)

### DIFF
--- a/Casks/s/screenkite.rb
+++ b/Casks/s/screenkite.rb
@@ -14,7 +14,7 @@ cask "screenkite" do
 
   auto_updates true
   depends_on arch: :arm64
-  depends_on macos: ">= :tahoe"
+  depends_on macos: ">= :sonoma"
 
   app "ScreenKite.app"
 end

--- a/Casks/s/screenkite.rb
+++ b/Casks/s/screenkite.rb
@@ -13,7 +13,8 @@ cask "screenkite" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on arch: :arm64
+  depends_on macos: ">= :tahoe"
 
   app "ScreenKite.app"
 end

--- a/Casks/s/screenkite.rb
+++ b/Casks/s/screenkite.rb
@@ -1,0 +1,19 @@
+cask "screenkite" do
+  version "1.2.1,377"
+  sha256 "fff0dc78be5f34bae0cde2c6766d031bb4c13f3452c65eccbc6335743c42c82e"
+
+  url "https://downloads.screenkite.com/mac-releases/ScreenKite-#{version.csv.second}.zip"
+  name "ScreenKite"
+  desc "Screen recorder and editor"
+  homepage "https://www.screenkite.com/"
+
+  livecheck do
+    url "https://downloads.screenkite.com/mac-releases/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "ScreenKite.app"
+end

--- a/Casks/s/screenkite.rb
+++ b/Casks/s/screenkite.rb
@@ -17,4 +17,21 @@ cask "screenkite" do
   depends_on macos: ">= :sonoma"
 
   app "ScreenKite.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.screenkite.mac.ScreenKitePreviewExtension",
+    "~/Library/Application Scripts/com.screenkite.mac.ScreenKiteThumbnailExtension",
+    "~/Library/Application Support/com.screenkite.mac",
+    "~/Library/Application Support/ScreenKite",
+    "~/Library/Caches/com.crashlytics.data/com.screenkite.mac",
+    "~/Library/Caches/com.screenkite.mac",
+    "~/Library/Containers/com.screenkite.mac.ScreenKitePreviewExtension",
+    "~/Library/Containers/com.screenkite.mac.ScreenKiteThumbnailExtension",
+    "~/Library/HTTPStorages/com.screenkite.mac",
+    "~/Library/HTTPStorages/com.screenkite.mac.binarycookies",
+    "~/Library/Logs/ScreenKite",
+    "~/Library/Preferences/com.screenkite.mac.plist",
+    "~/Library/Saved Application State/com.screenkite.mac.savedState",
+    "~/Library/WebKit/com.screenkite.mac",
+  ]
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully. Tested with `--appdir=/Users/mike/Downloads/202604/temp/screenkite-homebrew-appdir` to avoid replacing an existing `/Applications/ScreenKite.app`.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. I used Codex to draft the cask and run the verification commands. I manually verified the stable Sparkle feed, checksum, audit, style, install, livecheck, and uninstall results. No `zap` stanza is included because I have not verified ScreenKite's user data/support paths for safe removal.

-----
