### PR TITLE
Add unifi-os-server v5.0.6

### DIFF
--- a/Casks/unifi-os-server.rb
+++ b/Casks/unifi-os-server.rb
@@ -1,0 +1,53 @@
+cask "unifi-os-server" do
+  arch arm: "arm64", intel: "amd64"
+
+  on_intel do
+    version "5.0.6"
+    sha256 "8e030977c6bf4e9c1e2e65ee3afd71033b67264167cf50add3fad48ab9544d40"
+  end
+
+  on_arm do
+    version "5.0.6"
+    sha256 "ecc766175285e446da5a5f774f65bcc1f97657fba6155c2930022fa0380b33dd"
+  end
+
+  url "https://fw-download.ubnt.com/data/unifi-os-server/b290-macOS-dmg-#{arch}-#{version}-a165bb5f-f865-476a-b4bd-703e0d3d4ca1.dmg",
+      verified: "fw-download.ubnt.com/data/unifi-os-server/"
+
+  name "UniFi OS Server"
+  desc "UniFi OS Server for managing UniFi networks and devices"
+  homepage "https://www.ui.com/download/software/unifi-os-server/"
+
+  livecheck do
+    url "https://fw-update.ui.com/api/firmware?filter=eq~~product~~unifi-os-server&filter=eq~~channel~~release"
+    regex(/macOS-dmg-(amd64|arm64)[-_]v?(\d+(?:\.\d+)+)/i)
+    strategy :json do |json, regex|
+      json.dig("_embedded", "firmware")&.filter_map do |item|
+        match = item.dig("platform")&.match(regex)
+        next unless match
+        arch = match[1]
+        version = match[2]
+        download_url = item.dig("_links", "download", "href")
+        next unless download_url
+        "#{version},#{arch},#{download_url}"
+      end
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "UniFi OS Server.app"
+
+  uninstall signal: ["TERM", "com.ui.unifi-os-server"]
+
+  zap trash: [
+    "~/Library/Application Support/UniFi OS Server",
+    "~/Library/Saved Application State/com.ui.unifi-os-server.savedState",
+    "~/Library/Preferences/com.ui.unifi-os-server.plist",
+    "~/Library/Logs/UniFi OS Server",
+  ]
+
+  caveats do
+    license "https://www.ui.com/eula/"
+  end
+end


### PR DESCRIPTION

## Description
Adds UniFi OS Server cask for managing UniFi networks and devices.

UniFi OS Server allows users to run the full UniFi OS experience on their own hardware (macOS, Windows, or Linux), with support for UniFi Network and Identity applications.

## Checklist
- [x] The PR title is descriptive and mentions the cask name
- [x] I have followed the Cask Cookbook guidelines
- [x] The cask builds successfully on my local machine (tested on macOS)
- [x] The cask does not already exist in the repository
- [x] The download URL is publicly accessible from Ubiquiti official servers
- [x] SHA256 checksums verified for both Intel and Apple Silicon architectures

## Additional Context
- Software homepage: https://www.ui.com/download/software/unifi-os-server/
- Download API: https://fw-update.ui.com/api/firmware
- Vendor: Ubiquiti Inc. (https://www.ui.com)
- This is a popular networking management tool with significant user base
- Tested on macOS Big Sur and newer
