### PR TITLE
openemu-silicon 1.0.7 (new cask)

### DIFF
--- a/Casks/o/openemu-silicon.rb
+++ b/Casks/o/openemu-silicon.rb
@@ -1,0 +1,29 @@
+cask "openemu-silicon" do
+  version "1.0.7"
+  sha256 "fdcc190fee721767c44632ec6396b9bcf8449d9d79ce4276abf7a87389ab3974"
+
+  url "https://github.com/nickybmon/OpenEmu-Silicon/releases/download/v#{version}/OpenEmu-Silicon.dmg"
+  name "OpenEmu Silicon"
+  desc "Native Apple Silicon port of the OpenEmu multi-system emulator"
+  homepage "https://github.com/nickybmon/OpenEmu-Silicon"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "OpenEmu.app"
+
+  zap trash: [
+    "~/Library/Application Support/OpenEmu",
+    "~/Library/Application Support/org.openemu.OEXPCCAgent.Agents",
+    "~/Library/Caches/org.openemu.OpenEmu",
+    "~/Library/HTTPStorages/org.openemu.OpenEmu",
+    "~/Library/HTTPStorages/org.openemu.OpenEmu.binarycookies",
+    "~/Library/Preferences/org.openemu.OpenEmu.plist",
+    "~/Library/Saved Application State/org.openemu.OpenEmu.savedState",
+  ]
+end


### PR DESCRIPTION
## openemu-silicon 1.0.7 (new cask)

### What is this?

OpenEmu Silicon is a native Apple Silicon port of [OpenEmu](https://github.com/OpenEmu/OpenEmu), the beloved macOS multi-system emulator. The existing `openemu` cask ships an Intel-only binary that requires Rosetta 2 and is deprecated (fails Gatekeeper check). This cask provides the ARM64-native replacement.

### Verification checklist

- [x] `brew audit --cask --new openemu-silicon` — 0 problems
- [x] `brew style openemu-silicon` — 0 offenses
- [x] SHA256 verified against the downloaded DMG
- [x] App bundle name confirmed (`OpenEmu.app`) by mounting the DMG
- [x] Bundle ID confirmed (`org.openemu.OpenEmu`) from `Info.plist`
- [x] `LSMinimumSystemVersion: 11.0` matches `depends_on macos: ">= :big_sur"`
- [x] Gatekeeper: `accepted, source=Notarized Developer ID`
- [x] Sparkle livecheck tested against `appcast.xml` — returns `1.0.7` correctly
- [x] App launches and runs on macOS 15 (Sequoia) on Apple Silicon

### Notes

- `auto_updates true` — the app uses Sparkle for in-app updates
- `livecheck` uses the Sparkle appcast strategy against the project's `appcast.xml`
- `zap` stanza covers all known application data paths for bundle ID `org.openemu.OpenEmu`
- Repo: https://github.com/nickybmon/OpenEmu-Silicon