### PR TITLE
Add deepend

### DIFF
--- a/Casks/d/deepend.rb
+++ b/Casks/d/deepend.rb
@@ -1,0 +1,29 @@
+cask "deepend" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.1.1"
+  sha256 arm:   "1b2fb55a2f34024ee03a7448570d7ac00a2582d4204112beb7713bdd6a90a478",
+         intel: "b586708aa0788410aed9e235befabc8ff2392d7332e1202359fe9265ce23424b"
+
+  url "https://github.com/deepen-stha/deepend-releases/releases/download/v#{version}/Deepend_#{version}_#{arch}.dmg",
+      verified: "github.com/deepen-stha/deepend-releases/"
+  name "Deepend"
+  desc "Developer utilities for JSON, text, PDF, API, and images, fully offline"
+  homepage "https://github.com/deepen-stha/deepend-releases"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Deepend.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.deepend.app",
+    "~/Library/Caches/com.deepend.app",
+    "~/Library/HTTPStorages/com.deepend.app",
+    "~/Library/Preferences/com.deepend.app.plist",
+    "~/Library/Saved Application State/com.deepend.app.savedState",
+    "~/Library/WebKit/com.deepend.app",
+  ]
+end


### PR DESCRIPTION
## Add deepend

New cask for **Deepend** — a free, cross-platform desktop app that bundles JSON, text, PDF, API, and image developer utilities, running 100% offline. Built with Tauri (~6 MB .dmg, no embedded Chromium).

- License: MIT
- Homepage / releases: https://github.com/deepen-stha/deepend-releases
- Already published on Microsoft winget as `DeepenShrestha.Deepend` (microsoft/winget-pkgs#367446)

The cask covers both Apple Silicon (`Deepend_*_aarch64.dmg`) and Intel (`Deepend_*_x64.dmg`) builds with separate sha256s, plus a `livecheck` that tracks the public releases repo, and a `zap` block to clean up `~/Library` paths under the `com.deepend.app` bundle identifier.

After merge:

```sh
brew install --cask deepend
```

---

### Honest pre-flight checklist

- [ ] `brew audit --new-cask deepend` — **not run locally; I am the maintainer and on Windows**, no Mac available to run brew. Please flag any audit failures and I will push fixes.
- [ ] `brew style --fix Casks/d/deepend.rb` — same: not run locally. Style was hand-matched against neighbouring casks (e.g. `Casks/d/discord.rb`, `Casks/d/dropbox.rb`).
- [ ] `brew uninstall --cask deepend` cleans state — `zap` block written from app's bundle identifier (`com.deepend.app`) but not verified end-to-end.

Happy to iterate on whatever the audit catches. Apologies for not running the standard pre-flight; the alternative was waiting until I got a Mac, vs. submitting now and fixing what audit finds.