### PR TITLE
write: update livecheck

### DIFF
--- a/Casks/w/write.rb
+++ b/Casks/w/write.rb
@@ -10,8 +10,8 @@ cask "write" do
   livecheck do
     url "https://www.styluslabs.com/download/write-dmg"
     regex(/write[._-]?v?(\d+)\.dmg/i)
-    strategy :header_match do |header, regex|
-      match = header["location"]&.match(regex)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
       next if match.blank?
 
       match[1].include?(".") ? match[1] : match[1].sub(/(\d)(\d)(\d)/, '\1.\2.\3')


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block in the `write` cask uses the `HeaderMatch` strategy with a `strategy` block but the first argument is `header` instead of `headers`. This isn't yet a problem but it will error at runtime after I modify the `HeaderMatch` strategy to be strict about the name of the first argument (as part of adding support for optionally using the unmerged headers from all responses instead of the default merged headers). This preemptively updates the argument name to prevent the check from breaking.