### PR TITLE
manus 1.5.6 (new cask)

### DIFF
--- a/Casks/m/manus.rb
+++ b/Casks/m/manus.rb
@@ -1,0 +1,34 @@
+cask "manus" do
+  version "1.5.6"
+  sha256 "52754fe4be85e2fd821b4b47df860bc43949964c586d8b504449a44d559108d9"
+
+  url "https://download.manus.im/Manus-Setup-#{version}.dmg"
+  name "Manus"
+  desc "AI agent for automating local computer workflows"
+  homepage "https://manus.im/desktop"
+
+  livecheck do
+    url "https://download.manus.im/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+  depends_on arch: :arm64
+
+  app "Manus.app"
+
+  uninstall quit: "im.manus.desktop"
+
+  zap trash: [
+    "~/Library/Application Support/Manus",
+    "~/Library/Caches/im.manus.desktop",
+    "~/Library/Caches/im.manus.desktop.ShipIt",
+    "~/Library/Caches/manus-updater",
+    "~/Library/HTTPStorages/im.manus.desktop",
+    "~/Library/Logs/Manus",
+    "~/Library/Preferences/im.manus.desktop.plist",
+    "~/Library/Saved Application State/im.manus.desktop.savedState",
+    "~/Library/WebKit/im.manus.desktop",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.4.1.

Adds the Manus Desktop app cask.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI helped draft and verify the cask. I manually verified the official download/updater metadata, bundle id, version, arm64 executable, minimum macOS version, audit/style/install/uninstall results, and reviewed the `zap` paths against the app bundle id and Electron updater cache.

-----
