### PR TITLE
clone-hero 1.1.0.6085

### DIFF
--- a/Casks/c/clone-hero.rb
+++ b/Casks/c/clone-hero.rb
@@ -1,8 +1,8 @@
 cask "clone-hero" do
-  version "1.0.0.4080"
-  sha256 "ea0cb7d9ac5e55cbbe736ed30b49e9faeb642ce96f8b4b6383aba05387ea9f12"
+  version "1.1.0.6085,-final"
+  sha256 "ca84b001de1e9205a9599b88355b6e0d005b6da7e28bef95d8baf3aa7b4bb819"
 
-  url "https://github.com/clonehero-game/releases/releases/download/V#{version}/CloneHero-mac.dmg",
+  url "https://github.com/clonehero-game/releases/releases/download/v#{version.csv.first}#{version.csv.second if version.csv.second}/CloneHero.v#{version.csv.first}#{version.csv.second if version.csv.second}.dmg",
       verified: "github.com/clonehero-game/"
   name "Clone Hero"
   desc "Guitar Hero clone"
@@ -10,7 +10,13 @@ cask "clone-hero" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)(.+)?$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next unless match
+
+      match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+    end
   end
 
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`clone-hero` is autobumped but the workflow failed to update to version 1.1.0.6085 because the tag includes a `-final` suffix and the dmg file name includes the tag now (CloneHero.v1.1.0.6085-final.dmg). This updates the version and adjusts the cask accordingly. The version usually doesn't include a `-final` suffix, so I've set this up so it should work with or without a suffix.