### PR TITLE
visit 3.5.0

### DIFF
--- a/Casks/v/visit.rb
+++ b/Casks/v/visit.rb
@@ -1,4 +1,60 @@
 cask "visit" do
+  on_arm do
+    on_monterey do
+      version "3.4.2"
+      sha256 "75b4d4bc4f8b4d9d8d0ef55e14d34e97442fbf2cf7e10b4726dd773f30b7e827"
+      url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version.dots_to_underscores}.darwin23-arm64.dmg",
+          verified: "github.com/visit-dav/visit/"
+
+      livecheck do
+        skip "Legacy version"
+      end
+    end
+    on_ventura do
+      version "3.4.2"
+      sha256 "75b4d4bc4f8b4d9d8d0ef55e14d34e97442fbf2cf7e10b4726dd773f30b7e827"
+      url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version.dots_to_underscores}.darwin23-arm64.dmg",
+          verified: "github.com/visit-dav/visit/"
+
+      livecheck do
+        skip "Legacy version"
+      end
+    end
+    on_sonoma do
+      version "3.4.2"
+      sha256 "75b4d4bc4f8b4d9d8d0ef55e14d34e97442fbf2cf7e10b4726dd773f30b7e827"
+      url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version.dots_to_underscores}.darwin23-arm64.dmg",
+          verified: "github.com/visit-dav/visit/"
+
+      livecheck do
+        skip "Legacy version"
+      end
+    end
+    on_sequoia :or_newer do
+      version "3.5.0"
+      sha256 "a22479b7349a215ace6887c8b624ec2313323a744544588e4132ceb28850a1fa"
+      url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version.dots_to_underscores}.darwin24-arm64.dmg",
+          verified: "github.com/visit-dav/visit/"
+
+      livecheck do
+        url :url
+        strategy :github_latest
+      end
+    end
+  end
+  on_intel do
+    on_monterey :or_newer do
+      version "3.4.2"
+
+      sha256 "27399911756a57817e6081d3a6e22e3d569028b9261fe04bf8ee1841fddad591"
+
+      url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version.dots_to_underscores}.darwin22-x86_64.dmg",
+          verified: "github.com/visit-dav/visit/"
+      livecheck do
+        skip "Legacy version"
+      end
+    end
+  end
   on_big_sur :or_older do
     version "3.3.2"
     sha256 "f406850b21ddc16a6ca636b5c9087b41baeb5460ac92a9b140194c010eb285b3"
@@ -9,24 +65,8 @@ cask "visit" do
     livecheck do
       skip "Legacy version"
     end
-
     caveats do
       requires_rosetta
-    end
-  end
-  on_monterey :or_newer do
-    arch arm: "23-arm64", intel: "22-x86_64"
-
-    version "3.4.2"
-    sha256 arm:   "75b4d4bc4f8b4d9d8d0ef55e14d34e97442fbf2cf7e10b4726dd773f30b7e827",
-           intel: "27399911756a57817e6081d3a6e22e3d569028b9261fe04bf8ee1841fddad591"
-
-    url "https://github.com/visit-dav/visit/releases/download/v#{version}/visit#{version.dots_to_underscores}.darwin#{arch}.dmg",
-        verified: "github.com/visit-dav/visit/"
-
-    livecheck do
-      url :url
-      strategy :github_latest
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`visit` is autobumped but the workflow failed to update to version 3.5.0 because the file name uses a `.darwin24` suffix instead of `.darwin23` in the previous version. This version also only seems to support ARM, so it would need to be manually updated anyway. This updates the version and adjusts the cask accordingly.

This approach is slightly absurd (three levels of on_os blocks, wow) because the 3.4.2 app for ARM has a higher minimum macOS requirement and that wasn't accounted for in the existing setup. That is to say, ARM machines on Monterey or Ventura have to use the Intel app but ones on Sonoma can use the ARM app.