### PR TITLE
markdown-preview 0.0.34 (new cask)

### DIFF
--- a/Casks/m/markdown-preview.rb
+++ b/Casks/m/markdown-preview.rb
@@ -1,0 +1,30 @@
+cask "markdown-preview" do
+  version "0.0.10,14"
+  sha256 "ba68369a432a80bdfba96220232b41b9aa1e940b6d4fae87b35ff0b85c666704"
+
+  url "https://cdn.amore.computer/releases/doc.md-preview/#{version.csv.first}-#{version.csv.second}/Markdown-Preview.dmg",
+      verified: "cdn.amore.computer/releases/doc.md-preview/"
+  name "Markdown Preview"
+  desc "Markdown previewer with bundled Quick Look extension"
+  homepage "https://md-preview.app/"
+
+  livecheck do
+    url "https://storage.md-preview.app/appcast.xml"
+    strategy :sparkle do |item|
+      "#{item.short_version},#{item.version}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "Markdown Preview.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/doc.md-preview",
+    "~/Library/Caches/doc.md-preview",
+    "~/Library/Containers/doc.md-preview",
+    "~/Library/HTTPStorages/doc.md-preview",
+    "~/Library/Preferences/doc.md-preview.plist",
+  ]
+end


### PR DESCRIPTION
Adds a cask for [Markdown Preview](https://markdownpreview.app/), an open-source native macOS Markdown viewer with a bundled Quick Look extension.

This refreshes #262530, which was closed on May 4 because the upstream repository and domain were under 30 days old. The repository was created on April 28 and is now 77 days old, with 1,059 stars, 54 forks, ongoing development, and a stable release published on July 13.

Changes since the original submission:

- Updates the cask from `0.0.10` to `0.0.34`.
- Uses the stable GitHub release asset instead of the previous Amore CDN URL.
- Uses GitHub's latest-release strategy for livecheck.
- Uses the current canonical homepage.
- Simplifies the version to the marketing version because the GitHub asset URL no longer includes the build number.

Validation:

- `brew style Casks/m/markdown-preview.rb`
- `brew audit --new --cask markdown-preview`
- `brew livecheck --cask markdown-preview` (`0.0.34 ==> 0.0.34`)
- `brew fetch --cask markdown-preview`
- Downloaded DMG checksum matches the cask SHA-256.
- App is a universal `arm64`/`x86_64` binary and passes Gatekeeper as a notarized Developer ID application.
