### PR TITLE
factory 0.74.0 (new cask)

### DIFF
--- a/Casks/d/droid-desktop.rb
+++ b/Casks/d/droid-desktop.rb
@@ -5,19 +5,18 @@ cask "droid-desktop" do
   sha256 arm:   "ea7912174b2a988a6ca197e29c1674eb6898f66c67f14d7793529fb6226cf3ee",
          intel: "87e69f054574df56e92de983decb8b7501d5c80eaa653454f3c37aff6b6c993d"
 
-  url "http://downloads.factory.ai/factory-desktop/releases/#{version}/darwin/#{arch}/Factory-#{version}-#{arch}.dmg"
-
+  url "https://downloads.factory.ai/factory-desktop/releases/#{version}/darwin/#{arch}/Factory-#{version}-#{arch}.dmg"
   name "Factory"
   desc "AI-powered desktop app by Factory"
   homepage "https://www.factory.ai/"
-
-  auto_updates true
-  depends_on macos: ">= :monterey"
 
   livecheck do
     url "https://downloads.factory.ai/factory-desktop/LATEST"
     regex(/v?(\d+(?:\.\d+)+)/i)
   end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Factory.app"
 

--- a/Casks/d/droid-desktop.rb
+++ b/Casks/d/droid-desktop.rb
@@ -1,0 +1,32 @@
+cask "droid-desktop" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.74.0"
+  sha256 arm:   "ea7912174b2a988a6ca197e29c1674eb6898f66c67f14d7793529fb6226cf3ee",
+         intel: "87e69f054574df56e92de983decb8b7501d5c80eaa653454f3c37aff6b6c993d"
+
+  url "http://downloads.factory.ai/factory-desktop/releases/#{version}/darwin/#{arch}/Factory-#{version}-#{arch}.dmg"
+
+  name "Factory"
+  desc "AI-powered desktop app by Factory"
+  homepage "https://www.factory.ai/"
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  livecheck do
+    url "https://downloads.factory.ai/factory-desktop/LATEST"
+    regex(/v?(\d+(?:\.\d+)+)/i)
+  end
+
+  app "Factory.app"
+
+  zap trash: [
+    "~/Library/Application Support/ai.factory.desktop",
+    "~/Library/Caches/ai.factory.desktop",
+    "~/Library/HTTPStorages/ai.factory.desktop",
+    "~/Library/Preferences/ai.factory.desktop.plist",
+    "~/Library/Saved Application State/ai.factory.desktop.savedState",
+    "~/Library/WebKit/ai.factory.desktop",
+  ]
+end

--- a/Casks/f/factory.rb
+++ b/Casks/f/factory.rb
@@ -7,7 +7,7 @@ cask "factory" do
 
   url "https://downloads.factory.ai/factory-desktop/releases/#{version}/darwin/#{arch}/Factory-#{version}-#{arch}.dmg"
   name "Factory"
-  desc "AI-powered desktop app by Factory"
+  desc "Native AI agent interface to build, manage, and ship software by Factory"
   homepage "https://www.factory.ai/"
 
   livecheck do

--- a/Casks/f/factory.rb
+++ b/Casks/f/factory.rb
@@ -1,4 +1,4 @@
-cask "droid-desktop" do
+cask "factory" do
   arch arm: "arm64", intel: "x64"
 
   version "0.74.0"


### PR DESCRIPTION
Built and tested locally on macOS Sequoia.

New cask for the Factory desktop application (Droid Desktop), the GUI companion to the existing `droid` CLI cask.

- [x] Submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version)
- [x] `brew audit --cask --online factory` is error-free
- [x] `brew style --fix factory` reports no offenses
- [x] Named according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference)
- [x] Checked cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests)
- [x] `brew audit --cask --new factory` worked successfully
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask factory` worked successfully
- [x] `brew uninstall --cask factory` worked successfully

AI assisted with the creation of this cask. I personally reviewed the `zap` stanza paths and verified they follow the standard macOS Library conventions for Electron-based desktop applications.