### PR TITLE
ariax 1.0.7,17 (new cask)

### DIFF
--- a/Casks/a/ariax.rb
+++ b/Casks/a/ariax.rb
@@ -1,5 +1,5 @@
 cask "ariax" do
-  version "1.0.7,17"
+  version "1.0.7,19"
   sha256 :no_check
 
   url "https://artifact.saltpi.cn/build/AriaX/macOS/latest.dmg"

--- a/Casks/a/ariax.rb
+++ b/Casks/a/ariax.rb
@@ -1,5 +1,5 @@
 cask "ariax" do
-  version "1.0.7,19"
+  version "1.0.7"
   sha256 :no_check
 
   url "https://artifact.saltpi.cn/build/AriaX/macOS/latest.dmg"
@@ -9,7 +9,7 @@ cask "ariax" do
 
   livecheck do
     url "https://artifact.saltpi.cn/build/AriaX/macOS/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/a/ariax.rb
+++ b/Casks/a/ariax.rb
@@ -1,0 +1,27 @@
+cask "ariax" do
+  version "1.0.7,17"
+  sha256 "6cd6d7af6fae1c8bf8493f7976b52ec2d9031c09d6f2d6b1fc911167f9feef24"
+
+  url "https://github.com/saltpi/Aria.X/releases/download/#{version.csv.first}/AriaX.dmg",
+      verified: "github.com/saltpi/Aria.X/"
+  name "AriaX"
+  desc "Aria2 download manager"
+  homepage "https://ariax.saltpi.cn/"
+
+  livecheck do
+    url "https://github.com/saltpi/Aria.X/releases/latest/download/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "AriaX.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/cn.saltpi.app.AriaX",
+    "~/Library/Application Scripts/group.cn.saltpi.app.AriaX",
+    "~/Library/Containers/cn.saltpi.app.AriaX",
+    "~/Library/Group Containers/group.cn.saltpi.app.AriaX",
+  ]
+end

--- a/Casks/a/ariax.rb
+++ b/Casks/a/ariax.rb
@@ -1,15 +1,14 @@
 cask "ariax" do
   version "1.0.7,17"
-  sha256 "6cd6d7af6fae1c8bf8493f7976b52ec2d9031c09d6f2d6b1fc911167f9feef24"
+  sha256 :no_check
 
-  url "https://github.com/saltpi/Aria.X/releases/download/#{version.csv.first}/AriaX.dmg",
-      verified: "github.com/saltpi/Aria.X/"
+  url "https://artifact.saltpi.cn/build/AriaX/macOS/latest.dmg"
   name "AriaX"
   desc "Aria2 download manager"
   homepage "https://ariax.saltpi.cn/"
 
   livecheck do
-    url "https://github.com/saltpi/Aria.X/releases/latest/download/appcast.xml"
+    url "https://artifact.saltpi.cn/build/AriaX/macOS/appcast.xml"
     strategy :sparkle
   end
 

--- a/Casks/a/ariax.rb
+++ b/Casks/a/ariax.rb
@@ -2,7 +2,8 @@ cask "ariax" do
   version "1.0.7"
   sha256 :no_check
 
-  url "https://artifact.saltpi.cn/build/AriaX/macOS/latest.dmg"
+  url "https://github.com/saltpi/Aria.X/releases/download/#{version}/AriaX.dmg",
+      verified: "github.com/saltpi/Aria.X/"
   name "AriaX"
   desc "Aria2 download manager"
   homepage "https://ariax.saltpi.cn/"


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ariax` is error-free.
- [x] `brew style --fix ariax` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new ariax` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ariax` worked successfully.
- [x] `brew uninstall --cask ariax` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.
AI was used to assist in formatting the Sparkle livecheck strategy, downloading the new release version from appcast.xml, resolving Homebrew audit errors such as configuring `verified: github.com/saltpi/Aria.X/`, running `brew audit --cask --online ariax` and style fixes, and ensuring local testing for install/uninstall succeeded. The zap stanzas are based on the standard Library container identifiers for the application.