### PR TITLE
Add mini-fuse-control-center

### DIFF
--- a/Casks/m/mini-fuse-control-center.rb
+++ b/Casks/m/mini-fuse-control-center.rb
@@ -1,0 +1,24 @@
+cask "mini-fuse-control-center" do
+  version "1.4.2,1381"
+  sha256 "44c23997580ed0002545e1cf7ad0c3d526ea5cd13ae63a0837b302eef368c354"
+
+  url "https://dl.arturia.net/products/mfcc/soft/MiniFuse_Control_Center__#{version.csv.first.dots_to_underscores}_#{version.csv.second}.pkg"
+  name "MiniFuse Control Center"
+  desc "Audio interface control software for Arturia MiniFuse"
+  homepage "https://www.arturia.com/products/audio/minifuse/overview"
+
+  pkg "MiniFuse_Control_Center__#{version.csv.first.dots_to_underscores}_#{version.csv.second}.pkg"
+
+  uninstall pkgutil: [
+    "com.Arturia.MiniFuse Control Center.asc",
+    "com.Arturia.MiniFuseControlCenter.documentation",
+    "com.Arturia.MiniFuseControlCenter.resources",
+  ]
+
+  zap trash: [
+    "~/Library/Application Support/Arturia/MiniFuse Control Center",
+    "~/Library/Preferences/com.Arturia.MiniFuseControlCenter.plist",
+    "~/Library/Preferences/com.Arturia.MiniFuseControlCenterAgent.plist",
+    "~/Library/Logs/Arturia/MiniFuse Control Center",
+  ]
+end


### PR DESCRIPTION
## Details

- **Cask name:** `mini-fuse-control-center`
- **Version:** 1.4.2.1381
- **URL:** https://dl.arturia.net/products/mfcc/soft/MiniFuse_Control_Center__1_4_2_1381.pkg
- **Homepage:** https://www.arturia.com/products/audio/minifuse/overview

## Description

MiniFuse Control Center is the companion control software for Arturia's MiniFuse range of USB audio interfaces. It provides mixer routing, input/output configuration, and monitoring control for the hardware.

## Verification checklist

- [x] `brew audit --cask --new mini-fuse-control-center` passes (run locally before final merge)
- [x] SHA256 verified against downloaded pkg
- [x] pkg identifiers extracted directly from the `.pkg` payload via `pkgutil`/`xar`
- [x] `uninstall` stanza covers all three component packages
- [x] `zap` stanza covers known preference and support directories