### PR TITLE
rockxy 0.15.1

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.15.0,23"
-  sha256 "332083ed4ccbe66c32c6b7312b9418db639e08cac0caffc5e5642e71ec376f90"
+  version "0.15.1,24"
+  sha256 "66eebf0f2e0f58200beca326272c2fca08433d5811f7c55e382fc0718859358c"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.15.1 build 24.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.15.1/Rockxy-0.15.1-24.dmg
- SHA-256: 66eebf0f2e0f58200beca326272c2fca08433d5811f7c55e382fc0718859358c
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- Direct release DMG download and SHA-256 verification

Note: `brew fetch --cask rockxy --force` was attempted after audit but Homebrew's local download lock stalled on this machine; the same public DMG URL was downloaded directly and matched the expected SHA-256.

Disclosure: this PR was prepared with AI assistance and reviewed through the release automation.
