### PR TITLE
manus 1.5.7

### DIFF
--- a/Casks/m/manus.rb
+++ b/Casks/m/manus.rb
@@ -1,6 +1,6 @@
 cask "manus" do
-  version "1.5.6"
-  sha256 "52754fe4be85e2fd821b4b47df860bc43949964c586d8b504449a44d559108d9"
+  version "1.5.7"
+  sha256 "042796058a082b2d93eb68a809566c15fdc04a3952ca1701782870fc69ab98cc"
 
   url "https://download.manus.im/Manus-Setup-#{version}.dmg"
   name "Manus"


### PR DESCRIPTION
Built and tested locally on macOS 26.4.1.

Updates Manus to 1.5.7.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI helped update and verify the cask. I manually verified the official updater metadata, SHA-256 checksum, `brew audit --cask --online manus`, `brew style --fix manus`, local upgrade from 1.5.6 to 1.5.7, installed bundle metadata, architecture, and uninstall. The `zap` stanza is unchanged.

-----
