### PR TITLE
Add dikton

### DIFF
--- a/Casks/d/dikton.rb
+++ b/Casks/d/dikton.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+cask "dikton" do
+  version "0.2.2"
+  sha256 "87fa78e13bc7f96641c8040e4ef37210e87313e040a85337ae1dfd9cbba137b5"
+
+  url "https://releases.dikton.app/download/v#{version}/Dikton_#{version}_universal.dmg"
+  name "Dikton"
+  desc "Real-time AI voice dictation with contextual rewriting"
+  homepage "https://dikton.app/"
+
+  livecheck do
+    url "https://releases.dikton.app/latest/mac"
+    strategy :header_match do |headers|
+      next unless headers["location"]
+
+      headers["location"][%r{/v(\d+(?:\.\d+)+)/}, 1]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Dikton.app"
+
+  zap trash: [
+    "~/Library/Application Support/app.dikton.desktop",
+    "~/Library/Application Support/CrashReporter/dikton-desktop_*.plist",
+    "~/Library/Caches/app.dikton.desktop",
+    "~/Library/Caches/dikton-desktop",
+    "~/Library/HTTPStorages/dikton-desktop.binarycookies",
+    "~/Library/Preferences/app.dikton.desktop.plist",
+    "~/Library/Preferences/dikton-desktop.plist",
+    "~/Library/WebKit/app.dikton.desktop",
+    "~/Library/WebKit/dikton-desktop",
+  ]
+end


### PR DESCRIPTION
After making changes to a cask:

- [x] \`brew style {{cask}}\` reports no offenses
- [x] \`brew audit --new-cask {{cask}}\` works for new casks; \`brew audit --cask --online {{cask}}\` for updates
- [x] The commit message includes the cask's name

### About the app

Dikton is a real-time AI voice dictation app for macOS. It transcribes speech in streaming and applies contextual AI rewriting (translation, tone shift, format) per active app.

- Homepage: https://dikton.app/
- Built with Tauri (Rust + WebView)
- Universal binary (Apple Silicon + Intel)

### Distribution

- DMG signed with Developer ID: \`Authority=Developer ID Application: rolf mouchel blaisot (2Z92A9TH52)\`
- Notarized: \`spctl: accepted, source=Notarized Developer ID\`
- Public versioned URL via Cloudflare: \`releases.dikton.app/download/v{version}/Dikton_{version}_universal.dmg\`
- \`livecheck\` strategy: \`header_match\` on the latest-redirect (\`releases.dikton.app/latest/mac\`)
- \`auto_updates true\` because Tauri's built-in updater handles patches once installed

### Local validation

\`\`\`
\$ brew style local/dikton-test/dikton
1 file inspected, no offenses detected

\$ brew audit --new --cask local/dikton-test/dikton
# (no errors)

\$ brew livecheck --cask local/dikton-test/dikton
dikton: 0.2.2 ==> 0.2.2
\`\`\`