### PR TITLE
memry 2026-05-06.4 (new cask)

### DIFF
--- a/Casks/m/memry.rb
+++ b/Casks/m/memry.rb
@@ -1,0 +1,39 @@
+cask "memry" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2026-05-06.4"
+  sha256 arm:   "ae2eafa7589164923e897281b89a4ce5592c8ca414476e2c550ba616684c0e20",
+         intel: "4a2c32e51d5ffd6416fa6a5c72931cbf2416090e8742404513cd761d24c036e3"
+
+  url "https://github.com/memrynote/memry/releases/download/v#{version}/Memry-#{version}-#{arch}.dmg",
+      verified: "github.com/memrynote/memry/"
+  name "Memry"
+  desc "Local-first workspace for notes, tasks, journals, and inbox"
+  homepage "https://memrynote.com/"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d{4}-\d{2}-\d{2}(?:\.\d+)?)$/i)
+    strategy :github_latest do |json, regex|
+      json["tag_name"]&.[](regex, 1)
+    end
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "Memry.app"
+
+  uninstall quit: "com.memrynote.memry"
+
+  zap trash: [
+    "~/Library/Application Support/Memry",
+    "~/Library/Application Support/memry",
+    "~/Library/Caches/com.memrynote.memry",
+    "~/Library/Caches/com.memrynote.memry.ShipIt",
+    "~/Library/HTTPStorages/com.memrynote.memry",
+    "~/Library/Logs/Memry",
+    "~/Library/Logs/memry",
+    "~/Library/Preferences/com.memrynote.memry.plist",
+    "~/Library/Saved Application State/com.memrynote.memry.savedState",
+  ]
+end


### PR DESCRIPTION
Adds [Memry](https://memrynote.com/), a local-first workspace for notes, tasks, journals, and inbox.

Release source: https://github.com/memrynote/memry/releases/tag/v2026-05-06.4

DMGs:
- https://github.com/memrynote/memry/releases/download/v2026-05-06.4/Memry-2026-05-06.4-arm64.dmg
- https://github.com/memrynote/memry/releases/download/v2026-05-06.4/Memry-2026-05-06.4-x64.dmg

Known audit note:
- `brew audit --new --cask memry` reports: GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you are editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assistance was used to draft the cask. Manual verification: release assets were checked, SHA-256 values were computed from downloaded DMGs, livecheck was checked, online audit/style/install/spctl/uninstall were run, and zap paths were checked against the app bundle id and Electron support/cache/log locations.
