### PR TITLE
kdenlive 26.04.0

### DIFF
--- a/Casks/k/kdenlive.rb
+++ b/Casks/k/kdenlive.rb
@@ -1,9 +1,14 @@
 cask "kdenlive" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "25.12.2"
-  sha256 arm:   "193959980b24f108f8782d518292f266d84d75d4d4549cccefb9dcfaf6ba83b5",
-         intel: "e63d895c91dc35b2b57ab44a9f48210db4ffd8c095bee84c9d3b7cf735f877c4"
+  on_arm do
+    version "26.04.0,A"
+    sha256 "b17a09c29b81b1651da15d92c0c33f3d1e977ebe2849ef68233eb33abd624900"
+  end
+  on_intel do
+    version "26.04.0"
+    sha256 "68b435007621152a875201f761ab27c05267bb7f5d96bf17d2104587381fb913"
+  end
 
   url "https://cdn.download.kde.org/stable/kdenlive/#{version.csv.first.major_minor}/macOS/kdenlive-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}-#{arch}.dmg",
       verified: "cdn.download.kde.org/stable/kdenlive/"


### PR DESCRIPTION
-----
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Updates `kdenlive` to 26.04.0.

Kdenlive's macOS download filenames include upstream packaging revision tokens whose presence and position vary by release and architecture.
Recent old version include `_A` after the architecture, `-B-` before the architecture, and the current 26.04.0 ARM artifact using `-A-` while the Intel artifact has no revision token.

This change stores the current ARM and Intel filename stems in `version.csv` and updates `livecheck` to derive both stems from the upstream download page. That lets livecheck/autobump track the shared app version while still producing the correct per-architecture URLs.

Local verification:

```bash
brew style Casks/k/kdenlive.rb
brew livecheck --cask kdenlive --autobump --json
brew audit --cask --online kdenlive --arch=arm
brew audit --cask --online kdenlive --arch=intel
brew lgtm --online
```

All of the above passed locally. zap stanza paths were not changed.

AI disclosure: I used OpenAI Codex to help inspect the existing cask, compare upstream filename patterns, draft the livecheck change, and prepare this PR text. I manually reviewed the final diff and verified it with the commands listed above.