### PR TITLE
rockxy 0.16.0

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.15.1,24"
-  sha256 "66eebf0f2e0f58200beca326272c2fca08433d5811f7c55e382fc0718859358c"
+  version "0.16.0,25"
+  sha256 "c5841339407e1ff7ccba712e94045b5fa6dace754f3067cb7e2448a23976ea01"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.16.0 build 25.

Release artifact:
- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.16.0/Rockxy-0.16.0-25.dmg
- SHA-256: c5841339407e1ff7ccba712e94045b5fa6dace754f3067cb7e2448a23976ea01
- Notarized: true

Local checks run:
- `brew style --fix rockxy`
- `brew audit --new --cask rockxy --verbose`
- `brew fetch --cask rockxy --verbose`
- `brew install --dry-run --cask rockxy`
