### PR TITLE
kimi 3.0.6

### DIFF
--- a/Casks/k/kimi.rb
+++ b/Casks/k/kimi.rb
@@ -10,7 +10,6 @@ cask "kimi" do
 
   livecheck do
     url "https://appsupport.moonshot.cn/api/app/pkg/latest/macos/download"
-    regex(/kimi[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :header_match
   end
 

--- a/Casks/k/kimi.rb
+++ b/Casks/k/kimi.rb
@@ -1,16 +1,20 @@
 cask "kimi" do
-  version "2.1.1"
-  sha256 "ee6286ac3d438b55c4dd62d211de20d2ca357f88350d6440a575f2ea22c53116"
+  version "3.0.6"
+  sha256 "57ff6dcae0653294b490ffb0f8a4941c0e93226fff0ad098aeea38bc9ba0184c"
 
-  url "https://kimi-img.moonshot.cn/app/download/macos/kimi_#{version}.dmg",
+  url "https://kimi-img.moonshot.cn/app/download/mac/kimi_#{version}.dmg",
       verified: "kimi-img.moonshot.cn/"
   name "kimi"
   desc "AI chat assistant from Moonshot"
   homepage "https://www.moonshot.ai/"
 
-  disable! date: "2025-12-25", because: :no_longer_available
+  livecheck do
+    url "https://appsupport.moonshot.cn/api/app/pkg/latest/macos/download"
+    regex(/kimi[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :header_match
+  end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Kimi.app"
 


### PR DESCRIPTION
Updates the Kimi cask to 3.0.9 and re-enables it using the currently available Moonshot macOS download path.

The old `macos` download path no longer served the 2.1.1 artifact, so this switches to the versioned `mac` path exposed by the latest download endpoint. I also added a header-based livecheck for that latest endpoint and adjusted the minimum macOS requirement to Monterey, matching the app bundle's `LSMinimumSystemVersion` of 12.0.

Validation:
- `brew style --fix Casks/k/kimi.rb`
- `brew audit --cask --online kimi`
- `brew livecheck --cask kimi`
- `git diff --check`
