### PR TITLE
font-google-sans-code: update font filenames for new MONO axis

### DIFF
--- a/Casks/font/font-g/font-google-sans-code.rb
+++ b/Casks/font/font-g/font-google-sans-code.rb
@@ -9,8 +9,8 @@ cask "font-google-sans-code" do
   name "Google Sans Code"
   homepage "https://fonts.google.com/specimen/Google+Sans+Code"
 
-  font "GoogleSansCode-Italic[wght].ttf"
-  font "GoogleSansCode[wght].ttf"
+  font "GoogleSansCode-Italic[MONO,wght].ttf"
+  font "GoogleSansCode[MONO,wght].ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
Built and tested locally on macOS.

Google added a `MONO` variable axis upstream, so the font filenames changed from `[wght].ttf` to `[MONO,wght].ttf`. Updates the `font` stanzas to match, fixing "Font source ... is not there" errors during upgrade.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

- [ ] AI was used to generate or assist with generating this PR.