### PR TITLE
kimi 3.0.9

### DIFF
--- a/Casks/k/kimi.rb
+++ b/Casks/k/kimi.rb
@@ -13,6 +13,7 @@ cask "kimi" do
     strategy :header_match
   end
 
+  depends_on arch: :arm64
   depends_on macos: ">= :monterey"
 
   app "Kimi.app"

--- a/Casks/k/kimi.rb
+++ b/Casks/k/kimi.rb
@@ -1,6 +1,6 @@
 cask "kimi" do
-  version "3.0.6"
-  sha256 "57ff6dcae0653294b490ffb0f8a4941c0e93226fff0ad098aeea38bc9ba0184c"
+  version "3.0.9"
+  sha256 "1d36e0881045c07d46edc543fa55b760b8839c3e5224bcc874f689ebd6ddd8ef"
 
   url "https://kimi-img.moonshot.cn/app/download/mac/kimi_#{version}.dmg",
       verified: "kimi-img.moonshot.cn/"


### PR DESCRIPTION
Updates the Kimi cask from 3.0.6 to 3.0.9.

The download remains on the versioned Moonshot `mac` path added in the previous update, and this bump refreshes the version and SHA-256 for the current release.

Validation:
- `brew style --fix Casks/k/kimi.rb`
- `brew audit --cask --online kimi`
- `brew livecheck --cask kimi`
- `git diff --check`
