### PR TITLE
typinator: fix download URL

### DIFF
--- a/Casks/t/typinator.rb
+++ b/Casks/t/typinator.rb
@@ -5,7 +5,7 @@ cask "typinator" do
   url "https://storage.ergonis.com/apps/production/typinator/archive/Typinator_#{version.no_dots}.dmg"
   name "Typinator"
   desc "Tool to automate the insertion of frequently used text and graphics"
-  homepage "https://www.ergonis.com/products/typinator/"
+  homepage "https://ergonis.com/en/typinator/"
 
   livecheck do
     url "https://update.ergonis.com/vck/typinator.xml"

--- a/Casks/t/typinator.rb
+++ b/Casks/t/typinator.rb
@@ -1,9 +1,8 @@
 cask "typinator" do
   version "10.0"
-  sha256 "dc01024d8b36bbb5770b63336eaf1873ba0620265554ba6a973f96650065e6d8"
+  sha256 "e8c42d9eaf3f737f412b01d01f9237cd583598091ff4c1b73577b0f38c7dfaa5"
 
-  url "https://www.ergonis.com/downloads/products/typinator/Typinator#{version.no_dots}-Install.dmg",
-      user_agent: :fake
+  url "https://storage.ergonis.com/apps/production/typinator/archive/Typinator_#{version.no_dots}.dmg"
   name "Typinator"
   desc "Tool to automate the insertion of frequently used text and graphics"
   homepage "https://www.ergonis.com/products/typinator/"


### PR DESCRIPTION
Ergonis moved the Typinator 10.0 download from `www.ergonis.com/downloads/products/typinator/` to `storage.ergonis.com/apps/production/typinator/archive/`.

The old URL (`Typinator100-Install.dmg`) returns HTTP 404, breaking `brew install --cask typinator`.

### Changes
- Update `url` to the new storage location
- Refresh SHA256 checksum to match the file at the new URL
- Remove `user_agent: :fake` (no longer needed for the new host)

### Verification
```
$ curl -sIL "https://storage.ergonis.com/apps/production/typinator/archive/Typinator_100.dmg" | grep HTTP
HTTP/2 200
$ shasum -a 256 Typinator_100.dmg
e8c42d9eaf3f737f412b01d01f9237cd583598091ff4c1b73577b0f38c7dfaa5
```

The new URL was found on the official Ergonis download-thank-you page at `ergonis.com/en/typinator/mac/10.0/download-thank-you/`.

---
*Generated with [Oz](https://app.warp.dev/conversation/a8f39596-1a30-4ed2-81a2-7aae2483ee9f)*

Co-Authored-By: Oz <oz-agent@warp.dev>