### PR TITLE
rockxy 0.18.0

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.17.0,26"
-  sha256 "8f52df359ff4c508b80f10ad8f3fd47f4f017f404fa15dc6e803f534f38dbd78"
+  version "0.18.0,27"
+  sha256 "0d8eefa4b36dd336ba869d3a50c675b98b9a15d83844e39fcc89b9d48c95c6bb"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.18.0 build 27.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.18.0/Rockxy-0.18.0-27.dmg
- SHA-256: 0d8eefa4b36dd336ba869d3a50c675b98b9a15d83844e39fcc89b9d48c95c6bb
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`

Disclosure: this PR was prepared with AI assistance and reviewed through the release automation.
