### PR TITLE
openchamber: update homepage, desc, add livecheck and zap paths

### DIFF
--- a/Casks/o/openchamber.rb
+++ b/Casks/o/openchamber.rb
@@ -5,7 +5,8 @@ cask "openchamber" do
   sha256 arm:   "0072e85b3093e7ceba0e4004fe7b96f76a21a770a6cef17a7e8d201a6759acdd",
          intel: "53084112bb3416ed1cb9c196d76e555ef30bcd04c925c96d5053f006dca72505"
 
-  url "https://github.com/openchamber/openchamber/releases/download/v#{version}/OpenChamber-#{version}-#{arch}.dmg"
+  url "https://github.com/openchamber/openchamber/releases/download/v#{version}/OpenChamber-#{version}-#{arch}.dmg",
+      verified: "github.com/openchamber/openchamber/"
   name "OpenChamber"
   desc "Desktop and web interface for OpenCode AI agent"
   homepage "https://openchamber.dev/"

--- a/Casks/o/openchamber.rb
+++ b/Casks/o/openchamber.rb
@@ -7,12 +7,25 @@ cask "openchamber" do
 
   url "https://github.com/openchamber/openchamber/releases/download/v#{version}/OpenChamber-#{version}-#{arch}.dmg"
   name "OpenChamber"
-  desc "Rich interface for OpenCode"
-  homepage "https://github.com/openchamber/openchamber"
+  desc "Desktop and web interface for OpenCode AI agent"
+  homepage "https://openchamber.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   depends_on macos: ">= :monterey"
 
   app "OpenChamber.app"
 
-  zap trash: "~/.config/openchamber"
+  zap trash: [
+    "~/.config/openchamber",
+    "~/Library/Application Support/ai.opencode.openchamber",
+    "~/Library/Caches/ai.opencode.openchamber",
+    "~/Library/Logs/OpenChamber",
+    "~/Library/Preferences/ai.opencode.openchamber.plist",
+    "~/Library/Saved Application State/ai.opencode.openchamber.savedState",
+    "~/Library/WebKit/ai.opencode.openchamber",
+  ]
 end


### PR DESCRIPTION
## Summary

- Update `homepage` from GitHub repo URL to official site `https://openchamber.dev/`
- Update `desc` to more accurately describe the application
- Add `livecheck` block with `strategy :github_latest` so the autobump bot can track new releases automatically
- Expand `zap` to include all known macOS user-data paths (bundle ID: `ai.opencode.openchamber`)

## Verification

`brew audit --cask openchamber` passes cleanly.