### PR TITLE
Gate macOS requirement in multi-platform casks

### DIFF
--- a/Casks/c/copilot-cli.rb
+++ b/Casks/c/copilot-cli.rb
@@ -2,6 +2,10 @@ cask "copilot-cli" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
+  on_macos do
+    depends_on macos: ">= :ventura"
+  end
+
   version "1.0.44"
   sha256 arm:          "d5a9b8cc2de1d1d6e08ae658cc352069c6ee70f26d11b3d7763b46e44098331a",
          intel:        "cf993c10a4b33caa5260d6b0978eeb6a73e15b82a2042d3bf2fc75b26899f632",
@@ -20,7 +24,6 @@ cask "copilot-cli" do
 
   auto_updates true
   conflicts_with cask: "copilot-cli@prerelease"
-  depends_on macos: ">= :ventura"
 
   binary "copilot"
 

--- a/Casks/c/copilot-cli@prerelease.rb
+++ b/Casks/c/copilot-cli@prerelease.rb
@@ -2,6 +2,10 @@ cask "copilot-cli@prerelease" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
+  on_macos do
+    depends_on macos: ">= :ventura"
+  end
+
   version "1.0.44-3"
   sha256 arm:          "33df72591e6b8066d052d3213054e00c17d2bd65adea47eb455f397b4adca739",
          intel:        "ffb64118f6461606e4fdb02451e10f2904d2318bf73dc2fbd9ec5755c9e392c8",
@@ -30,7 +34,6 @@ cask "copilot-cli@prerelease" do
 
   auto_updates true
   conflicts_with cask: "copilot-cli"
-  depends_on macos: ">= :ventura"
 
   binary "copilot"
 

--- a/Casks/c/copilot-language-server.rb
+++ b/Casks/c/copilot-language-server.rb
@@ -2,6 +2,10 @@ cask "copilot-language-server" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
+  on_macos do
+    depends_on macos: ">= :big_sur"
+  end
+
   version "1.485.0"
   sha256 arm:          "2ccdbab51e3c9f42c608dc2026e50337fbf5938f296a341cd20b2387ed166134",
          intel:        "abb8f137bee53b3ad181afd1ae6625690f8a562b8bf38654de3806aaa2d55bb1",
@@ -12,8 +16,6 @@ cask "copilot-language-server" do
   name "GitHub Copilot Language Server"
   desc "Language Server Protocol server for GitHub Copilot"
   homepage "https://github.com/github/copilot-language-server-release"
-
-  depends_on macos: ">= :big_sur"
 
   binary "copilot-language-server"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

We have a few casks that support both macOS and Linux and have a `depends_on macos:` call at the top level. This should only apply to macOS, so this moves the call into an `on_macos` block. In the near future, a top-level `depends_on macos:` call will not only set the macOS requirement but also specify that the cask is macOS-only (https://github.com/Homebrew/brew/pull/22187), so this is a precursor to being able to change that behavior.