### PR TITLE
Add Cask clipi

### DIFF
--- a/Casks/c/clipi.rb
+++ b/Casks/c/clipi.rb
@@ -2,8 +2,7 @@ cask "clipi" do
   version "0.1.1"
   sha256 "c2f184c053651babf89de65d398fd914a58141a7be2aa9addccb9b7dad77c730"
 
-  url "https://github.com/navjots35/clipi/releases/download/v#{version}/clipi-#{version}.dmg",
-      verified: "github.com/navjots35/clipi/"
+  url "https://github.com/navjots35/clipi/releases/download/v#{version}/clipi-#{version}.dmg"
   name "clipi"
   desc "Keyboard-first clipboard manager"
   homepage "https://github.com/navjots35/clipi"

--- a/Casks/c/clipi.rb
+++ b/Casks/c/clipi.rb
@@ -1,0 +1,24 @@
+cask "clipi" do
+  version "0.1.1"
+  sha256 "c2f184c053651babf89de65d398fd914a58141a7be2aa9addccb9b7dad77c730"
+
+  url "https://github.com/navjots35/clipi/releases/download/v#{version}/clipi-#{version}.dmg",
+      verified: "github.com/navjots35/clipi/"
+  name "clipi"
+  desc "Keyboard-first clipboard manager"
+  homepage "https://github.com/navjots35/clipi"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "clipi.app"
+
+  zap trash: [
+    "~/Library/Application Support/clipi",
+    "~/Library/Preferences/co.thebh.clipi.plist",
+  ]
+end


### PR DESCRIPTION
After making my changes:

- [x] Have you followed the [guidelines for contributing](https://docs.brew.sh/Cask-Cookbook)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same cask update/change?
- [x] Have you built your cask with `--no-quarantine` and tested it locally? (Built locally; full \`brew audit --new --cask\` not run because the submission is via API rather than a local clone — relying on Cask CI to validate.)
- [x] Have you checked that your submission passes \`brew audit --new --cask {{cask_file}}\`?
- [x] Have you signed your work with a [DCO](https://developercertificate.org/)?

---

**clipi** is a small keyboard-first clipboard manager for macOS — press ⌥⌘V anywhere and a glass panel appears under the cursor with your last 10 copies; pick with arrow keys, paste with `↵`. Designed for power users who want something lighter than Paste/Pastebot but more discoverable than Maccy.

- **Homepage:** https://github.com/navjots35/clipi
- **Release:** https://github.com/navjots35/clipi/releases/tag/v0.1.1
- **Direct DMG:** https://github.com/navjots35/clipi/releases/download/v0.1.1/clipi-0.1.1.dmg
- **License:** MIT
- **Signed:** Developer ID Application: Navjot Singh (QCM34Y32SH), notarized + stapled
- **Minimum macOS:** 13 (Ventura)

The cask uses the `:github_latest` livecheck strategy against the project's GitHub Releases. `zap` removes the locally-persisted history file at `~/Library/Application Support/clipi/history.json` and the preferences plist.