### PR TITLE
bing-wallpaper 1.1.9

### DIFF
--- a/Casks/b/bing-wallpaper.rb
+++ b/Casks/b/bing-wallpaper.rb
@@ -1,8 +1,8 @@
 cask "bing-wallpaper" do
-  version "1.1.8"
-  sha256 "564b0793186dfb639d5207849a65ab20a6ea0b93a16d3de3939a24bb9b56984c"
+  version "1.1.9"
+  sha256 "64f63c9f2f9f8c42a441ed3dc630e6d2cdcc0a7287b6ec872ebcfe41b474905e"
 
-  url "https://download.microsoft.com/download/3a8e7366-aac0-4636-bc1d-a3c6c217accf/Installer/#{version}/MSN/Var1/MW021/Bing%20Wallpaper.pkg"
+  url "https://download.microsoft.com/download/3c2365ad-ed5f-4ebc-bacf-6dd9c66a2d15/Installer/#{version}/var1/MW011/2/BingWallpaper.pkg"
   name "Bing Wallpaper"
   desc "Use the Bing daily image as your wallpaper"
   homepage "https://bingwallpaper.microsoft.com/"
@@ -15,7 +15,7 @@ cask "bing-wallpaper" do
 
   depends_on macos: ">= :big_sur"
 
-  pkg "Bing Wallpaper.pkg"
+  pkg "BingWallpaper.pkg"
 
   uninstall launchctl: [
               "com.microsoft.msbwapp",
@@ -27,7 +27,8 @@ cask "bing-wallpaper" do
               "com.microsoft.msbwapp",
               "com.microsoft.msbwdefaults",
             ],
-            pkgutil:   "com.microsoft.msbwpackage"
+            pkgutil:   "com.microsoft.msbwpackage",
+            delete:    "/Applications/Microsoft Bing for Safari.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.msbwdefaults.sfl*",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`bing-wallpaper` is autobumped but the workflow failed to update to version 1.1.9 because the asset URL path changed again. The hexadecimal part seems to vary but I'm not sure if it changes with each version or if it only changes the other parts of the URL path change. We may need to include it as part of the `version` if the rest of the URL stabilizes at some point but we're having to manually update the URL for version updates anyway, so it wouldn't save us much effort at the moment. Anyway, this updates the version and `url` accordingly.