### PR TITLE
electorrent 2.9.0

### DIFF
--- a/Casks/e/electorrent.rb
+++ b/Casks/e/electorrent.rb
@@ -1,23 +1,24 @@
 cask "electorrent" do
-  version "2.8.5"
-  sha256 "83e9e16181e8944f1feee57efe199acd90ab556d358dca6a006469ad008d4779"
+  version "2.9.0"
+  sha256 "9c11fddd4f66f61b8d17cf6138061930f600e7641d9ffe93ed77331abeef57a8"
 
-  url "https://github.com/tympanix/Electorrent/releases/download/v#{version}/electorrent-#{version}.dmg"
+  url "https://github.com/tympanix/Electorrent/releases/download/v#{version}/Electorrent-#{version}-universal.dmg"
   name "Electorrent"
   desc "Desktop remote torrenting application"
   homepage "https://github.com/tympanix/Electorrent"
 
   livecheck do
     url "https://electorrent.vercel.app/update/dmg/0.0.0"
-    strategy :json do |json|
-      json["name"]&.tr("v", "")
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json["name"]&.[](regex, 1)
     end
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on :macos
+  depends_on macos: ">= :big_sur"
 
   app "Electorrent.app"
 
@@ -26,8 +27,4 @@ cask "electorrent" do
     "~/Library/Preferences/com.github.tympanix.Electorrent.plist",
     "~/Library/Saved Application State/com.github.tympanix.Electorrent.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`electorrent` is autobumped but the workflow failed to update to version 2.9.0 because the file name format has changed (adding a `-universal` suffix). This updates the version and adjusts the cask accordingly.

Besides that, this also modifies the `livecheck` block to use a regex to omit non-numeric text at the start of the version instead of `.tr("v", "")`. The `tr` approach would not catch an uppercase V and removes the provided character globally, so it can fail or work in ways we don't intend. For what it's worth, `.tr("v", "")` is convenient but `.delete_prefix("v")` would be more accurate if case sensitivity wasn't an issue here.