### PR TITLE
miaoyan: update livecheck

### DIFF
--- a/Casks/m/miaoyan.rb
+++ b/Casks/m/miaoyan.rb
@@ -10,9 +10,7 @@ cask "miaoyan" do
 
   livecheck do
     url "https://miaoyan.app/appcast.xml"
-    strategy :sparkle do |items|
-      items.map(&:nice_version)
-    end
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The existing `livecheck` block for `miaoyan` uses the `nice_version` value, which is currently "3.5.1,3.5.0". Autobump treats this as a new version and interpolating it into the cask `url` predictably fails. This updates the `livecheck` block to use the `short_version` value, which correctly gives 3.5.1 as the newest version.