### PR TITLE
nostalgiapp 1.0.8.8.10

### DIFF
--- a/Casks/n/nostalgiapp.rb
+++ b/Casks/n/nostalgiapp.rb
@@ -1,15 +1,25 @@
 cask "nostalgiapp" do
-  version "1.0.8.8.7"
-  sha256 "ec6d001fa7225abffa8537aa6250f1615b9cf830b817abfdab0e1b74a848e00b"
+  version "1.0.8.8.10,137"
+  sha256 "98cf35a883eaea487ade749e4210349efef0476ca31a3d7cb5a597dc69a4cd48"
 
-  url "https://www.nostalgi.app/downloads/NostalgiApp-#{version}.dmg"
+  url "https://www.nostalgi.app/downloads/NostalgiApp-#{version.csv.first}#{"-b#{version.csv.second}" if version.csv.second}.dmg"
   name "NostalgiApp"
   desc "Launcher for eXoDOS and retro game collections"
-  homepage "https://nostalgi.app/"
+  homepage "https://www.nostalgi.app/"
 
+  # The `sparkle:version` corresponds to the number in the file name suffix
+  # (e.g. `-b123`) but we match against the URL instead of using `nice_version`
+  # because we only want to include the second number in the version if it's
+  # used in the URL.
   livecheck do
-    url "https://nostalgi.app/appcast.xml"
-    strategy :sparkle, &:short_version
+    url "https://www.nostalgi.app/appcast.xml"
+    regex(/NostalgiApp[._-]v?(\d+(?:\.\d+)+)(?:[._-]b(\d+))?/i)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
+      next unless match
+
+      match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`nostalgiapp` is autobumped but the workflow failed to update to version 1.0.8.8.10 because the file name for newer versions includes a suffix like `-b137`. This updates the version and adjusts the cask accordingly. I've modified the `livecheck` block to match the version from the `url` using a regex, as we only want to include the second version part if it's used in the asset URL.