### PR TITLE
Petdex 0.1.9 (new cask)

### DIFF
--- a/Casks/p/petdex.rb
+++ b/Casks/p/petdex.rb
@@ -1,7 +1,7 @@
 cask "petdex" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.1.6"
+  version "0.1.9"
   sha256 :no_check
 
   url "https://petdex.crafter.run/api/desktop/latest-release?asset=darwin-#{arch}"
@@ -18,7 +18,6 @@ cask "petdex" do
   end
 
   auto_updates true
-  depends_on formula: "node"
   depends_on macos: ">= :ventura"
 
   app "Petdex.app"

--- a/Casks/p/petdex.rb
+++ b/Casks/p/petdex.rb
@@ -1,0 +1,37 @@
+cask "petdex" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.1.6"
+  sha256 :no_check
+
+  url "https://petdex.crafter.run/api/desktop/latest-release?asset=darwin-#{arch}"
+  name "Petdex"
+  desc "Desktop companion for Codex pets"
+  homepage "https://petdex.crafter.run/"
+
+  livecheck do
+    url "https://petdex.crafter.run/api/desktop/latest-release?asset=darwin-arm64"
+    regex(%r{/desktop-v?(\d+(?:\.\d+)+)/Petdex-arm64\.dmg}i)
+    strategy :header_match do |all_headers, regex|
+      all_headers.filter_map { |headers| headers["location"]&.[](regex, 1) }.first
+    end
+  end
+
+  auto_updates true
+  depends_on formula: "node"
+  depends_on macos: ">= :ventura"
+
+  app "Petdex.app"
+
+  uninstall quit: "run.crafter.petdex-desktop"
+
+  zap trash: [
+    "~/.petdex",
+    "~/.petdex-desktop",
+    "~/Library/Caches/run.crafter.petdex-desktop",
+    "~/Library/HTTPStorages/run.crafter.petdex-desktop",
+    "~/Library/Preferences/run.crafter.petdex-desktop.plist",
+    "~/Library/Saved Application State/run.crafter.petdex-desktop.savedState",
+    "~/Library/WebKit/run.crafter.petdex-desktop",
+  ]
+end

--- a/Casks/p/petdex.rb
+++ b/Casks/p/petdex.rb
@@ -1,19 +1,23 @@
 cask "petdex" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.1.9"
-  sha256 :no_check
+  version "0.1.10"
+  sha256 arm:   "02885442276100ecb52bb3151abe9df2b6a62e9857d70d648e705173d2853eb9",
+         intel: "7f53237019edc213a431d28872cc819bb1758ba4301de1165a8eeb3ed56c32ac"
 
-  url "https://petdex.crafter.run/api/desktop/latest-release?asset=darwin-#{arch}"
+  url "https://github.com/crafter-station/petdex/releases/download/desktop-v#{version}/Petdex-#{arch}.dmg",
+      verified: "github.com/crafter-station/petdex/"
   name "Petdex"
   desc "Desktop companion for Codex pets"
   homepage "https://petdex.crafter.run/"
 
   livecheck do
-    url "https://petdex.crafter.run/api/desktop/latest-release?asset=darwin-arm64"
-    regex(%r{/desktop-v?(\d+(?:\.\d+)+)/Petdex-arm64\.dmg}i)
-    strategy :header_match do |all_headers, regex|
-      all_headers.filter_map { |headers| headers["location"]&.[](regex, 1) }.first
+    url :url
+    regex(%r{/desktop-v?(\d+(?:\.\d+)+)/Petdex[._-]#{arch}\.dmg}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.filter_map do |asset|
+        asset["browser_download_url"]&.[](regex, 1)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Add the Petdex macOS desktop app as a new cask.
- Use the official Petdex desktop download endpoint with Apple Silicon and Intel asset selection.
- Add livecheck via the release redirect, plus Node and macOS dependency metadata.

## Validation

- `brew style Casks/p/petdex.rb`
- `brew livecheck petdex --cask`
- `brew audit --cask --new petdex`
