### PR TITLE
reamp 1.7.0

### DIFF
--- a/Casks/r/reamp.rb
+++ b/Casks/r/reamp.rb
@@ -1,15 +1,15 @@
 cask "reamp" do
-  version "1.6.3"
-  sha256 "f31f664d512fd248d479fc82e17670d1e99bd4f37174698b39faf74ab3b05460"
+  version "1.7.0,990"
+  sha256 "eeff97b12857cc76a3c86f75d63b5e90cf3f9aef03f38e50221a9e8a3dfc173c"
 
-  url "https://re-amp.ru/app/releases/reAMP-#{version}.zip"
+  url "https://update.re-amp.ru/downloads/Reamp-#{version.csv.first}(#{version.csv.second}).zip"
   name "re:AMP"
   desc "WinAMP clone written in SwiftUI"
   homepage "https://re-amp.ru/"
 
   livecheck do
     url "https://re-amp.ru/app/appcast.xml"
-    strategy :sparkle, &:short_version
+    strategy :sparkle, &:nice_version
   end
 
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`reamp` is autobumped but the workflow failed to update to version 1.7.0 because the asset URL is different and the file name format now includes a secondary number in parentheses. This updates the version and adjusts the cask accordingly.