### PR TITLE
timemator 3.2.2

### DIFF
--- a/Casks/t/timemator.rb
+++ b/Casks/t/timemator.rb
@@ -1,9 +1,9 @@
 cask "timemator" do
-  version "3.2.1"
-  sha256 "92623740733fcd7374fbc2b107479316800f3cb794de5f1ec4dcd73c6424c669"
+  version "3.2.2"
+  sha256 "8450093db94e3ad856a820b2849a3c8f64abbf4d7427ae524a823462344a00c7"
 
-  url "https://catforce-timemator.s3.amazonaws.com/releases/Timemator_#{version}.dmg",
-      verified: "catforce-timemator.s3.amazonaws.com/"
+  url "https://timemator.s3.amazonaws.com/releases/Timemator_#{version}.dmg",
+      verified: "timemator.s3.amazonaws.com/"
   name "Timemator"
   desc "Automatic time-tracking application"
   homepage "https://timemator.com/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`timemator` is autobumped but the workflow failed to update to version 3.2.2 because the S3 URL is different. This updates the version and adjusts the cask `url` to align with the asset URL in the appcast and on the website.