### PR TITLE
topaz-gigapixel 1.2.0

### DIFF
--- a/Casks/t/topaz-gigapixel.rb
+++ b/Casks/t/topaz-gigapixel.rb
@@ -1,25 +1,30 @@
 cask "topaz-gigapixel" do
-  version "1.1.3"
-  sha256 "7c8bbd7038a805d733f3991cc6a705142884db6f9a5a35a3db15972843abebf9"
+  arch arm: "arm64", intel: "x86_64"
+  livecheck_arch = on_arch_conditional intel: "/intel"
 
-  url "https://downloads.topazlabs.com/deploy/TopazGigapixel/#{version}/TopazGigapixel-#{version}.pkg"
+  version "1.2.0"
+  sha256 arm:   "f23a4e4b51d25c669c620b7a64eda1ed64014af2c0abf564107e39d44ce65e9b",
+         intel: "b7db2dd3b927461dc7066afc342afb39fff4459e2a3ede451fb2839c9c08475d"
+
+  url "https://downloads.topazlabs.com/deploy/TopazGigapixel/#{version}/TopazGigapixel-#{version}-#{arch}.pkg"
   name "Topaz Gigapixel"
   desc "AI image upscaler"
   homepage "https://www.topazlabs.com/topaz-gigapixel"
 
   livecheck do
-    url "https://topazlabs.com/d/gigapixelstudio/latest/mac/full"
+    url "https://topazlabs.com/d/gigapixelstudio/latest/mac#{livecheck_arch}/full"
+    regex(/TopazGigapixel[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}/i)
     strategy :header_match
   end
 
   auto_updates true
-  depends_on arch: :arm64
   depends_on macos: :monterey
 
-  pkg "TopazGigapixel-#{version}.pkg"
+  pkg "TopazGigapixel-#{version}-#{arch}.pkg"
 
   uninstall pkgutil: "com.topazlabs.TopazGigapixel",
             delete:  [
+              "/Applications/Topaz Gigapixel.app",
               "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixel.plugin",
               "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelApply.plugin",
               "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelAutomate.plugin",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`topaz-gigapixel` is autobumped but the workflow failed to update to version 1.2.0 because upstream now offers an Intel version alongside the ARM version, so the file names have an arch suffix. This updates the version and adjusts the cask to handle both architectures, using the existing approach in the `topaz-photo` cask.