### PR TITLE
wetype 2.1.0

### DIFF
--- a/Casks/w/wetype.rb
+++ b/Casks/w/wetype.rb
@@ -1,8 +1,8 @@
 cask "wetype" do
-  version "2.0.1,581"
-  sha256 "b1ecc57e7d4595e1306a73095c5a9c808b8dbc67f95ddeabc68a2a5b4609d7f5"
+  version "2.1.0,601"
+  sha256 "bb75e2f50ec94e02c38c488e719d7ac7197a00b13bd697016647fc65b9f039de"
 
-  url "https://download.z.weixin.qq.com/app/mac/#{version.csv.first}/WeTypeInstaller_#{version.csv.first}_#{version.csv.second}.zip"
+  url "https://download.weread.qq.com/app/wxkb/mac/#{version.csv.first}/WeType_#{version.csv.first}_#{version.csv.second}.zip"
   name "WeType"
   name "微信输入法"
   desc "Text input app from WeChat team for Chinese users"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`wetype` is autobumped but the workflow failed to update to version 2.1.0 because the asset URL is now different. This updates the version and modifies the cask `url` to use the URL that the JSON file in the `livecheck` block links to, which is the same zip file that the installer uses.