### PR TITLE
whale 3.0.0

### DIFF
--- a/Casks/w/whale.rb
+++ b/Casks/w/whale.rb
@@ -1,15 +1,29 @@
 cask "whale" do
-  version "2.4.0"
-  sha256 "63857d17bf6d44c65215d729870737a17153f33c01605dc093626b7185731b02"
+  arch arm: "-arm64"
 
-  url "https://github.com/1000ch/whale/releases/download/v#{version}/Whale-#{version}.dmg"
+  on_arm do
+    version "3.0.0"
+    sha256 "80696c337b94274b5acd053d668dfc54d7fa608ee293470a3804e0ab285f8a5a"
+
+    depends_on macos: ">= :monterey"
+  end
+  on_intel do
+    version "2.4.0"
+    sha256 "63857d17bf6d44c65215d729870737a17153f33c01605dc093626b7185731b02"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: ">= :catalina"
+  end
+
+  url "https://github.com/1000ch/whale/releases/download/v#{version}/Whale-#{version}#{arch}.dmg"
   name "Whale"
   desc "Unofficial Trello app"
   homepage "https://github.com/1000ch/whale"
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
-  depends_on :macos
 
   app "Whale.app"
 
@@ -21,8 +35,4 @@ cask "whale" do
     "~/Library/Preferences/net.1000ch.whale.plist",
     "~/Library/Saved Application State/net.1000ch.whale.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`whale` is autobumped but the workflow failed to update to version 3.0.0 because the macOS app seems to be ARM-only now. The previous version was from 2021-03-06 and the build setup seems to have changed. Unless/until upstream offers an Intel version again, I've set this up so that the ARM version can be updated and Intel will say on the old 2.4.0 version.