### PR TITLE
choragus 4.10 (new cask)

### DIFF
--- a/Casks/c/choragus.rb
+++ b/Casks/c/choragus.rb
@@ -1,0 +1,24 @@
+cask "choragus" do
+  version "4.10"
+  sha256 "23f14cdfeebe933144ed83578d330f14ae1bbaa53478e8ab7f7f1b59d6e91c44"
+
+  url "https://github.com/scottwaters/Choragus/releases/download/v#{version}/Choragus.dmg"
+  name "Choragus"
+  desc "Sonos controller"
+  homepage "https://github.com/scottwaters/Choragus"
+
+  livecheck do
+    url "https://scottwaters.github.io/Choragus/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Choragus.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.choragus.app",
+    "~/Library/Containers/com.choragus.app",
+  ]
+end


### PR DESCRIPTION
- **choragus (new cask)**
- **choragus: fix livecheck version**

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online choragus` is error-free.
- [x] `brew style --fix choragus` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=choragus%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new choragus` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask choragus` worked successfully.
- [x] `brew uninstall --cask choragus` worked successfully.

-----

- [x] AI was used to draft the initial `choragus` cask (stanzas including `livecheck` and `zap`). I manually reviewed the result, verified the DMG contains `Choragus.app`, and ran:
- `brew style --fix choragus`
- `brew audit --cask --online choragus`
- `brew audit --cask --strict choragus`
- `brew audit --cask --new choragus`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask choragus`
- `brew uninstall --cask choragus`

zap: verified paths after running the app; Choragus is sandboxed, so data
lives under `~/Library/Containers/com.choragus.app` and
`~/Library/Application Scripts/com.choragus.app` — not top-level `Application
Support/Caches/Preferences`. Zap updated to match observed paths only.

-----
