### PR TITLE
macmd-viewer 1.2.1 (new cask)

### DIFF
--- a/Casks/m/macmd-viewer.rb
+++ b/Casks/m/macmd-viewer.rb
@@ -2,8 +2,7 @@ cask "macmd-viewer" do
   version "1.2.1"
   sha256 "a189d96898f47d8fdf609269abf454d122a8699949cca7549af176d43cea10db"
 
-  url "https://macmdviewer.com/downloads/v#{version}/MacMDViewer.dmg",
-      verified: "macmdviewer.com/downloads/"
+  url "https://macmdviewer.com/downloads/v#{version}/MacMDViewer.dmg"
   name "MacMD Viewer"
   desc "Native SwiftUI Markdown viewer with QuickLook and Mermaid support"
   homepage "https://macmdviewer.com/"

--- a/Casks/m/macmd-viewer.rb
+++ b/Casks/m/macmd-viewer.rb
@@ -13,7 +13,7 @@ cask "macmd-viewer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "MacMD Viewer.app"
 

--- a/Casks/m/macmd-viewer.rb
+++ b/Casks/m/macmd-viewer.rb
@@ -2,14 +2,14 @@ cask "macmd-viewer" do
   version "1.2.1"
   sha256 "a189d96898f47d8fdf609269abf454d122a8699949cca7549af176d43cea10db"
 
-  url "https://github.com/macmdviewer/MacMDViewer/releases/download/v#{version}/MacMDViewer.dmg",
-      verified: "github.com/macmdviewer/MacMDViewer/"
+  url "https://macmdviewer.com/downloads/v#{version}/MacMDViewer.dmg",
+      verified: "macmdviewer.com/downloads/"
   name "MacMD Viewer"
-  desc "Native SwiftUI Markdown viewer for macOS with QuickLook and Mermaid support"
-  homepage "https://macmdviewer.com"
+  desc "Native SwiftUI Markdown viewer with QuickLook and Mermaid support"
+  homepage "https://macmdviewer.com/"
 
   livecheck do
-    url :url
+    url "https://github.com/macmdviewer/MacMDViewer/releases/latest"
     strategy :github_latest
   end
 

--- a/Casks/m/macmd-viewer.rb
+++ b/Casks/m/macmd-viewer.rb
@@ -1,0 +1,27 @@
+cask "macmd-viewer" do
+  version "1.2.1"
+  sha256 "a189d96898f47d8fdf609269abf454d122a8699949cca7549af176d43cea10db"
+
+  url "https://github.com/macmdviewer/MacMDViewer/releases/download/v#{version}/MacMDViewer.dmg",
+      verified: "github.com/macmdviewer/MacMDViewer/"
+  name "MacMD Viewer"
+  desc "Native SwiftUI Markdown viewer for macOS with QuickLook and Mermaid support"
+  homepage "https://macmdviewer.com"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "MacMD Viewer.app"
+
+  zap trash: [
+    "~/Library/Caches/com.arthur.MarkdownViewer",
+    "~/Library/HTTPStorages/com.arthur.MarkdownViewer",
+    "~/Library/Preferences/com.arthur.MarkdownViewer.plist",
+    "~/Library/Saved Application State/com.arthur.MarkdownViewer.savedState",
+  ]
+end

--- a/Casks/m/macmd-viewer.rb
+++ b/Casks/m/macmd-viewer.rb
@@ -4,7 +4,7 @@ cask "macmd-viewer" do
 
   url "https://macmdviewer.com/downloads/v#{version}/MacMDViewer.dmg"
   name "MacMD Viewer"
-  desc "Native SwiftUI Markdown viewer with QuickLook and Mermaid support"
+  desc "Markdown viewer with QuickLook and Mermaid support"
   homepage "https://macmdviewer.com/"
 
   livecheck do


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions). v1.2.1 is the current stable production release; pre-release tags are explicitly suffixed \`-beta.N\` and excluded.
- [ ] \`brew audit --cask --online macmd-viewer\` is error-free. (Will verify locally before maintainer review.)
- [ ] \`brew style --fix macmd-viewer\` reports no offenses. (Will verify locally before maintainer review.)

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference). \`macmd-viewer\` — hyphenated lowercase form of the product name.
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+macmd+viewer&type=pullrequests). No prior submission found.
- [ ] \`brew audit --cask --new macmd-viewer\` worked successfully. (Will verify locally.)
- [ ] \`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask macmd-viewer\` worked successfully. (Will verify locally.)
- [ ] \`brew uninstall --cask macmd-viewer\` worked successfully. (Will verify locally.)

---

- [x] AI was used to generate or assist with generating this PR.

  AI assistance: I (Arthur Teboul, dev of MacMD Viewer) used Claude Code to draft the cask file and this PR description. The cask formula was modeled on existing similar casks (\`marked.rb\`, \`typora.rb\`, \`obsidian.rb\`). The \`zap\` paths were verified against the actual files MacMD Viewer creates: app caches under \`~/Library/Caches/com.arthur.MarkdownViewer\`, HTTPStorages, preferences plist, saved application state. SHA256 was computed locally with \`shasum -a 256\` on the DMG downloaded from the public GitHub release v1.2.1. I will run the local audit/install/uninstall checks before requesting maintainer review.

---

### About MacMD Viewer

[MacMD Viewer](https://macmdviewer.com) is a native SwiftUI Markdown viewer for macOS:

- 2 MB on disk, ~30 MB RAM, Apple Silicon native, launches in under 0.5s
- QuickLook extension (press Space on any \`.md\` file in Finder)
- Renders GFM tables, Mermaid diagrams (flowchart/sequence/Gantt/ER/mindmap), KaTeX math, syntax highlighting for 180+ languages
- Read-only by design — pairs with any editor (Cursor, Vim, VS Code, Obsidian)
- File watcher: re-renders when the file is saved externally
- Signed (Developer ID Application), notarized, Sparkle EdDSA auto-updates
- \$19.99 one-time license activated in-app after install (the DMG itself is freely downloadable, consistent with [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks#but-the-vendors-canonical-form-is-not-an-installer))

In production since v1.1.0 (released 2026-04-14), iterative releases through v1.2.1. Public release repository: [\`macmdviewer/MacMDViewer\`](https://github.com/macmdviewer/MacMDViewer).