### PR TITLE
perplexity 26.19.0 (new cask)

### DIFF
--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,9 +1,8 @@
 cask "perplexity" do
-  version "26.19.0"
-  sha256 "20f86784c170c4d733eab8b80df246aa7f5190f87ffda15241b8c64022b2be9f"
+  version :latest
+  sha256 :no_check
 
-  url "https://macos-download.perplexity.ai/Perplexity.dmg",
-      verified: "macos-download.perplexity.ai/"
+  url "https://macos-download.perplexity.ai/Perplexity.dmg"
   name "Perplexity"
   desc "AI-powered answer engine with agentic search capabilities"
   homepage "https://www.perplexity.ai/"

--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,5 +1,5 @@
 cask "perplexity" do
-  version :latest
+  version "26.19.0"
   sha256 :no_check
 
   url "https://macos-download.perplexity.ai/Perplexity.dmg"

--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,0 +1,28 @@
+cask "perplexity" do
+  version "26.19.0"
+  sha256 "20f86784c170c4d733eab8b80df246aa7f5190f87ffda15241b8c64022b2be9f"
+
+  url "https://macos-download.perplexity.ai/Perplexity.dmg",
+      verified: "macos-download.perplexity.ai/"
+  name "Perplexity"
+  desc "AI-powered answer engine with agentic search capabilities"
+  homepage "https://www.perplexity.ai/"
+
+  livecheck do
+    url "https://macos-download.perplexity.ai/appcast.xml"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Perplexity.app"
+
+  zap trash: [
+    "~/Library/Application Support/Perplexity",
+    "~/Library/Caches/ai.perplexity.macv3",
+    "~/Library/HTTPStorages/ai.perplexity.macv3",
+    "~/Library/Logs/Perplexity",
+    "~/Library/Preferences/ai.perplexity.macv3.plist",
+    "~/Library/Saved Application State/ai.perplexity.macv3.savedState",
+  ]
+end


### PR DESCRIPTION
## Description

Adds a cask for [Perplexity](https://www.perplexity.ai/), an AI-powered answer engine. This submission is for the new **Personal Computer** native Mac app (released May 2026), which is distributed as a **direct DMG download only** — it is not available on the Mac App Store, making it eligible for inclusion in homebrew-cask.

> Note: A previous request to add Perplexity was declined ([Discussion #6444](https://github.com/orgs/Homebrew/discussions/6444)) because the app was only on the Mac App Store. The new Personal Computer app changes this.

## Cask info

- **Homepage**: https://www.perplexity.ai/
- **Download**: https://macos-download.perplexity.ai/Perplexity.dmg
- **Version**: 26.19.0
- **SHA256**: `20f86784c170c4d733eab8b80df246aa7f5190f87ffda15241b8c64022b2be9f`
- **Min macOS**: Sonoma (14)
- **Bundle ID**: `ai.perplexity.macv3`

## Known issue: Cloudflare protection

The download domain `macos-download.perplexity.ai` is behind Cloudflare's managed challenge, which blocks plain `curl` requests (HTTP 403). This also affects the Sparkle appcast at `https://macos-download.perplexity.ai/appcast.xml` used for livecheck.

This may require Perplexity to whitelist Homebrew's download infrastructure, or an alternative CDN URL to be identified. Happy to follow up with Perplexity's team if the maintainers can confirm whether this is a blocker.

## Checklist

- [x] `brew style` passes with no offenses
- [x] `app` stanza verified by mounting the DMG
- [x] `zap` paths verified against bundle ID `ai.perplexity.macv3`
- [x] `depends_on macos: ">= :sonoma"` matches `LSMinimumSystemVersion: 14.7`
- [ ] `brew audit --new --cask perplexity` — blocked by Cloudflare during local testing