### PR TITLE
claude-code@latest 2.1.139

### DIFF
--- a/Casks/c/claude-code@latest.rb
+++ b/Casks/c/claude-code@latest.rb
@@ -2,11 +2,11 @@ cask "claude-code@latest" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.1.138"
-  sha256 arm:          "759d23ce626193c89bc8b35c5c6ca8a9e33b9c2e504ee143e4cd119988774097",
-         x86_64:       "d99d3a7afd63841943906b11ed8791b0ee47fe5cf95601a8b805c20900014f54",
-         x86_64_linux: "c3c56ffbc12cf16e40c33687c9fe6361ed250c35a9e1718d0c38d49049f5f8c3",
-         arm64_linux:  "693ecca41a62d58fee660884bd982ca5cdeab5b277925fcdfe880cdf02f98671"
+  version "2.1.139"
+  sha256 arm:          "aa8a0a39f2abbd9e09518eb7268cda105b8029620a38f5a5cbc362b65331c3db",
+         x86_64:       "12303d03814e76e8d09fb989286e88b7c5865facd00d71bc790112dae087acef",
+         x86_64_linux: "c1800a0ae51b5a4c7b33be6a32d62b6169d93f6174119b2eeb6896cf0cd5d7e6",
+         arm64_linux:  "3985aaf75b3bff1d8d031b726c804e4152e1530261683cdce14e954f0af2c912"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION
claude-code@latest 2.1.139

-------

autobump error https://github.com/Homebrew/homebrew-cask/actions/runs/25715998390/job/75506387769#step:5:103

```
==> Downloading https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.139/darwin-x64/claude
Error: Could not find 'version' stanza with value "2.1.138"!
Error: Process completed with exit code 1.
```