### PR TITLE
font-space-mono: deprecate

### DIFF
--- a/Casks/font/font-s/font-space-mono.rb
+++ b/Casks/font/font-s/font-space-mono.rb
@@ -2,9 +2,11 @@ cask "font-space-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/googlefonts/spacemono/archive/refs/heads/master.tar.gz"
+  url "https://github.com/googlefonts/spacemono/archive/refs/heads/main.tar.gz"
   name "Space Mono"
   homepage "https://github.com/googlefonts/spacemono"
+
+  deprecate! date: "2026-05-12", because: :discontinued
 
   font "spacemono-main/fonts/ttf/SpaceMono-Bold.ttf"
   font "spacemono-main/fonts/ttf/SpaceMono-BoldItalic.ttf"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free. *(Could not run locally — Command Line Tools outdated on dev machine. Will rely on CI.)*
- [x] `brew style --fix <cask>` reports no offenses.

-----

- [ ] AI was used to generate or assist with generating this PR.

-----

Upstream repository [`googlefonts/spacemono`](https://github.com/googlefonts/spacemono) has been archived since 2025-01-17 and is no longer maintained.

Also fixed the broken source URL: the repository's default branch was renamed from `master` to `main`, so the old `archive/refs/heads/master.tar.gz` URL was 404ing.

Flagged by the testbot in #172732.