### PR TITLE
kdenlive 26.04.1

### DIFF
--- a/Casks/k/kdenlive.rb
+++ b/Casks/k/kdenlive.rb
@@ -1,14 +1,9 @@
 cask "kdenlive" do
   arch arm: "arm64", intel: "x86_64"
 
-  on_arm do
-    version "26.04.0,A"
-    sha256 "b17a09c29b81b1651da15d92c0c33f3d1e977ebe2849ef68233eb33abd624900"
-  end
-  on_intel do
-    version "26.04.0"
-    sha256 "68b435007621152a875201f761ab27c05267bb7f5d96bf17d2104587381fb913"
-  end
+  version "26.04.1"
+  sha256 arm:   "cd0be82b9d6b48915d8c2f6bb30f580b9809279bf0517ab7c2435a731ab733fc",
+         intel: "3bc350e152a3e1485f8d8c9c8411f94b58a36acc2df3ec784a6e6dfa9be4e1d8"
 
   url "https://cdn.download.kde.org/stable/kdenlive/#{version.csv.first.major_minor}/macOS/kdenlive-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}-#{arch}.dmg",
       verified: "cdn.download.kde.org/stable/kdenlive/"
@@ -24,7 +19,7 @@ cask "kdenlive" do
     end
   end
 
-  depends_on macos: :big_sur
+  depends_on macos: :ventura
 
   app "kdenlive.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Update `kdenlive` to 26.04.1

There has been some discussion about the versioning conventions with the past few kdenlive releases (see #263069), however no signifcant changes to `livecheck` has been made. This pull request simply updates the release version and sha256. Since both `arm64` and `x86_64` releases have the same version, the additional `,A` was removed and the versions combined. The minimum MacOS version was updated to `ventura` to match the requirements stated on the [source website](https://kdenlive.org/download/).