### PR TITLE
cask copilot-cli@prerelease: remove unsupported shell completion generation

### DIFF
--- a/Casks/c/copilot-cli@prerelease.rb
+++ b/Casks/c/copilot-cli@prerelease.rb
@@ -37,7 +37,5 @@ cask "copilot-cli@prerelease" do
 
   binary "copilot"
 
-  generate_completions_from_executable "copilot", "completion"
-
   zap trash: "~/.copilot"
 end


### PR DESCRIPTION
## Summary

The `generate_completions_from_executable "copilot", "completion"` stanza causes three warnings on every install and upgrade because the GitHub Copilot CLI does not implement the standard `completion <shell>` subcommand.

**Observed behavior:**
```
Warning: Failed to generate bash completions from .../copilot: Failure while executing;
`copilot completion bash` exited with 1.
error: Invalid command format.
Did you mean: copilot -i "completion bash"?
For non-interactive mode, use the -p or --prompt option.
```

The CLI is interactive-first; it uses `-i` for interactive mode and `-p` for non-interactive prompts. There is no `completion <shell>` subcommand.

## Fix

Remove the `generate_completions_from_executable` line. Shell completions can be re-added once the upstream CLI implements a compatible completion interface.

## Test

```bash
brew install --cask copilot-cli@prerelease
# No completion warnings should appear
```