### PR TITLE
Add stockdock 1.0

### DIFF
--- a/Casks/s/stockdock.rb
+++ b/Casks/s/stockdock.rb
@@ -1,0 +1,20 @@
+cask "stockdock" do
+  version "1.0"
+  sha256 "37ef0bdb5b02501e538fc833ad84a55c5af7c866d190db2e0c4cbd05b65b9081"
+
+  url "https://github.com/simonsruggi/StockDock/releases/download/v#{version}/StockDock.zip",
+      verified: "github.com/simonsruggi/StockDock/"
+  name "StockDock"
+  desc "Menu bar app to track stocks and portfolios in real time"
+  homepage "https://github.com/simonsruggi/StockDock"
+
+  depends_on macos: ">= :sonoma"
+
+  app "StockDock.app"
+
+  zap trash: [
+    "~/Library/Application Support/StockDock",
+    "~/Library/Caches/com.simone.stockdock",
+    "~/Library/Preferences/com.simone.stockdock.plist",
+  ]
+end


### PR DESCRIPTION
## Description

StockDock is a free, lightweight macOS menu bar app for tracking stocks and portfolios in real time. Built with SwiftUI, no account required, no API keys needed — data comes directly from Yahoo Finance.

**Homepage:** https://github.com/simonsruggi/StockDock
**Release:** https://github.com/simonsruggi/StockDock/releases/tag/v1.0

### Features

- Menu bar P&L display with 8 configurable modes
- Watchlist with live prices and daily change
- Multiple portfolios with holdings and P&L tracking
- Pre-market and after-hours prices
- Currency conversion (EUR, USD, GBP, CHF, JPY, CAD, AUD)
- Auto-updates via Sparkle