### PR TITLE
Add stockdock 1.0

### DIFF
--- a/Casks/s/stockdock.rb
+++ b/Casks/s/stockdock.rb
@@ -1,0 +1,19 @@
+cask "stockdock" do
+  version "1.0"
+  sha256 "d6526f64bceb3eedfc6a2abf7479693b4311c022f9d3c39eeeb52e4c85fafb27"
+
+  url "https://github.com/simonsruggi/StockDock/releases/download/v#{version}/StockDock.zip"
+  name "StockDock"
+  desc "Menu bar app to track stocks and portfolios in real time"
+  homepage "https://github.com/simonsruggi/StockDock"
+
+  depends_on macos: :sonoma
+
+  app "StockDock.app"
+
+  zap trash: [
+    "~/Library/Application Support/StockDock",
+    "~/Library/Caches/com.simone.stockdock",
+    "~/Library/Preferences/com.simone.stockdock.plist",
+  ]
+end


### PR DESCRIPTION
## Description

StockDock is a free, lightweight macOS menu bar app for tracking stocks and portfolios in real time. Built with SwiftUI, no account required, no API keys needed — data comes directly from Yahoo Finance.

The app is signed and notarized with Developer ID Application certificate.

**Homepage:** https://github.com/simonsruggi/StockDock
**Release:** https://github.com/simonsruggi/StockDock/releases/tag/v1.0