### PR TITLE
presentify 8.0.4 (new cask)

### DIFF
--- a/Casks/p/presentify.rb
+++ b/Casks/p/presentify.rb
@@ -1,0 +1,28 @@
+cask "presentify" do
+  version "8.0.4"
+  sha256 "a16a3f69582a9db996c3dd81072bab161156e2eb0a0e421297974bba1669ddef"
+
+  url "https://rampatra.github.io/presentify-updates/Presentify-#{version}.dmg",
+      verified: "rampatra.github.io/presentify-updates/"
+  name "Presentify"
+  desc "Annotate screens, highlight cursors, and spotlight or zoom key areas"
+  homepage "https://presentifyapp.com/"
+
+  livecheck do
+    url "https://rampatra.github.io/presentify-updates/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "Presentify.app"
+
+  zap trash: [
+    "~/Library/Application Support/Presentify",
+    "~/Library/Caches/com.rampatra.presentify",
+    "~/Library/HTTPStorages/com.rampatra.presentify",
+    "~/Library/Preferences/com.rampatra.presentify.plist",
+    "~/Library/Saved Application State/com.rampatra.presentify.savedState",
+  ]
+end

--- a/Casks/p/presentify.rb
+++ b/Casks/p/presentify.rb
@@ -19,10 +19,9 @@ cask "presentify" do
   app "Presentify.app"
 
   zap trash: [
-    "~/Library/Application Support/Presentify",
     "~/Library/Caches/com.rampatra.presentify",
     "~/Library/HTTPStorages/com.rampatra.presentify",
     "~/Library/Preferences/com.rampatra.presentify.plist",
-    "~/Library/Saved Application State/com.rampatra.presentify.savedState",
+    "~/Library/Preferences/presentify-user-defaults-suite.plist",
   ]
 end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online presentify` is error-free.
- [x] `brew style --fix presentify` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask name to the end of the search field).
- [x] `brew audit --cask --new presentify` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask presentify` worked successfully.
- [x] `brew uninstall --cask presentify` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI helped draft the cask and run local verification. I verified the DMG contains `Presentify.app`, the app is accepted as Notarized Developer ID, `brew livecheck --cask presentify` returns `8.0.4`, audit/style pass, and install/uninstall work using a temporary appdir. The `zap` paths are based on the bundle identifier `com.rampatra.presentify` and common Application Support, Caches, HTTPStorages, Preferences, and Saved Application State locations.

-----