### PR TITLE
executor 1.4.28 (new cask)

### DIFF
--- a/Casks/e/executor-desktop.rb
+++ b/Casks/e/executor-desktop.rb
@@ -1,0 +1,34 @@
+cask "executor-desktop" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.4.28"
+  sha256 arm:   "b1e5a8f370ac93914b20b85071e282828ae736b9c3a32e921ea3558b432c4add",
+         intel: "29de91639428e2b82b6c50688ee4ce0824e5e3ce1246948ed7b10e21bdd3dfc7"
+
+  url "https://github.com/RhysSullivan/executor/releases/download/v#{version}/executor-desktop-mac-#{arch}.dmg",
+      verified: "github.com/RhysSullivan/executor/"
+  name "Executor"
+  desc "Tool discovery and execution layer for AI agents"
+  homepage "https://executor.sh/"
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Executor.app"
+
+  uninstall quit: "sh.executor.desktop"
+
+  zap trash: [
+    "~/.executor",
+    "~/.local/share/executor",
+    "~/Library/Application Support/@executor-js/desktop",
+    "~/Library/Application Support/Executor",
+    "~/Library/Caches/sh.executor.desktop",
+    "~/Library/Caches/sh.executor.desktop.ShipIt",
+    "~/Library/HTTPStorages/sh.executor.desktop",
+    "~/Library/HTTPStorages/sh.executor.desktop.binarycookies",
+    "~/Library/Logs/Executor",
+    "~/Library/Preferences/sh.executor.desktop.plist",
+    "~/Library/Saved Application State/sh.executor.desktop.savedState",
+  ]
+end

--- a/Casks/e/executor.rb
+++ b/Casks/e/executor.rb
@@ -1,4 +1,4 @@
-cask "executor-desktop" do
+cask "executor" do
   arch arm: "arm64", intel: "x64"
 
   version "1.4.28"


### PR DESCRIPTION
Adds a new cask for [Executor](https://executor.sh/)

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

I opened the app, added some config, ran `brew uninstall --cask` then reinstalled and confirmed the source persisted. I then ran `brew uninstall --zap --cask` then reinstalled and confirmed fresh empty state. This means removing `~/.executor` which is probably a bit unusual - happy to change that if desired.