### PR TITLE
Add Burrete cask

### DIFF
--- a/Casks/b/burrete.rb
+++ b/Casks/b/burrete.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "burrete" do
-  version "0.10.31"
-  sha256 "0345b0e2a3c1a6b1b2e9b4331f38678fdc3127e19099e96d7bbee830d86519ca"
+  version "0.10.33"
+  sha256 "8f0f2ba2d1886a37132290c261741f55a88068d75110b7946e533e4841f6d0d6"
 
   url "https://github.com/SergeiNikolenko/Burrete/releases/download/v#{version}/Burrete-#{version}.zip"
   name "Burrete"

--- a/Casks/b/burrete.rb
+++ b/Casks/b/burrete.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+cask "burrete" do
+  version "0.10.31"
+  sha256 "0345b0e2a3c1a6b1b2e9b4331f38678fdc3127e19099e96d7bbee830d86519ca"
+
+  url "https://github.com/SergeiNikolenko/Burrete/releases/download/v#{version}/Burrete-#{version}.zip"
+  name "Burrete"
+  desc "Finder-native molecular structure previews"
+  homepage "https://github.com/SergeiNikolenko/Burrete"
+
+  depends_on macos: ">= :monterey"
+
+  app "Burrete.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.local.BurreteV10",
+    "~/Library/Caches/com.local.BurreteV10",
+    "~/Library/Containers/com.local.BurreteV10",
+    "~/Library/Containers/com.local.BurreteV10.Preview",
+  ]
+
+  caveats <<~EOS
+    Open Burrete once after installation so macOS registers the Quick Look extension.
+  EOS
+end


### PR DESCRIPTION
Add Burrete, a macOS Quick Look extension and menu bar app for molecular structure previews.

The release asset is hosted on GitHub Releases and the SHA-256 is taken from the uploaded asset digest.