### PR TITLE
notion-cli 0.13.2 (new cask)

### DIFF
--- a/Casks/n/notion-cli.rb
+++ b/Casks/n/notion-cli.rb
@@ -1,4 +1,4 @@
-cask "notion-cli@beta" do
+cask "notion-cli" do
   arch arm: "aarch64", intel: "x86_64"
   os macos: "apple-darwin", linux: "unknown-linux-musl"
 

--- a/Casks/n/notion-cli@beta.rb
+++ b/Casks/n/notion-cli@beta.rb
@@ -1,0 +1,25 @@
+cask "notion-cli@beta" do
+  arch arm: "aarch64", intel: "x86_64"
+  os macos: "apple-darwin", linux: "unknown-linux-musl"
+
+  version "0.13.2"
+  sha256 arm:          "40ce5ed7490f9371bc52a28918723f5c2010bf7d9b7a7b30273d8b63b30d5054",
+         intel:        "18dd6f6c289d24f6ef609160923d4ca02f66ea46910b45feae44a028096d7254",
+         arm64_linux:  "21c6b57dd7e7dbf8bd653191b3b8c0c0142042c24939ebab46048a7b9f22e2e7",
+         x86_64_linux: "44bbcf91e113bd33ef5275d1ee45160f4463bddae53beaeb381273f797d349c9"
+
+  url "https://ntn.dev/releases/v#{version}/ntn-#{arch}-#{os}.tar.gz",
+      verified: "ntn.dev/"
+  name "Notion CLI"
+  desc "Command-line interface for Notion"
+  homepage "https://www.notion.com/product/dev"
+
+  livecheck do
+    url "https://ntn.dev/latest.txt"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  binary "ntn-#{arch}-#{os}/ntn"
+
+  zap trash: "~/.notion"
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.5 (25F71).

Adds the Notion CLI cask for the official `ntn` binary.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with cask scaffolding and release/source checks. I verified the official installer URL, checksums, archive contents, `ntn --version`, and the `zap` path with `ntn doctor` using a fake home directory.

-----
