### PR TITLE
Add switch-mac

### DIFF
--- a/Casks/s/switch-mac.rb
+++ b/Casks/s/switch-mac.rb
@@ -1,0 +1,27 @@
+cask "switch-mac" do
+  version "0.1.7"
+  sha256 "bb59c30e0a38c776d162ef2d12096c2a5ed50065b2e45e9a66476465ea8d0e8d"
+
+  url "https://github.com/Sanyam-G/switch/releases/download/v#{version}/Switch-#{version}.dmg",
+      verified: "github.com/Sanyam-G/switch/"
+  name "Switch"
+  desc "Keyboard-driven window switcher that cycles windows, not apps"
+  homepage "https://switch-dev.sanyamgarg.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Switch.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.sanyamgarg.switch",
+    "~/Library/Caches/com.sanyamgarg.switch",
+    "~/Library/Containers/com.sanyamgarg.switch",
+    "~/Library/Preferences/com.sanyamgarg.switch.plist",
+    "~/Library/Saved Application State/com.sanyamgarg.switch.savedState",
+  ]
+end

--- a/Casks/s/switch-mac.rb
+++ b/Casks/s/switch-mac.rb
@@ -1,6 +1,6 @@
 cask "switch-mac" do
-  version "0.1.7"
-  sha256 "51458ccc415b4ad2e311a6da3d4af941b1e61428ba3c90a9775e8dda5cd074cc"
+  version "0.1.8"
+  sha256 "d28b18c0f57e9caa23b04fd6ac1d54f0c6d7241642953d853440b84431ec91bd"
 
   url "https://github.com/Sanyam-G/switch/releases/download/v#{version}/Switch-#{version}.dmg",
       verified: "github.com/Sanyam-G/switch/"

--- a/Casks/s/switch-mac.rb
+++ b/Casks/s/switch-mac.rb
@@ -1,6 +1,6 @@
 cask "switch-mac" do
   version "0.1.7"
-  sha256 "bb59c30e0a38c776d162ef2d12096c2a5ed50065b2e45e9a66476465ea8d0e8d"
+  sha256 "51458ccc415b4ad2e311a6da3d4af941b1e61428ba3c90a9775e8dda5cd074cc"
 
   url "https://github.com/Sanyam-G/switch/releases/download/v#{version}/Switch-#{version}.dmg",
       verified: "github.com/Sanyam-G/switch/"


### PR DESCRIPTION
Switch — keyboard-driven window switcher for macOS. ⌘-Tab cycles windows, not apps.

I am the author and maintainer.

- Source: https://github.com/Sanyam-G/switch
- Homepage: https://switch-dev.sanyamgarg.com
- macOS 14+, notarized + Developer ID signed, FSL-1.1-MIT
- Cask name `switch-mac` because `switch` is taken by an NCH audio converter

- [x] `brew audit --cask --new Casks/s/switch-mac.rb` runs without errors
- [x] `brew style --cask Casks/s/switch-mac.rb` passes
- [x] `brew install --cask Sanyam-G/homebrew-cask/switch-mac` installs cleanly via a local tap