### PR TITLE
flameshot: fix duplicate macOS dependency

### DIFF
--- a/Casks/f/flameshot.rb
+++ b/Casks/f/flameshot.rb
@@ -25,8 +25,6 @@ cask "flameshot" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on :macos
-
   app "flameshot.app"
 
   uninstall quit: "org.flameshot.flameshot"


### PR DESCRIPTION
Fix the following error
`Error: Cask 'flameshot' definition is invalid: Only a single 'depends_on macos' is allowed.`


Was recently introduced on https://github.com/Homebrew/homebrew-cask/commit/1cf331d55db12b182dc41149d745d0b77747f643

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

-----
