### PR TITLE
kanvibe 1.0.0 (new cask)

### DIFF
--- a/Casks/k/kanvibe.rb
+++ b/Casks/k/kanvibe.rb
@@ -1,0 +1,18 @@
+cask "kanvibe" do
+  version "1.0.0"
+  sha256 "657ef07b414305891c5d773d177b0738e90f149515f3f08e0d60d97cf488bd86"
+
+  url "https://github.com/rookedsysc/kanvibe/releases/download/#{version}/KanVibe-#{version}.dmg"
+  name "KanVibe"
+  desc "AI agent task management Kanban board"
+  homepage "https://github.com/rookedsysc/kanvibe"
+
+  depends_on :macos
+
+  app "KanVibe.app"
+
+  zap trash: [
+    "~/Library/Application Support/KanVibe",
+    "~/Library/Preferences/com.kanvibe.desktop.plist",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 10.15.0.

Adds KanVibe, an AI agent task management Kanban board distributed as a macOS DMG.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online kanvibe` is error-free.
- [x] `brew style --fix kanvibe` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new kanvibe` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask kanvibe` worked successfully.
- [x] `brew uninstall --cask kanvibe` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to draft the cask and PR checklist text, and to review the cask against Homebrew Cask Cookbook guidance.

I manually verified the release asset, checksum, cask token, audit/style output, installation, and uninstallation. I also launched KanVibe after installation and verified the `zap` stanza paths are app-created user-specific support/preference files:

- `~/Library/Application Support/KanVibe`
- `~/Library/Preferences/com.kanvibe.desktop.plist`

I verified that these paths are appropriate for `zap` cleanup and do not remove user-created documents outside KanVibe's application data.
