### PR TITLE
hermes-box 0.1.0 (new cask)

### DIFF
--- a/Casks/h/hermes-box.rb
+++ b/Casks/h/hermes-box.rb
@@ -1,0 +1,24 @@
+cask "hermes-box" do
+  version "0.1.0"
+  sha256 "74e0410f3fbd1c93bb6dbe5a99f59f3a07bbbfa09408a3921f35c3b148976702"
+
+  url "https://github.com/BotonJ/Hermes-Box/releases/download/v#{version}/HermesBox-#{version}.tar.gz"
+  name "HermesBox"
+  desc "Cross-platform desktop panel for AI CLIs"
+  homepage "https://github.com/BotonJ/Hermes-Box"
+
+  depends_on macos: ">= :ventura"
+
+  app "HermesBox.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.hermesbox.app",
+    "~/Library/Caches/com.hermesbox.app",
+    "~/Library/LaunchAgents/com.hermesbox.app*.plist",
+    "~/Library/Preferences/com.hermesbox.app.plist",
+  ]
+
+  caveats <<~EOS
+    On first launch, right-click the app and select "Open" to bypass Gatekeeper.
+  EOS
+end


### PR DESCRIPTION
## Summary

Add **hermes-box** — a cross-platform desktop panel for AI CLIs.

- Multi-tab terminal with lazy PTY spawn
- CLI selector: Claude Code, Hermes, OpenClaw, Codex, OpenCode, custom tools
- Approval system for command interception
- Multi-theme presets
- System tray + auto-start

**Homepage:** https://github.com/BotonJ/Hermes-Box

### Checklist

- [x] `brew style --fix Casks/h/hermes-box.rb` passes
- [x] SHA-256 verified against release binary
- [x] `cask "hermes-box"` does not conflict with existing `cask "hermes"` (different app)

### Notes

- First launch requires right-click > Open to bypass Gatekeeper (unsigned binary)
- macOS Ventura+ required