### PR TITLE
duo-desktop 7.17.0.0 (new cask)

### DIFF
--- a/Casks/d/duo-desktop.rb
+++ b/Casks/d/duo-desktop.rb
@@ -1,0 +1,44 @@
+cask "duo-desktop" do
+  version "7.17.0.0"
+  sha256 "c98854b818a82ece79c0d2404d9ae5bc209e47ad26f5c197204ca19ba4c7c4c9"
+
+  url "https://dl.duosecurity.com/DuoDesktop-#{version}.pkg",
+      verified: "dl.duosecurity.com/"
+  name "Duo Desktop"
+  desc "Endpoint health checks for Duo-protected applications"
+  homepage "https://duo.com/docs/duo-desktop"
+
+  livecheck do
+    url "https://duo.com/docs/checksums"
+    regex(/DuoDesktop[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+  end
+
+  depends_on :macos
+
+  pkg "DuoDesktop-#{version}.pkg"
+
+  uninstall launchctl: [
+              "com.duosecurity.duoappupdater",
+              "com.duosecurity.DuoDesktopService",
+              "com.duosecurity.ForceLaunchDuoDesktop",
+              "com.duosecurity.LaunchDuoDesktop",
+              "com.duosecurity.trustedpeermessagebroker",
+            ],
+            pkgutil:   "com.duosecurity.duo-device-health",
+            delete:    [
+              "/Applications/Duo Desktop.app",
+              "/Library/LaunchAgents/com.duosecurity.ForceLaunchDuoDesktop.plist",
+              "/Library/LaunchAgents/com.duosecurity.LaunchDuoDesktop.plist",
+              "/Library/LaunchDaemons/com.duosecurity.duoappupdater.plist",
+              "/Library/LaunchDaemons/com.duosecurity.DuoDesktopService.plist",
+              "/Library/LaunchDaemons/com.duosecurity.trustedpeermessagebroker.plist",
+            ]
+
+  zap trash: [
+    "/Library/Logs/Duo",
+    "~/Library/Caches/com.duosecurity.duo-device-health",
+    "~/Library/Logs/Duo Desktop",
+    "~/Library/Preferences/com.duosecurity.devicehealth.localdata.plist",
+    "~/Library/Preferences/com.duosecurity.duo-device-health.plist",
+  ]
+end

--- a/Casks/d/duo-desktop.rb
+++ b/Casks/d/duo-desktop.rb
@@ -17,7 +17,8 @@ cask "duo-desktop" do
 
   pkg "DuoDesktop-#{version}.pkg"
 
-  uninstall launchctl: [
+  uninstall quit:      "com.duosecurity.duo-device-health",
+            launchctl: [
               "com.duosecurity.duoappupdater",
               "com.duosecurity.DuoDesktopService",
               "com.duosecurity.ForceLaunchDuoDesktop",

--- a/Casks/d/duo-desktop.rb
+++ b/Casks/d/duo-desktop.rb
@@ -17,14 +17,14 @@ cask "duo-desktop" do
 
   pkg "DuoDesktop-#{version}.pkg"
 
-  uninstall quit:      "com.duosecurity.duo-device-health",
-            launchctl: [
+  uninstall launchctl: [
               "com.duosecurity.duoappupdater",
               "com.duosecurity.DuoDesktopService",
               "com.duosecurity.ForceLaunchDuoDesktop",
               "com.duosecurity.LaunchDuoDesktop",
               "com.duosecurity.trustedpeermessagebroker",
             ],
+            quit:      "com.duosecurity.duo-device-health",
             pkgutil:   "com.duosecurity.duo-device-health",
             delete:    [
               "/Applications/Duo Desktop.app",


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->
After making any changes to a cask, existing or new, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

`brew audit` reports one warning: `cask token mentions desktop`. Keeping the token as `duo-desktop` because "Duo Desktop" is the official product name from Duo Security (Cisco), distinguishing it from Duo Mobile and Duo Connect. Precedent for retaining `desktop` in tokens where it is part of the upstream product name: `signal-desktop`, `proton-mail-desktop`, `cherry-studio-desktop`.

-----
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used Claude to scaffold the cask file. Manual verification I performed:

- Confirmed `version` (7.17.0.0) and `sha256` against Duo's official checksums page: https://duo.com/docs/checksums
- Extracted the real `pkgutil` identifier (`com.duosecurity.duo-device-health`) by running `pkgutil --expand` on the downloaded `.pkg` and reading `PackageInfo`
- Installed the pkg manually on macOS and ran `sudo find /Library/Application\ Support /Library/Logs /Library/LaunchAgents /Library/LaunchDaemons ~/Library -iname "*duo*"` to enumerate every file, launch agent, and launch daemon Duo Desktop creates. Populated `uninstall delete:`, `uninstall launchctl:`, and `zap trash:` from that real-world output rather than guessing
- Ran `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask duo-desktop` and `brew uninstall --cask duo-desktop` end-to-end; verified clean teardown of every file in the delete list and all five launchctl services
-----