### PR TITLE
audiocupcake 1.0.19

### DIFF
--- a/Casks/a/audiocupcake.rb
+++ b/Casks/a/audiocupcake.rb
@@ -1,8 +1,8 @@
 cask "audiocupcake" do
-  version "1.0.18"
-  sha256 "904bd9876dbb6bbd272b9bd250057b2421495fa21a88e3cda4392297cadd6fc9"
+  version "1.0.19"
+  sha256 "2b2472daf32dbd9512794a93dc6675159d920eb3950694e1588bc167a04b4dd3"
 
-  url "https://audiocupcake.com/wp-content/uploads/2020/02/AudioCupcake%20#{version}.dmg"
+  url "https://audiocupcake.com/wp-content/uploads/2020/02/AudioCupcake-#{version}.dmg"
   name "AudioCupcake"
   desc "Master your audiobook narration and podcasts"
   homepage "https://www.audiocupcake.com/"
@@ -12,7 +12,7 @@ cask "audiocupcake" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on :macos
+  depends_on macos: :big_sur
 
   app "AudioCupcake.app"
 
@@ -24,8 +24,4 @@ cask "audiocupcake" do
     "~/Library/Preferences/com.sottovoce.AudioCupcake.plist",
     "~/Library/Saved Application State/com.sottovoce.AudioCupcake.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`audiocupcake` is autobumped but the workflow failed to update to version 1.0.19 because the asset file name now uses a hyphen as the delimiter instead of a space. This updates the version and `url` accordingly.