### PR TITLE
after-dark-classic: deprecate

### DIFF
--- a/Casks/a/after-dark-classic.rb
+++ b/Casks/a/after-dark-classic.rb
@@ -7,10 +7,7 @@ cask "after-dark-classic" do
   desc "Classic After Dark screensaver set"
   homepage "https://en.infinisys.co.jp/product/afterdarkclassicset/index.shtml"
 
-  livecheck do
-    url :homepage
-    regex(/After\sDark\sClassic\sSet\s(\d+(?:\.\d+)+)/i)
-  end
+  deprecate! date: "2026-05-14", because: :discontinued
 
   depends_on :macos
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The homepage for `after-dark-classic` no longer contains any download links and instead shows a message saying:

> ## Sales of all products suspended from 29th of March 2026
>
> Infinisys has announced that sales of all of its products have been
> terminated from the 29th of March 2026. We would like to thank all
> those who have supported our products over the years.

This deprecates the cask as discontinued and removes the `livecheck` block accordingly.