### PR TITLE
akuity 0.30.0-rl.2.0.20260514104802-719d0fecc362

### DIFF
--- a/Casks/a/akuity.rb
+++ b/Casks/a/akuity.rb
@@ -2,11 +2,11 @@ cask "akuity" do
   arch arm: "arm64", intel: "amd64"
   os macos: "darwin", linux: "linux"
 
-  version "0.29.0-rc.1.0.20260424100956-84cc6da083dd"
-  sha256 arm:          "9beee0bb460e675e2c50732641cd7248ed3f1438657c57c260e1c039609e6cf1",
-         intel:        "26ab4a47255405df523ad0546e3ef8bf784fab56a91b36cbefb8456e8571dd92",
-         arm64_linux:  "db8c719ae064b5c00641bcf6d6d9ea5eeec9ad38bed1d27e9406e21ea5b351a9",
-         x86_64_linux: "5b2f1b7429d7993ac45eabbe4717937c27c8ba1a8e1434def323fee2f324cf11"
+  version "0.30.0-rl.2.0.20260514104802-719d0fecc362"
+  sha256 arm:          "74ae2e57158ce5533795bf2e56a36ddfaad19a25247e432b83b445d3751ead10",
+         intel:        "e3e7359348e7c13a8914a02e10c3c20b563eae14eff5875b4b480f59c68ee0a6",
+         arm64_linux:  "d85ffaff4284972ce47873e6163aca736a1113f500f10ee94d02bd8572ed0aec",
+         x86_64_linux: "78fdf35fb11f6eee9c0d5e98cd26ce76b68a63b9cb778a7d62895578d85649e7"
 
   url "https://dl.akuity.io/akuity-cli/v#{version}/#{os}/#{arch}/akuity"
   name "Akuity"
@@ -15,7 +15,7 @@ cask "akuity" do
 
   livecheck do
     url "https://dl.akuity.io/akuity-cli/stable.txt"
-    regex(/^v?(\d+(?:\.\d+)+(?:-rc(?:\.\d+)*)?(?:[._-]\d+(?:\.\d+)*)?(?:[_-]?\h+)?)$/i)
+    regex(/^v?(\d+(?:\.\d+)+.*)$/i)
   end
 
   binary "akuity"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`akuity` is autobumped but the workflow failed to update to version 0.30.0-rl.2.0.20260513101032-a5313101acc0 because the `livecheck` block regex tries to specifically match the version format and fails because this version uses a `-rl` suffix but the regex can only optionally match `-rc`. This updates the version and modifies the `livecheck` block regex to loosely match anything after the version. The `stable.txt` file only contains the version text, so this loose regex will ensure that the check doesn't break again for this reason.