### PR TITLE
codebuddy 4.9.5.25622162

### DIFF
--- a/Casks/c/codebuddy.rb
+++ b/Casks/c/codebuddy.rb
@@ -1,11 +1,11 @@
 cask "codebuddy" do
   arch arm: "arm64", intel: "x64"
 
-  version "4.4.2.20019762,f909b20a20,df14f824"
-  sha256 arm:   "4b0f740747b645c5c7a3e62a6a677c1502c2a79202fef57c360f915dfd49ae86",
-         intel: "d03e32577fbf6dce5c54d63b13af6e09c9c33442c5817b96db7153b0ab3fbf98"
+  version "4.9.5.25622162,bae7923c"
+  sha256 arm:   "d98f10aca4e30eab27198d30c486f4da2cbbf6b477c926c65af01eecf77becea",
+         intel: "9d8a650f7e037e775a4b9c9e7aaffb06a01f426513a6df5bc82d3a97340a8943"
 
-  url "https://codebuddy-1328495429.cos.accelerate.myqcloud.com/aiide/darwin-#{arch}/CodeBuddy-darwin-#{arch}-#{version.csv.first}-#{version.csv.second}-#{version.csv.third}.zip",
+  url "https://codebuddy-1328495429.cos.accelerate.myqcloud.com/aiide/darwin-#{arch}/CodeBuddy-darwin-#{arch}-#{version.csv.first}-#{version.csv.second}.zip",
       verified: "codebuddy-1328495429.cos.accelerate.myqcloud.com/aiide/"
   name "CodeBuddy"
   desc "AI-powered adaptive IDE"
@@ -13,12 +13,12 @@ cask "codebuddy" do
 
   livecheck do
     url "https://www.codebuddy.ai/v2/update?platform=ide-darwin-#{arch}&version=1.0.0&x-machine-id=default"
-    regex(%r{/CodeBuddy[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)-(\h+)-(\h+)\.zip}i)
+    regex(%r{/CodeBuddy[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)-(\h+)\.zip}i)
     strategy :json do |json, regex|
       match = json["url"]&.match(regex)
       next if match.blank?
 
-      "#{match[1]},#{match[2]},#{match[3]}"
+      "#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`codebuddy` is autobumped but the workflow failed to update to version 4.9.5.25622162 because the file name now only contains one hexadecimal suffix but the previous version had two. The `livecheck` block regex expects two hex suffixes, so it fails to match the current format. This updates the version and adjusts the cask accordingly.