### PR TITLE
codebuddy-cn 4.9.9.27861944

### DIFF
--- a/Casks/c/codebuddy-cn.rb
+++ b/Casks/c/codebuddy-cn.rb
@@ -1,11 +1,11 @@
 cask "codebuddy-cn" do
   arch arm: "arm64", intel: "x64"
 
-  version "4.7.0.23812295,7d73d160ce,a0234226"
-  sha256 arm:   "a164a221d23bb63737766ffc11a8bbbefd38cd2886f5f58f8a020d481fdd7ece",
-         intel: "7baed8c9412aa30b26f6244697bcc8029efc6bf8bffd7fec6e7ad1d136eaf84e"
+  version "4.9.9.27861944,19255a94"
+  sha256 arm:   "eb689d5aaab6a73220b57249cb2afee680f2bd5929287fbd93afbfe5d6aa6937",
+         intel: "9d9ff4ade4faa5e7110cc6470bb2b82fd2f45c7f7eea7249662a6a9811604e80"
 
-  url "https://acc-1258344699.cos.accelerate.myqcloud.com/aiide/darwin-#{arch}/CodeBuddy-darwin-#{arch}-#{version.csv.first}-#{version.csv.second}-#{version.csv.third}-cn.zip",
+  url "https://acc-1258344699.cos.accelerate.myqcloud.com/aiide/darwin-#{arch}/CodeBuddy-darwin-#{arch}-#{version.csv.first}-#{version.csv.second}-cn.zip",
       verified: "acc-1258344699.cos.accelerate.myqcloud.com/aiide/"
   name "CodeBuddy CN"
   desc "AI-powered adaptive IDE (Chinese version)"
@@ -13,12 +13,12 @@ cask "codebuddy-cn" do
 
   livecheck do
     url "https://copilot.tencent.com/v2/update?platform=ide-darwin-#{arch}&version=1.0.0&x-machine-id=default"
-    regex(%r{/CodeBuddy[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)-(\h+)-(\h+)[._-]cn\.zip}i)
+    regex(%r{/CodeBuddy[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)-(\h+)[._-]cn\.zip}i)
     strategy :json do |json, regex|
       match = json["url"]&.match(regex)
       next if match.blank?
 
-      "#{match[1]},#{match[2]},#{match[3]}"
+      "#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`codebuddy-cn` is autobumped but the workflow failed to update to version 4.9.9.27861944 because the file name now only contains one hexadecimal suffix but the previous version had two. The `livecheck` block regex expects two hex suffixes, so it fails to match the current format. This updates the version and adjusts the cask accordingly.