### PR TITLE
shichizip-zs 0.2.0 (new cask)

### DIFF
--- a/Casks/s/shichizip-zs.rb
+++ b/Casks/s/shichizip-zs.rb
@@ -1,0 +1,24 @@
+cask "shichizip-zs" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "0.2.0"
+  sha256 arm:   "19987c1b9482caa95f3cd3f9c449e2776f91fd458445abf72a79af7e9c55d1a0",
+         intel: "61b573ea7bedbf2632a9d1eabe9a5f8f903139f22427b29d3c97905762375e27"
+
+  url "https://github.com/idawnlight/ShichiZip/releases/download/v#{version}/ShichiZipZS-v#{version}-#{arch}.zip"
+  name "ShichiZip ZS"
+  desc "7-Zip derivative GUI based on mcmilk/7-Zip-zstd"
+  homepage "https://github.com/idawnlight/ShichiZip"
+
+  depends_on macos: :ventura
+
+  app "ShichiZip ZS.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/ee.dawn.ShichiZipZS.OpenInShichiZipAction",
+    "~/Library/Application Scripts/ee.dawn.ShichiZipZS.RevealInFileManagerAction",
+    "~/Library/Application Scripts/ee.dawn.ShichiZipZS.SmartQuickExtractAction",
+    "~/Library/Group Containers/VNM753Y3JX.ShichiZipZS",
+    "~/Library/Preferences/ee.dawn.ShichiZipZS.plist",
+  ]
+end


### PR DESCRIPTION
Add ShichiZipZS, a new Cask. I have tested it with Homebrew 5.1.11-96-g0410293. 

Additional notes:

- ShichiZipZS is the Zstandard fork variant of ShichiZip, officially built and released by upstream alongside the mainline build on every release. It is not a third-party repackage — both ship from the same repo ([idawnlight/ShichiZip](https://github.com/idawnlight/ShichiZip)).
- The two variants are *functionally* distinct: the ZS build is compiled adding Zstandard compression support absent in mainline. Users working with .zst archives may require this specific binary.
- This cask is prepared with reference to the merged `shichizip` cask, https://github.com/Homebrew/homebrew-cask/pull/263599. This PR is advised as discussed in [idawnlight/ShichiZip#22](https://github.com/idawnlight/ShichiZip/issues/22).
- It's my first attempt to commit to this project, and I am willing to help fix any issues if exist. Thanks.
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----