### PR TITLE
linear 1.30.0

### DIFF
--- a/Casks/l/linear.rb
+++ b/Casks/l/linear.rb
@@ -1,27 +1,15 @@
 cask "linear" do
-  arch arm: "arm64", intel: "x64"
+  version "1.30.0"
+  sha256 "81802428822e83a10997f2b5545fc00102c9444ddb340d705754b3517c50fc86"
 
-  version "1.28.13,260318pho1bttxr"
-  sha256 arm:   "acaf0297625baab0e0edaf664556056dc30818a70d0a36b3580f0fde28747ec6",
-         intel: "d7cfb37b547fcf8db984b3712e768e4d0ee53cd5de781d9799040b692ca245df"
-
-  url "https://download.todesktop.com/200315glz2793v6/Linear%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-#{arch}-mac.zip",
-      verified: "download.todesktop.com/200315glz2793v6/"
+  url "https://releases.linear.app/Linear-#{version}-universal.dmg"
   name "Linear"
   desc "App to manage software development and track bugs"
   homepage "https://linear.app/"
 
   livecheck do
-    url "https://download.todesktop.com/200315glz2793v6/latest-mac.yml"
-    regex(/Linear\sv?(\d+(?:\.\d+)+)(?:\s-\sBuild\s([a-z\d]+?))?-#{arch}-mac\.zip/i)
-    strategy :electron_builder do |yaml, regex|
-      yaml["files"]&.map do |item|
-        match = item["url"]&.match(regex)
-        next if match.blank?
-
-        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
-      end
-    end
+    url "https://releases.linear.app/mac"
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
Linear now ships macOS as a universal DMG from `releases.linear.app`. This removes the obsolete per-arch ZIP hashes and ToDesktop livecheck; `header_match` reads the current filename from the official download endpoint.

Tested locally on macOS 26.5.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with updating the cask and explaining the upstream packaging changes. Verified the official download URL, checksum via `brew bump-cask-pr`, livecheck output, online audit, style, and confirmed the `zap` stanza was unchanged.

-----
