### PR TITLE
codeexpander 5.12.3

### DIFF
--- a/Casks/c/codeexpander.rb
+++ b/Casks/c/codeexpander.rb
@@ -1,40 +1,28 @@
 cask "codeexpander" do
-  version "4.3.8"
-  sha256 "993849b21822b62c29b96d70e7ee306e329ed963d0560ca2ecc2b5e7e23d29e1"
+  version "5.12.3"
+  sha256 :no_check
 
-  url "https://github.com/oncework/codeexpander/releases/download/#{version.major_minor}.x/CodeExpander-#{version}.dmg"
+  url "https://download.floweb.cn/CodeExpander_latest_universal.dmg",
+      verified: "download.floweb.cn/"
   name "CodeExpander"
-  desc "Cloud synchronisation development tool"
-  homepage "https://github.com/oncework/codeexpander"
+  desc "Text expansion, screenshot & annotation, and clipboard management tool"
+  homepage "https://codeexpander.com/"
 
   livecheck do
-    url :url
-    regex(/^CodeExpander[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["name"]&.match(regex)
-        next if match.blank?
-
-        match[1]
-      end
+    url "https://download.floweb.cn/codeexpander-latest.json"
+    strategy :json do |json|
+      json["version"]
     end
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on :macos
 
   app "CodeExpander.app"
 
   zap trash: [
-    "~/.codeexpander",
-    "~/Documents/codeexpander",
-    "~/Library/Logs/Codeexpander",
-    "~/Library/Preferences/com.codeexpander.plist",
-    "~/Library/Saved Application State/com.codeexpander.savedState",
+    "~/Library/Caches/codeexpander",
+    "~/Library/Caches/com.codeexpander.pro",
+    "~/Library/Logs/com.codeexpander.pro",
+    "~/Library/WebKit/com.codeexpander.pro",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`codeexpander` is autobumped but the workflow failed to update to version 5.12.3 because upstream no longer provides assets via GitHub releases starting with version 5. The 5.x.x release tag simply links to codeexpander.com as the place to download the app. The website only provides an unversioned dmg file and the tarball that the app update source links to is also unversioned.

This updates the version and adjusts the cask accordingly. The JSON file used in the `livecheck` block is what the app checks for new version information.