### PR TITLE
datagraph: update livecheck

### DIFF
--- a/Casks/d/datagraph.rb
+++ b/Casks/d/datagraph.rb
@@ -8,8 +8,11 @@ cask "datagraph" do
   homepage "https://www.visualdatatools.com/DataGraph/"
 
   livecheck do
-    url "https://www.visualdatatools.com/DataGraph/Download/"
-    regex(/Version\s+v?(\d+(?:\.\d+)+)/i)
+    url "https://community.visualdatatools.com/datagraph/versions/"
+    regex(/href=["']?[^"' >]*?(?:datagraph|version)[._-]v?(\d+(?:[.-]\d+)+)/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("-", ".") }
+    end
   end
 
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block for `datagraph` tries to check the upstream download page but it redirects to the homepage, which now includes the download information at the bottom of the page. However, this check produces an "Unable to get versions" error because the text that includes the version is only present in a JavaScript file with a hashed filename, not the page HTML.

The app doesn't seem to check for version information, so this updates the `livecheck` block to check the "Versions" page and matches the version from links. This may break or miss versions, as the link text has varied over time (e.g., "whats-new-in-datagraph-4-5", "november-webinars-welcome-to-datagraph-4-6", "version-4-7", "whats-new-in-version-5-1", etc.). This also won't be able to identify patch releases like 5.5.1 (i.e., the cask uses a 5.5 version but the app is actually 5.5.1). Unfortunately, I don't see an alternative at the moment other than the `ExtractPlist` strategy (which we try to avoid whenever possible).