### PR TITLE
digiexam 26.1.24

### DIFF
--- a/Casks/d/digiexam.rb
+++ b/Casks/d/digiexam.rb
@@ -1,5 +1,5 @@
 cask "digiexam" do
-  version "26.1.10"
+  version "26.1.24"
   sha256 :no_check
 
   url "https://www.digiexam.com/hubfs/client/Digiexam_Mac_universal.dmg"
@@ -7,25 +7,12 @@ cask "digiexam" do
   desc "Academic testing platform with device lockdown"
   homepage "https://www.digiexam.com/"
 
-  # The Release Notes page uses JavaScript to render release information and the
-  # version data is stored in a JS file with a URL that changes between updates.
+  # The Release Notes page includes versions in the HTML but we can't reliably
+  # identify which ones are specifically for Mac. Instead, this matches versions
+  # from the JavaScript text, which identifies versions based on platform.
   livecheck do
-    url "https://www.digiexam.com/release-notes"
-    regex(/mac:\s*\[.*?version:\s*["']v?(\d+(?:\.\d+)+)["']/i)
-    strategy :page_match do |page, regex|
-      # Find the current JS file URL on the page
-      js_url = page[/src=["']?([^"' >]*?module_?Release_?Notes_?Customized_?Module(?:\.min)?\.js)["']?/i, 1]
-      next unless js_url
-
-      # Fetch the JS file content
-      js_content = Homebrew::Livecheck::Strategy.page_content(URI.join(@url, js_url).to_s)[:content]
-      next if js_content.blank?
-
-      # NOTE: We can only reliably match the first Mac version (which should be
-      # newest), as matching additional versions could spill over into the data
-      # for another OS
-      js_content[regex, 1]
-    end
+    url "https://www.digiexam.com/platform/release-notes"
+    regex(/\\?"platform\\?":\s*\\?"mac\\?".*?\\?"version\\?":\s*\\?["']v?(\d+(?:\.\d+)+)\\?["']/i)
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`digiexam` is autobumped but the workflow failed to update to version 26.1.24 because the approach we're using in the `livecheck` block no longer works. The JavaScript is now in a `script` element in the page HTML rather than an external file. This updates the version and modifies the `livecheck` block to check that instead. This is similar to the existing approach but without having to fetch a separate file and with the added wrinkle of having to account for escaped characters.