### PR TITLE
raycast@beta 0.60.0.0,2fc04147cc (new cask)

### DIFF
--- a/Casks/r/raycast@beta.rb
+++ b/Casks/r/raycast@beta.rb
@@ -1,0 +1,40 @@
+cask "raycast@beta" do
+  version "0.60.0.0,2fc04147cc"
+  sha256 "3d05f997953396984ac92211e5045c26f24b7bd37142b4ce3cbcb78ad5744075"
+
+  url "https://x-r2.raycast-releases.com/Raycast_Beta_#{version.csv.first}_#{version.csv.second}_arm64.dmg",
+      verified: "x-r2.raycast-releases.com/"
+  name "Raycast Beta"
+  desc "Control your tools with a few keystrokes (beta channel, v2)"
+  homepage "https://raycast.com/"
+
+  livecheck do
+    url "https://www.raycast.com/new"
+    regex(/Raycast[._-]Beta[._-]v?(\d+(?:\.\d+)+)[._-]([0-9a-f]+)[._-]arm64\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
+  end
+
+  no_autobump! because: :bumped_by_upstream
+
+  auto_updates true
+  depends_on macos: ">= :tahoe"
+  depends_on arch: :arm64
+
+  app "Raycast Beta.app"
+
+  uninstall quit:       "com.raycast-x.macos",
+            login_item: "Raycast Beta"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.raycast-x.macos",
+    "~/Library/Application Support/com.raycast-x.macos",
+    "~/Library/Caches/com.raycast-x.macos",
+    "~/Library/Caches/SentryCrash/Raycast Beta",
+    "~/Library/Cookies/com.raycast-x.macos.binarycookies",
+    "~/Library/HTTPStorages/com.raycast-x.macos",
+    "~/Library/Preferences/com.raycast-x.macos.plist",
+    "~/Library/WebKit/com.raycast-x.macos",
+  ]
+end

--- a/Casks/r/raycast@beta.rb
+++ b/Casks/r/raycast@beta.rb
@@ -5,7 +5,7 @@ cask "raycast@beta" do
   url "https://x-r2.raycast-releases.com/Raycast_Beta_#{version.csv.first}_#{version.csv.second}_arm64.dmg",
       verified: "x-r2.raycast-releases.com/"
   name "Raycast Beta"
-  desc "Control your tools with a few keystrokes (beta channel, v2)"
+  desc "Control your tools with a few keystrokes"
   homepage "https://raycast.com/"
 
   livecheck do
@@ -15,8 +15,6 @@ cask "raycast@beta" do
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
-
-  no_autobump! because: :bumped_by_upstream
 
   auto_updates true
   depends_on macos: :tahoe

--- a/Casks/r/raycast@beta.rb
+++ b/Casks/r/raycast@beta.rb
@@ -19,7 +19,7 @@ cask "raycast@beta" do
   no_autobump! because: :bumped_by_upstream
 
   auto_updates true
-  depends_on macos: ">= :tahoe"
+  depends_on macos: :tahoe
   depends_on arch: :arm64
 
   app "Raycast Beta.app"


### PR DESCRIPTION
Adds Raycast Beta (v2 early access) from https://www.raycast.com/new

v2 ships as a separate app from v1 with its own bundle id `com.raycast-x.macos`, and is intended to be installed alongside the existing `raycast` cask

## Stanza choices

- `version "0.60.0.0,2fc04147cc"`: the download URL embeds both a semver and a 10-char build hash, both required to construct the URL
- `depends_on arch: :arm64`: upstream only ships an arm64 DMG for the beta channel
- `depends_on macos: :tahoe`: `LSMinimumSystemVersion` in the DMG's `Info.plist` is `26.0`
- `livecheck` with `:page_match`: Raycast does not expose a JSON endpoint for the beta channel, so the regex parses the DMG href off the public download page
- `zap` paths: derived from observed `Info.plist` keys. v1's `~/.config/raycast` and `BrowserExtension` containers are excluded; v2 does not ship a browser extension and uses a different config root

## On "stable version"

Public beta channel, analogous to `brave-browser@beta`, `figma@beta`, `iterm2@beta`, `whatsapp@beta`. Same product, separate release stream, installed alongside the stable cask. Treated as the documented exception for public beta channels in [Acceptable-Casks](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version)

## Pre-flight checks

All checks verified via CI on macos-26 arm runner

- [x] `brew style raycast@beta`: no offenses
- [x] `brew audit --cask --new raycast@beta`: no offenses
- [x] `brew audit --cask --online raycast@beta`: no offenses (job `syntax (macos-26)`, passed after the `:tahoe` fix in 004a924)
- [x] `brew livecheck --cask raycast@beta`: resolves to `0.60.0.0,2fc04147cc`
- [x] `brew install --cask raycast@beta` / `brew uninstall --cask raycast@beta`: passed clean (job `test raycast@beta (macos-26, arm)`)
- [x] DMG `Info.plist` inspected; `CFBundleIdentifier`, `CFBundleName`, `LSMinimumSystemVersion` match the cask

## AI assistance disclosure

- [x] AI was used to generate this PR. Claude drafted the cask stanzas, parsed the DMG's `Info.plist` to confirm bundle id and display name, formulated the livecheck regex, and ran `brew style`, `brew audit --new --cask`, and `brew livecheck` locally under Linuxbrew before pushing. The DMG was downloaded and inspected to verify every cask value against the real binary; `zap` paths were derived from observed plist keys, not invented. The macOS-only checks (`--online` audit, `install`/`uninstall`) were not run locally and only marked complete after the CI runs on macos-26 reported success