### PR TITLE
Revert "codex: add shell completions"

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -23,7 +23,5 @@ cask "codex" do
 
   binary "codex-#{arch}-#{os}", target: "codex"
 
-  generate_completions_from_executable "codex-#{arch}-#{os}", "completion", base_name: "codex"
-
   zap rmdir: "~/.codex"
 end


### PR DESCRIPTION


Reverts Homebrew/homebrew-cask#260536

It appears that the API mode does not support `generate_completions_from_executable`


```
homebrew-cask on  main via 💎 v2.6.10
❯ brew reinstall codex
Warning: Formula codex was renamed to homebrew/cask/codex.
Error: Cask 'codex' definition is invalid: 'generate_completions_from_executable' does not support shell(s): bash, zsh, fish

homebrew-cask on  main via 💎 v2.6.10
❯ cd Casks/c/

homebrew-cask/Casks/c on  main via 💎 v2.6.10
❯ brew reinstall ./codex.rb
Error: Failed to load formula: ./codex.rb
codex: undefined method 'cask' for module Formulary::FormulaNamespacea905b986206253a3856f5c6c517658bbceefff8df5279fcbdc7cb3bd5f4f7f5e
Warning: Treating ./codex.rb as a cask.
==> Fetching downloads for: codex
==> Verifying checksum for 'c88d974589d27aa1cadfd0922a92a7fc37985e02c20e6b2d1d68ad7be9d30ced--codex-aarch64-apple-darwin.tar.gz'                                           Downloaded   79.1MB/ 79.1M
✔︎ Cask codex (0.130.0)                                                                                                                                                     Verified     79.1MB/ 79.1MB
==> Verifying checksum for 'c88d974589d27aa1cadfd0922a92a7fc37985e02c20e6b2d1d68ad7be9d30ced--codex-aarch64-apple-darwin.tar.gz'
All dependencies satisfied.
==> Uninstalling Cask codex
==> Unlinking Binary '/opt/homebrew/bin/codex'
==> Purging files for version 0.129.0 of Cask codex
==> Installing Cask codex
==> Linking Binary 'codex-aarch64-apple-darwin' to '/opt/homebrew/bin/codex'
🍺  codex was successfully installed!

homebrew-cask/Casks/c on  main via 💎 v2.6.10 took 14s
```