### PR TITLE
bartender: update minimum macOS

### DIFF
--- a/Casks/b/bartender.rb
+++ b/Casks/b/bartender.rb
@@ -16,7 +16,7 @@ cask "bartender" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sequoia"
+  depends_on macos: ">= :sonoma"
 
   app "Bartender #{version.major}.app"
 

--- a/Casks/b/bartender.rb
+++ b/Casks/b/bartender.rb
@@ -16,7 +16,7 @@ cask "bartender" do
   end
 
   auto_updates true
-  depends_on macos: :sonoma
+  depends_on macos: ">= :sequoia"
 
   app "Bartender #{version.major}.app"
 


### PR DESCRIPTION
Bartender 6 supports macOS Tahoe & Sequoia. In case of Sonoma you have to use Bartender 5. 

From the actual website: https://www.macbartender.com/Bartender6/support/

**Which macOS versions should I use with Bartender 6?**
Bartender 6 is for macOS Tahoe & Sequoia. If you are using Sonoma, your Bartender 6 license also works with Bartender 5, so you can keep using the right version for your Mac.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
