### PR TITLE
general-software-fresh 1.0.5 (new cask)

### DIFF
--- a/Casks/g/general-software-fresh.rb
+++ b/Casks/g/general-software-fresh.rb
@@ -1,0 +1,28 @@
+cask "general-software-fresh" do
+  version "1.0.5"
+  sha256 "10f98ac0fc06f865734d3154a6f5e16fb67236805d214ef5d6cc178506d20d3a"
+
+  url "https://download.general.software/fresh/#{version}/Fresh.dmg"
+  name "Fresh"
+  desc "Short-term memory for screenshots, downloads, clipboard, and desktop files"
+  homepage "https://general.software/fresh/"
+
+  livecheck do
+    url "https://bs.general.software/api/appcast/fresh"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  conflicts_with cask: "fresh"
+  depends_on macos: :sonoma
+
+  app "Fresh.app"
+
+  zap trash: [
+    "~/Library/Application Support/Fresh",
+    "~/Library/Caches/com.generalsoftwarecorp.freshmac",
+    "~/Library/HTTPStorages/com.generalsoftwarecorp.freshmac",
+    "~/Library/Preferences/com.generalsoftwarecorp.freshmac.plist",
+    "~/Library/WebKit/com.generalsoftwarecorp.freshmac",
+  ]
+end


### PR DESCRIPTION
- **general-software-fresh 1.0.5 (new cask)**

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online general-software-fresh` is error-free.
- [x] `brew style --fix general-software-fresh` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=general-software-fresh%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new general-software-fresh` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask general-software-fresh` worked successfully.
- [x] `brew uninstall --cask general-software-fresh` worked successfully.

-----

- [x] AI was used to draft the initial `general-software-fresh` cask (stanzas including `livecheck` and `zap`). I manually reviewed the result, verified the DMG contains `Fresh.app`, and ran:
- `brew style --fix general-software-fresh`
- `brew audit --cask --online general-software-fresh`
- `brew audit --cask --strict general-software-fresh`
- `brew audit --cask --new general-software-fresh`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask general-software-fresh`
- `brew uninstall --cask general-software-fresh`

zap: verified paths after running the app.

-----
