### PR TITLE
retcon: update livecheck url

### DIFF
--- a/Casks/r/retcon.rb
+++ b/Casks/r/retcon.rb
@@ -9,7 +9,7 @@ cask "retcon" do
   homepage "https://retcon.app/"
 
   livecheck do
-    url "https://lemon.garden/retcon/appcast.xml"
+    url "https://downloads.lemon.garden/retcon/appcast.xml"
     strategy :sparkle do |items|
       items.find { |item| item.channel == "release" }&.short_version
     end


### PR DESCRIPTION
Updates the live check URL for the Retcon cask. This new URL is a more direct download, which bypasses some server redirects; this helps me (as the Retcon dev) with having clearer logs. Thank you!

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
