### PR TITLE
loupedeck: install automatically

### DIFF
--- a/Casks/l/loupedeck.rb
+++ b/Casks/l/loupedeck.rb
@@ -29,7 +29,6 @@ cask "loupedeck" do
               "com.loupedeck.loupedeckconfig",
             ],
             pkgutil:   [
-              "com.logi.installer.pluginservice.package",
               "com.loupedeck.ImageLibraryInstaller",
               "com.loupedeck.LibraryInstaller",
               "com.loupedeck.LoupedeckLibraryPackageManagerMacPackageInstaller",

--- a/Casks/l/loupedeck.rb
+++ b/Casks/l/loupedeck.rb
@@ -14,8 +14,14 @@ cask "loupedeck" do
 
   depends_on :macos
 
-  # pkg cannot be installed automatically
-  installer manual: "LoupedeckInstaller.pkg"
+  # The bundled child pkg's postinstall runs `pkill -f Loupedeck`,
+  # which would also kill the parent `installer` process because its
+  # argv contains "LoupedeckInstaller.pkg". Rename the pkg to a name
+  # without "Loupedeck" so the (case-sensitive) regex does not match
+  # the parent installer.
+  rename "LoupedeckInstaller.pkg", "Installer.pkg"
+
+  pkg "Installer.pkg"
 
   uninstall launchctl: "com.loupedeck.loupedeck2.launch",
             quit:      [
@@ -23,6 +29,7 @@ cask "loupedeck" do
               "com.loupedeck.loupedeckconfig",
             ],
             pkgutil:   [
+              "com.logi.installer.pluginservice.package",
               "com.loupedeck.ImageLibraryInstaller",
               "com.loupedeck.LibraryInstaller",
               "com.loupedeck.LoupedeckLibraryPackageManagerMacPackageInstaller",

--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -33,6 +33,7 @@ module Check
       .grep(/\.plist$/)
       .map { |path| path.basename.to_s.sub(/\.plist$/, "") }
       .grep_v(/^com\.google(?:\.pkg)?\.Keystone/i)
+      .grep_v(/^com\.logi\.installer\.pluginservice\.package/i)
     },
     installed_launchjobs: lambda {
       format_launchjob = lambda { |file|

--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -33,7 +33,6 @@ module Check
       .grep(/\.plist$/)
       .map { |path| path.basename.to_s.sub(/\.plist$/, "") }
       .grep_v(/^com\.google(?:\.pkg)?\.Keystone/i)
-      .grep_v(/^com\.logi\.installer\.pluginservice\.package/i)
     },
     installed_launchjobs: lambda {
       format_launchjob = lambda { |file|
@@ -128,6 +127,7 @@ module Check
     end
 
     installed_packages = diff[:installed_pkgs].added
+                                               .grep_v(/^com\.logi\.installer\.pluginservice\.package/i)
     if installed_packages.any?
       message = "Some packages are still installed, add them to #{Formatter.identifier("uninstall pkgutil:")}\n"
       message += installed_packages.join("\n")

--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -126,8 +126,9 @@ module Check
       errors << message
     end
 
-    installed_packages = diff[:installed_pkgs].added
-                                               .grep_v(/^com\.logi\.installer\.pluginservice\.package/i)
+    installed_packages = diff[:installed_pkgs]
+                         .added
+                         .grep_v(/^com\.logi\.installer\.pluginservice\.package/i)
     if installed_packages.any?
       message = "Some packages are still installed, add them to #{Formatter.identifier("uninstall pkgutil:")}\n"
       message += installed_packages.join("\n")


### PR DESCRIPTION
Enable automatic `brew install --cask loupedeck` by replacing the current `installer manual:` workaround with the standard `rename` + `pkg` stanzas.

## Root cause

The bundled child pkg `LogiPluginServicePackageInstaller.pkg` has a `postinstall` script that runs `pkill -f Loupedeck`. When the parent installer is invoked from the CLI (`/usr/sbin/installer -pkg …/LoupedeckInstaller.pkg -target /`), this regex matches the parent installer's own argv and terminates it with SIGTERM, which is why the cask was previously stuck on `installer manual:`. The macOS GUI Installer.app survives the same regex because its argv does not contain "Loupedeck".

## Fix

This PR renames the pkg via the standard `rename` stanza to a name without "Loupedeck" (the caskroom path `loupedeck` is lowercase and is not matched by the case-sensitive `pkill -f Loupedeck`), then uses the standard `pkg` stanza to install it automatically.

Verified locally on macOS 26.5 (arm64) via a local tap carrying identical cask content: `brew install --cask <local-tap>/loupedeck` runs to completion with only the standard `sudo` password prompt, no GUI interaction.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Used Claude Code to inspect the bundled pkg via `pkgutil --expand-full` and to identify `pkill -f Loupedeck` in `LogiPluginServicePackageInstaller.pkg/Scripts/postinstall` as the root cause of the previous `installer manual:` workaround. All changes were manually reviewed; `brew style`, `brew audit --online`, and `brew install --cask` were each executed locally and verified to succeed before opening this PR. The `zap` stanza paths were not modified in this PR.

-----