### PR TITLE
stoondb: add cask 1.1.1 (resubmission)

### DIFF
--- a/Casks/s/stoondb.rb
+++ b/Casks/s/stoondb.rb
@@ -4,7 +4,7 @@ cask "stoondb" do
 
   url "https://github.com/dissojak/StoonDB/releases/download/v#{version}/StoonDB-macOS-v#{version}.dmg"
   name "StoonDB"
-  desc "Native macOS control panel for local databases and phpMyAdmin"
+  desc "Native control panel for local databases and phpMyAdmin"
   homepage "https://github.com/dissojak/StoonDB"
 
   depends_on macos: :monterey

--- a/Casks/s/stoondb.rb
+++ b/Casks/s/stoondb.rb
@@ -4,10 +4,10 @@ cask "stoondb" do
 
   url "https://github.com/dissojak/StoonDB/releases/download/v#{version}/StoonDB-macOS-v#{version}.dmg"
   name "StoonDB"
-  desc "A blazing-fast, native macOS control panel for your local database and phpMyAdmin."
+  desc "Native macOS control panel for local databases and phpMyAdmin"
   homepage "https://github.com/dissojak/StoonDB"
 
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "StoonDB.app"
 

--- a/Casks/s/stoondb.rb
+++ b/Casks/s/stoondb.rb
@@ -1,6 +1,6 @@
 cask "stoondb" do
   version "1.1.1"
-  sha256 "9849940d731195d18ee826c5566c3ccf6c062f065d07e1096e374ae011e1a49d"
+  sha256 "fcae2b03de2eb42c1eb71ec472951ba5be6717dd3425da19c0d6cdda95fe2354"
 
   url "https://github.com/dissojak/StoonDB/releases/download/v#{version}/StoonDB-macOS-v#{version}.dmg"
   name "StoonDB"

--- a/Casks/stoondb.rb
+++ b/Casks/stoondb.rb
@@ -1,0 +1,18 @@
+cask "stoondb" do
+  version "1.1.1"
+  sha256 "9849940d731195d18ee826c5566c3ccf6c062f065d07e1096e374ae011e1a49d"
+
+  url "https://github.com/dissojak/StoonDB/releases/download/v#{version}/StoonDB-macOS-v#{version}.dmg"
+  name "StoonDB"
+  desc "A blazing-fast, native macOS control panel for your local database and phpMyAdmin."
+  homepage "https://github.com/dissojak/StoonDB"
+
+  depends_on macos: ">= :monterey"
+
+  app "StoonDB.app"
+
+  zap trash: [
+    "~/Library/Application Support/StoonDB",
+    "~/Library/Preferences/com.dissojak.stoondb.plist",
+  ]
+end


### PR DESCRIPTION
Resubmitting the StoonDB cask (v1.1.1). This PR adds the  cask so users can ==> Searching for similarly named casks.... See prior PR #264531 for discussion; updated to match tap layout and style guidelines.