### PR TITLE
smoothcsv: add smoothcsv-cli binary

### DIFF
--- a/Casks/s/smoothcsv.rb
+++ b/Casks/s/smoothcsv.rb
@@ -11,6 +11,16 @@ cask "smoothcsv" do
   depends_on :macos
 
   app "SmoothCSV.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/smoothcsv.wrapper.sh"
+  binary shimscript, target: "smoothcsv"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/bash
+      exec '#{appdir}/SmoothCSV.app/Contents/MacOS/smoothcsv-cli' "$@"
+    EOS
+  end
 
   uninstall quit: "com.smoothcsv.desktop"
 

--- a/Casks/s/smoothcsv.rb
+++ b/Casks/s/smoothcsv.rb
@@ -11,16 +11,7 @@ cask "smoothcsv" do
   depends_on :macos
 
   app "SmoothCSV.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/smoothcsv.wrapper.sh"
-  binary shimscript, target: "smoothcsv"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/SmoothCSV.app/Contents/MacOS/smoothcsv-cli' "$@"
-    EOS
-  end
+  binary "#{appdir}/SmoothCSV.app/Contents/MacOS/smoothcsv-cli", target: "smoothcsv"
 
   uninstall quit: "com.smoothcsv.desktop"
 


### PR DESCRIPTION
Adds a shimscript binary named `smoothcsv` to execute `#{appdir}/SmoothCSV.app/Contents/MacOS/smoothcsv-cli`. 

https://github.com/kohii/smoothcsv3/blob/main/docs/cli.md

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online smoothcsv` is error-free.
- [x] `brew style --fix smoothcsv` reports no offenses.
