### PR TITLE
jumpshare: add auto_updates true

### DIFF
--- a/Casks/j/jumpshare.rb
+++ b/Casks/j/jumpshare.rb
@@ -13,6 +13,7 @@ cask "jumpshare" do
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on macos: :big_sur
 
   app "Jumpshare.app"


### PR DESCRIPTION
-----

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online jumpshare` is error-free.
- [x] `brew style --fix jumpshare` reports no offenses.

-----

- [x] AI was used to generate or assist with generating this PR. Verified the Sparkle livecheck URL returns the correct current version (3.4.22). `brew style --fix` passes with no offenses.

-----