### PR TITLE
keycombiner: add auto_updates true

### DIFF
--- a/Casks/k/keycombiner.rb
+++ b/Casks/k/keycombiner.rb
@@ -12,6 +12,7 @@ cask "keycombiner" do
     strategy :electron_builder
   end
 
+  auto_updates true
   depends_on :macos
 
   app "KeyCombiner.app"


### PR DESCRIPTION
-----

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online keycombiner` is error-free.
- [x] `brew style --fix keycombiner` reports no offenses.

-----

- [x] AI was used to generate or assist with generating this PR. Verified the Electron Builder livecheck URL returns the correct current version (0.8.0). `brew style --fix` passes with no offenses.

-----