### PR TITLE
bing-wallpaper 1.1.10

### DIFF
--- a/Casks/b/bing-wallpaper.rb
+++ b/Casks/b/bing-wallpaper.rb
@@ -1,16 +1,21 @@
 cask "bing-wallpaper" do
-  version "1.1.9"
-  sha256 "64f63c9f2f9f8c42a441ed3dc630e6d2cdcc0a7287b6ec872ebcfe41b474905e"
+  version "1.1.10,45e5bd06-b77e-48d7-a4f2-ae06e39dd0b4"
+  sha256 "44a0000f1e18a0be1daaa4f1b14eedc2d2e10136a8b8a56eed88b33ce699fbe3"
 
-  url "https://download.microsoft.com/download/3c2365ad-ed5f-4ebc-bacf-6dd9c66a2d15/Installer/#{version}/var1/MW011/2/BingWallpaper.pkg"
+  url "https://download.microsoft.com/download/#{version.csv.second}/Installer/#{version.csv.first}/var1/MW011/2/BingWallpaper.pkg"
   name "Bing Wallpaper"
   desc "Use the Bing daily image as your wallpaper"
   homepage "https://bingwallpaper.microsoft.com/"
 
   livecheck do
     url "https://go.microsoft.com/fwlink/?linkid=2181295&installerType=PKG"
-    regex(%r{Installer/(\d+(?:\.\d+)+)[^/]*/}i)
-    strategy :header_match
+    regex(%r{/([\h-]+)/Installer/(\d+(?:\.\d+)+)[^/]*/}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next unless match
+
+      "#{match[2]},#{match[1]}"
+    end
   end
 
   depends_on macos: :big_sur


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`bing-wallpaper` is autobumped but the workflow failed to update to version 1.1.10 because the hyphenated hexadecimal part of the asset URL may change with a new version. Since this is a variable part of the URL, we'll need to add it to the cask `version`. This updates the version and adjusts the cask accordingly.