### PR TITLE
free-download-manager: update livecheck

### DIFF
--- a/Casks/f/free-download-manager.rb
+++ b/Casks/f/free-download-manager.rb
@@ -8,8 +8,8 @@ cask "free-download-manager" do
   homepage "https://www.freedownloadmanager.org/"
 
   livecheck do
-    url "https://www.freedownloadmanager.org/download-fdm-for-mac.htm"
-    regex(/>\s*FDM\s*v?(\d+(?:\.\d+)+)/i)
+    url "https://www.freedownloadmanager.org/download.htm"
+    regex(/>\s*FDM\s+v?(\d+(?:\.\d+)+)\s+for\s+Mac\s*</i)
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block for `free-download-manager` is set up to check the Mac download page but this now redirects to a single download page that lists versions for all supported platforms. The regex ends up matching "22.04" from the Ubuntu version, so this is incorrectly returning it as newest. This addresses the issue by updating the regex to specifically match the "FDM 6.34.0 for Mac" text as a way of only matching the version for Mac.