### PR TITLE
dosbox-x-app 2026.05.02

### DIFF
--- a/Casks/d/dosbox-x-app.rb
+++ b/Casks/d/dosbox-x-app.rb
@@ -1,25 +1,22 @@
 cask "dosbox-x-app" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "2026.03.29,2026.03.29"
-  sha256 arm:   "92ca56423000c9708ea922beb30eeb5d2083030d6efa36ed7afdc11adf786f9e",
-         intel: "b804f57f2001b7a89ada6161ed9865e48ccc907fc9337fe0b94521b6a9466fea"
+  version "2026.05.02"
+  sha256 arm:   "e15b2b31897647bb1ff0e908c740acbc00249d64d1304a15658f683bec1dbc44",
+         intel: "da411bb31c2c7954876302104aebd1ed635b6cfe3ffad160cb5dfcfab86d6a0d"
 
-  url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.csv.first}/dosbox-x-macosx-#{arch}-#{version.csv.second}.zip",
+  url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.csv.first}/dosbox-x-macosx-#{arch}-#{version.csv.second || version.csv.first}.zip",
       verified: "github.com/joncampbell123/dosbox-x/"
   name "DOSBox-X"
   desc "Fork of the DOSBox project"
   homepage "https://dosbox-x.com/"
 
   livecheck do
-    url :url
-    regex(%r{/dosbox-x-v?(\d+(?:\.\d+)+)/dosbox-x-macosx-#{arch}-([^/]+)\.zip$}i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["browser_download_url"]&.match(regex)
-        next if match.blank?
-
-        "#{match[1]},#{match[2]}"
+    url :homepage
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/dosbox-x-macosx?-#{arch}[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        (match[0] == match[1]) ? match[0] : "#{match[0]},#{match[1]}"
       end
     end
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`dosbox-x-app` is autobumped but the workflow failed to update to version 2026.05.02 because upstream publishes normal and "OSFREE" releases and the latter is published after the normal release, so it ends up being the "latest" release on GitHub and the `livecheck` block regex doesn't match the tag format. The homepage links to the normal release and that's what we use in the cask. This updates the version and modifies the livecheck block to match the version from the links on the homepage, as that saves us from having to check multiple GitHub releases. This also adjusts the version setup to ensure that we only include both the tag and file name version in the cask `version` when they differ (i.e., the current version unnecessarily duplicates the version).