### PR TITLE
Add Claudette

### DIFF
--- a/Casks/c/claudette.rb
+++ b/Casks/c/claudette.rb
@@ -1,0 +1,33 @@
+cask "claudette" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.24.0"
+  sha256 arm:   "3aad742890d1b7cfdc321a3321ca505c1c879d4f62d5537556ec2e6e20021bfc",
+         intel: "a46b1fd21fa32a71602382d2bc9cc22fce4e770daa185815349c0370c46c4f8a"
+
+  url "https://github.com/utensils/Claudette/releases/download/v#{version}/Claudette_#{version}_#{arch}.dmg",
+      verified: "github.com/utensils/Claudette/"
+  name "Claudette"
+  desc "Desktop orchestrator for parallel Claude Code agents"
+  homepage "https://github.com/utensils/Claudette"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Claudette.app"
+
+  zap trash: [
+    "~/.claudette",
+    "~/Library/Application Support/claudette",
+    "~/Library/Caches/com.claudette.app",
+    "~/Library/HTTPStorages/com.claudette.app",
+    "~/Library/Preferences/com.claudette.app.plist",
+    "~/Library/Saved Application State/com.claudette.app.savedState",
+    "~/Library/WebKit/com.claudette.app",
+  ]
+end


### PR DESCRIPTION
## Checklist

After making the changes to the cask:

- [x] `brew install --cask claudette` works successfully (verified Developer ID + notarization on the installed app: `spctl -a -vvv` returns `accepted, source=Notarized Developer ID`).
- [ ] `brew audit --new --cask claudette` works successfully *(left to CI — local audit environment is Nix-managed and cannot run developer commands).*
- [ ] `brew style --fix Casks/c/claudette.rb` reports no offenses *(left to CI for the same reason; `ruby -c` is clean).*
- [x] The commit message includes the cask's name.

## Description

Claudette is a cross-platform desktop orchestrator for parallel Claude Code agents, built with Tauri 2 (Rust) and React/TypeScript. The macOS DMGs are Developer ID-signed by Sean Callan (\`W7WB5YMFHC\`) and Apple-notarized; tickets are stapled. Minimum macOS is Big Sur (11.0).

- **Homepage:** https://github.com/utensils/Claudette
- **License:** MIT
- **Stars:** 43 (meets the notability threshold)
- **Bundle identifier:** \`com.claudette.app\`
- **Built-in updater:** ships a Tauri updater (\`latest.json\`), so the cask declares \`auto_updates true\`.

The \`zap\` stanza covers Claudette's user-data tree (\`~/.claudette/\`), its OS data dir (\`~/Library/Application Support/claudette\`), and the standard webview/preference paths under the bundle id.