### PR TITLE
expressvpn 14.1.1.13156

### DIFF
--- a/Casks/e/expressvpn.rb
+++ b/Casks/e/expressvpn.rb
@@ -1,15 +1,28 @@
 cask "expressvpn" do
-  version "14.1.0.13058"
-  sha256 "4395df575fd2282c345a436dbd11aa8399567768ad8d562de92f440d38c0f7e1"
+  version "14.1.1.13156"
+  sha256 "b954a07bde7413436dfc38fe8dcc26e684dc0ed3fbc27e2bfcfae496019dd75d"
 
   url "https://www.expressvpn.works/clients/mac/expressvpn-macos-universal-#{version}_release.zip"
   name "ExpressVPN"
   desc "VPN client for secure and private internet access"
   homepage "https://www.expressvpn.works/"
 
+  # The download page (https://www.expressvpn.com/latest) uses JavaScript to
+  # render asset links, so we check the JSON source.
   livecheck do
-    url "https://portal.expressvpn.com/latest"
-    regex(/href=.*?expressvpn[._-]macos[._-]universal[._-]v?(\d+(?:\.\d+)+)[._-]release\.zip/i)
+    url "https://main-kp-site-gateway-http.prodv2.pac.xvservice.net/api/v2/installers"
+    regex(/expressvpn[._-]macos[._-]universal[._-]v?(\d+(?:\.\d+)+)[._-]release\.zip/i)
+    strategy :json do |json, regex|
+      version = nil
+      json["installers"].filter_map do |_key, item|
+        match = item.dig("locations", "default")&.match(regex)
+        next unless match
+
+        version = match[1]
+        break
+      end
+      version
+    end
   end
 
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`expressvpn` is autobumpbed but the workflow failed to update to version 14.1.1.13156 because the `livecheck` block URL redirects to a newer download page which uses JavaScript to render download links rather than including them in the HTML. This updates the version and modifies the `livecheck` block to check the JSON data that the download page uses to render asset links.