### PR TITLE
fmail2: disable

### DIFF
--- a/Casks/f/fmail2.rb
+++ b/Casks/f/fmail2.rb
@@ -9,10 +9,7 @@ cask "fmail2" do
   desc "Unofficial native application for Fastmail"
   homepage "https://fmail.arievanboxel.fr/"
 
-  livecheck do
-    url "https://fmail.appmac.fr/update/sparkle/appcast.xml"
-    strategy :sparkle, &:short_version
-  end
+  disable! date: "2026-05-16", because: :discontinued
 
   auto_updates true
   depends_on macos: :monterey


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The homepage for `fmail2` states:

> # This application is no longer supported
>
> This version of FMail has been discontinued and is no longer
> receiving updates, security patches, or technical support. A current
> version is available at fmail3.appmac.fr.

The asset URL also returns a 404, so this disables the cask as it's no longer usable.