### PR TITLE
cherry-studio 1.9.6

### DIFF
--- a/Casks/c/cherry-studio.rb
+++ b/Casks/c/cherry-studio.rb
@@ -1,18 +1,19 @@
 cask "cherry-studio" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.9.5"
-  sha256 arm:   "dba05d6b87e6068b5444ce4d3bef12cf9184fc6ecc863167e0f46bbb05c4b973",
-         intel: "eb28e802063777db91643b2660ef7e9b762c7c892ded82f3656d0d738af1f65b"
+  version "1.9.6"
+  sha256 arm:   "2b3c69e24fe4fa4e986b0290e03d3af2438ef7aedac315bf203e5a476c52cf93",
+         intel: "52d97cf4d5a03759c6a1dfa22f26f8437e02690e9a0d5b5cc69dddc869a237e8"
 
-  url "https://releases.cherry-ai.com/Cherry-Studio-#{version}-#{arch}.zip"
+  url "https://github.com/CherryHQ/cherry-studio/releases/download/v#{version}/Cherry-Studio-#{version}-#{arch}.dmg",
+      verified: "github.com/CherryHQ/cherry-studio/"
   name "Cherry Studio"
   desc "Desktop client that supports multiple LLM providers"
-  homepage "https://cherry-ai.com/"
+  homepage "https://www.cherry-ai.com/"
 
   livecheck do
-    url "https://releases.cherry-ai.com/latest-mac.yml"
-    strategy :electron_builder
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`cherry-studio` is autobumped but the workflow failed to update to version 1.9.6 because the `latest-mac.yml` file that the `livecheck` block checks no longer resolves. The current version of the app now checks GitHub releases and the website also fetches release information from the GitHub API to handle the download links. This updates the version and adjusts the cask accordingly.