### PR TITLE
folo: update livecheck

### DIFF
--- a/Casks/f/folo.rb
+++ b/Casks/f/folo.rb
@@ -13,8 +13,7 @@ cask "folo" do
 
   livecheck do
     url :url
-    regex(%r{^(?:desktop[/@])?v?(\d+(?:\.\d+)+(?:[._-]beta[._-]?\d+)?)$}i)
-    strategy :github_latest
+    regex(%r{^(?:desktop[/@])?v?(\d+(?:\.\d+)+)$}i)
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The latest release on GitHub for `folo` is currently a mobile version, so livecheck is producing an "Unable to get versions" error as the regex is doesn't match the `mobile/v0.5.3` tag. Since we can't rely on the latest release always being a desktop version and the first-party website simply links to the latest release on GitHub, we either have to check multiple releases or the Git tags. This updates the `livecheck` block to use the `Git` strategy for now and we can update it to use `GithubReleases` when needed.