### PR TITLE
font-kikai-chokoku-jis 0.320

### DIFF
--- a/Casks/font/font-k/font-kikai-chokoku-jis.rb
+++ b/Casks/font/font-k/font-kikai-chokoku-jis.rb
@@ -1,26 +1,35 @@
 cask "font-kikai-chokoku-jis" do
-  version "0.310"
-  sha256 "a0c2b1cde05d89e34ec2b1b137f27ab23b768b89570fbd800c48dd2cd4a7c5a7"
+  version "0.320"
+  sha256 "8702e0e538a8ae423a8bf8ea60abdafa07414b04388adfdab8311afdfde1b1e4"
 
-  url "https://font.kim/ki-cho-jis_#{version.no_dots}.zip"
+  url "https://font.kim/distribution/fk-kikaichokoku-v#{version.no_dots}.zip"
   name "Kikai Chokoku JIS"
   name "機械彫刻用標準書体フォント"
   homepage "https://font.kim/"
 
   livecheck do
     url :homepage
-    regex(%r{<script\s+type="application/ld\+json">([^<]+)</script>}i)
+    regex(/href=.*?fk-kikaichokoku[._-]v?(\d+(?:\.\d+)*)\.zip/i)
     strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
+      ver = page.scan(regex).map { |match| match[0] }.max
+      next ver if ver.include?(".")
 
-      json = Homebrew::Livecheck::Strategy::Json.parse_json(match[1])
-      json&.select { |item| item["name"] == "機械彫刻用標準書体 M" }
-          &.map { |item| item["softwareVersion"] }
+      # Find version text with dot(s) that matches dotless version
+      dotted_ver = nil
+      page.scan(%r{<td[^>]*?>\s*v?(\d+(?:\.\d+)+)\s*</td>}i).each do |match|
+        dotless_ver = DSL::Version.new(match[0]).no_dots
+
+        if ver == dotless_ver
+          dotted_ver = match[0]
+          break
+        end
+      end
+
+      dotted_ver
     end
   end
 
-  font "KikaiChokokuJIS-Md.otf"
+  font "fkKikaiChokoku.otf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`font-kikai-chokoku-jis` is autobumped but the workflow failed to update to version 0.320 because the `livecheck` block is producing an "Unable to get versions" error due to the homepage no longer containing the JSON data in the HTML. This updates the version and modifies the `livecheck` block to match the version from the zip file name. This is a bit tricky because the version in the file name doesn't contain dots and we don't want to naively add a dot where we think it should exist, so this matches version text with dots on the page and then finds one that matches the dotless version from the file name. This isn't foolproof but it works for now in this context.