### PR TITLE
ftdi-vcp-driver: deprecate

### DIFF
--- a/Casks/f/ftdi-vcp-driver.rb
+++ b/Casks/f/ftdi-vcp-driver.rb
@@ -5,15 +5,9 @@ cask "ftdi-vcp-driver" do
   url "https://ftdichip.com/wp-content/uploads/#{version.csv.second}/#{version.csv.third}/FTDIUSBSerialDextInstaller_#{version.csv.first.dots_to_underscores}.dmg"
   name "FTDI VCP Driver"
   desc "Virtual COM port driver"
-  homepage "https://www.ftdichip.com/Drivers/VCP.htm"
+  homepage "https://ftdichip.com/drivers/vcp-drivers/"
 
-  livecheck do
-    url "https://ftdichip.com/drivers/vcp-drivers/"
-    regex(%r{href=.*?/(\d+)/(\d+)/FTDIUSBSerialDextInstaller[._-]v?(\d+(?:[._]\d+)+)\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[2].tr("_", ".")},#{match[0]},#{match[1]}" }
-    end
-  end
+  deprecate! date: "2026-05-16", because: :unreachable
 
   depends_on :macos
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

~`ftdi-vcp-driver` is autobumped but the workflow failed to update to version 1.6.0 because the asset file name and format changed, so the `livecheck` block regex doesn't match the current link. This updates the version and adjusts the cask accordingly.~

~I haven't tried to install this and it's been years since the previous version was released, so let's see if the installation process has changed.~

I attempted to update `ftdi-vcp-driver` to the newest version, 1.6.0, but the asset URL is unreachable in the CI environment (receiving a 403 Forbidden response). The asset URL is simply a WordPress upload served from the website (which is behind Cloudflare) and the file isn't  accessible in the CI environment regardless of user agent or referer. We can't maintain casks with an asset that can't be fetched in the CI environment, so unfortunately we have to deprecate this.