### PR TITLE
headlamp: update livecheck

### DIFF
--- a/Casks/h/headlamp.rb
+++ b/Casks/h/headlamp.rb
@@ -13,15 +13,7 @@ cask "headlamp" do
 
   livecheck do
     url :url
-    regex(/Headlamp[._-]v?(\d+(?:[.-]\d+)+)-mac-#{arch}/i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["name"]&.match(regex)
-        next if match.blank?
-
-        match[1]
-      end
-    end
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block for `headlamp` uses the `GithubLatest` strategy but upstream also creates for `headlamp-helm` and `headlamp-plugin`, which can also become the "latest" release on GitHub. The "latest" release is currently for a `headlamp-plugin-0.14.0` tag, so the regex predictably doesn't match and livecheck produces an "Unable to get versions error".

We were using `GithubLatest` primarily to work around upstream using a version in the file name that didn't always match the tag (e.g., 1.2.3-4 vs 1.2.3) but they seem to have been consistent in recent versions. This addresses the issue by switching to the `Git` strategy and only matching the tags for the app. If this doesn't end up being sufficient over time, we can switch to the `GithubReleases` strategy but we try to avoid that whenever possible. [Unfortunately the first-party website doesn't link to specific files, so checking GitHub would be our only option.]