### PR TITLE
hermit-crab: disable

### DIFF
--- a/Casks/h/hermit-crab.rb
+++ b/Casks/h/hermit-crab.rb
@@ -7,12 +7,7 @@ cask "hermit-crab" do
   desc "Run shell commands without leaving your current app"
   homepage "https://belkadan.com/hermitcrab/"
 
-  livecheck do
-    url "https://belkadan.com/hermitcrab/updates/"
-    strategy :sparkle
-  end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  disable! date: "2026-05-16", because: :no_longer_available
 
   auto_updates true
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The belkadan.com server used in the `hermit-crab` cask URLs stopped responding sometime in the recent past. For historic context, the most recent version update (1.0.3) was done in 2020, so this isn't entirely surprising. This disables the cask, as it's effectively unusable in this state.