### PR TITLE
rockxy 0.19.0,28

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.18.0,27"
-  sha256 "0d8eefa4b36dd336ba869d3a50c675b98b9a15d83844e39fcc89b9d48c95c6bb"
+  version "0.19.0,28"
+  sha256 "47e61989895ec2155816ad52602ddb7428241a668af6792caa99274cb56479af"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Update Rockxy to 0.19.0 build 28.

Verification:
- brew style --changed
- Downloaded https://github.com/RockxyApp/Rockxy/releases/download/v0.19.0/Rockxy-0.19.0-28.dmg and verified sha256 47e61989895ec2155816ad52602ddb7428241a668af6792caa99274cb56479af

Note: `brew audit --cask --online --changed` was not runnable from the temporary sparse checkout because Homebrew requires the command to run inside an installed tap.