### PR TITLE
font-office-code-pro: re-enable via community mirror

### DIFF
--- a/Casks/font/font-o/font-office-code-pro.rb
+++ b/Casks/font/font-o/font-office-code-pro.rb
@@ -2,11 +2,11 @@ cask "font-office-code-pro" do
   version "1.004"
   sha256 "9bca923d17f6c47a586d8e4567d46ccfa58fb8b8e2247b5ee2a19da1597c58f6"
 
-  url "https://github.com/nathco/Office-Code-Pro/archive/refs/tags/#{version}.tar.gz"
+  # Upstream nathco/Office-Code-Pro was deleted from GitHub on 2025-08-18.
+  # Sourced from a community mirror with a byte-identical 1.004 tarball.
+  url "https://github.com/case/font-office-code-pro-mirror/releases/download/#{version}/Office-Code-Pro-#{version}.tar.gz"
   name "Office Code Pro"
-  homepage "https://github.com/nathco/Office-Code-Pro"
-
-  disable! date: "2025-08-18", because: :no_longer_available
+  homepage "https://github.com/case/font-office-code-pro-mirror"
 
   font "Office-Code-Pro-#{version}/Fonts/Office Code Pro D/OTF/OfficeCodeProD-Bold.otf"
   font "Office-Code-Pro-#{version}/Fonts/Office Code Pro D/OTF/OfficeCodeProD-BoldItalic.otf"


### PR DESCRIPTION
The upstream repository [`nathco/Office-Code-Pro`](https://github.com/nathco/Office-Code-Pro) was deleted from GitHub around 2025-08-18, which prompted #224323 to disable this cask. Office Code Pro is [OFL-1.1 licensed](https://openfontlicense.org/) and the deletion appears to be intentional upstream removal, rather than a temporary outage (the repo has sadly been a `404` for ~9 months as of this PR).

To preserve installability, I've published a community mirror at [`case/font-office-code-pro-mirror`](https://github.com/case/font-office-code-pro-mirror) with a byte-identical copy of the v1.004 release tarball,  recovered from the Internet Archive's [2020-09-05 snapshot](https://web.archive.org/web/20200905112753/https://codeload.github.com/nathco/Office-Code-Pro/tar.gz/1.004) of `codeload.github.com/nathco/Office-Code-Pro/tar.gz/1.004`. My mirror's release asset SHA256 (`9bca923d17f6c47a586d8e4567d46ccfa58fb8b8e2247b5ee2a19da1597c58f6`) is identical to the historical `sha256` already pinned in this cask, so the artifact users install via the re-enabled cask is bit-for-bit the same as the original.

This PR:
- Removes the `disable! date: "2025-08-18", because: :no_longer_available` line.
- Updates `url` to point at the mirror's release asset.
- Updates `homepage` from the 404'd `nathco/Office-Code-Pro` to the mirror repo.
- Adds a 2-line comment above `url` documenting the mirror status for future maintainers.
- Leaves `sha256`, `version`, `name`, all 16 `font` stanzas, and `# No zap stanza required` unchanged.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version) - **stable version**
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask: **this is not a new cask**

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used AI assistance to help track down the original, archival tarball and its SHA, to ensure identical, bit-for-bit comparison with the pre-disabled artifact. I've manually reviewed all the changes, and confirmed that they are fully correct.

-----
