### PR TITLE
fix issue 264739: invalid 'libreoffice-still' definition

### DIFF
--- a/Casks/l/libreoffice-still.rb
+++ b/Casks/l/libreoffice-still.rb
@@ -32,7 +32,6 @@ cask "libreoffice-still" do
   end
 
   conflicts_with cask: "libreoffice"
-  depends_on :macos
 
   app "LibreOffice.app"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"


### PR DESCRIPTION
This fixes issue [264739](https://github.com/Homebrew/homebrew-cask/issues/264739) on cask _libreoffice-still_:

> Error: Cask 'libreoffice-still' definition is invalid: Only a single 'depends_on macos' is allowed.