### PR TITLE
Add yalla-video 1.1.2

### DIFF
--- a/Casks/y/yalla-video.rb
+++ b/Casks/y/yalla-video.rb
@@ -1,0 +1,29 @@
+cask "yalla-video" do
+  version "1.1.2"
+  sha256 "da7b5e546026fd48912b8450a5b8d289d36bf535baae7a7748f451e73ea33bb5"
+
+  url "https://github.com/monzer15/yalla-video-releases/releases/download/v#{version}/Yalla-Video-#{version}-arm64.dmg",
+      verified: "github.com/monzer15/yalla-video-releases/"
+  name "Yalla Video"
+  desc "Fast desktop video downloader for YouTube and 1000+ sites"
+  homepage "https://github.com/monzer15/yalla-video-releases"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+  depends_on arch: :arm64
+
+  app "Yalla Video.app"
+
+  zap trash: [
+    "~/Library/Application Support/Yalla Video",
+    "~/Library/Caches/io.github.monzer15.YallaVideo",
+    "~/Library/Logs/Yalla Video",
+    "~/Library/Preferences/io.github.monzer15.YallaVideo.plist",
+    "~/Library/Saved Application State/io.github.monzer15.YallaVideo.savedState",
+  ]
+end

--- a/Casks/y/yalla-video.rb
+++ b/Casks/y/yalla-video.rb
@@ -2,8 +2,7 @@ cask "yalla-video" do
   version "1.1.2"
   sha256 "da7b5e546026fd48912b8450a5b8d289d36bf535baae7a7748f451e73ea33bb5"
 
-  url "https://github.com/monzer15/yalla-video-releases/releases/download/v#{version}/Yalla-Video-#{version}-arm64.dmg",
-      verified: "github.com/monzer15/yalla-video-releases/"
+  url "https://github.com/monzer15/yalla-video-releases/releases/download/v#{version}/Yalla-Video-#{version}-arm64.dmg"
   name "Yalla Video"
   desc "Fast desktop video downloader for YouTube and 1000+ sites"
   homepage "https://github.com/monzer15/yalla-video-releases"
@@ -14,7 +13,7 @@ cask "yalla-video" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
   depends_on arch: :arm64
 
   app "Yalla Video.app"


### PR DESCRIPTION
New cask for Yalla Video, an Electron desktop video downloader for YouTube and 1000+ sites.

- Upstream: https://github.com/monzer15/yalla-video-releases
- License: MIT
- macOS: arm64 only (no Intel build shipped upstream), Big Sur+

The DMG is currently unsigned and unnotarized; users will need to right-click \> Open to bypass Gatekeeper on first launch.