### PR TITLE
vibedock 1.0.0 (new cask)

### DIFF
--- a/Casks/v/vibedock.rb
+++ b/Casks/v/vibedock.rb
@@ -1,19 +1,26 @@
 cask "vibedock" do
-  version "0.1.2"
+  version "1.0.0"
   sha256 "3fd3aa347395d7c3bfbbbae0ce5ffcd7b9dce999bd8552414bb6da9ee9debbce"
 
   url "https://dl.vibedock.dev/Vibedock-#{version}.dmg"
   name "Vibedock"
   desc "Menu bar manager for Claude Code MCP servers"
-  homepage "https://vibedock.dev"
+  homepage "https://vibedock.dev/"
 
-  depends_on macos: ">= :ventura"
+  livecheck do
+    url "https://vibedock.dev/changelog.json"
+    strategy :json do |json|
+      json[0]["version"]
+    end
+  end
+
+  depends_on macos: :ventura
 
   app "Vibedock.app"
 
   zap trash: [
     "~/Library/Application Support/Vibedock",
-    "~/Library/Preferences/dev.vibedock.plist",
     "~/Library/Caches/dev.vibedock",
+    "~/Library/Preferences/dev.vibedock.plist",
   ]
 end

--- a/Casks/v/vibedock.rb
+++ b/Casks/v/vibedock.rb
@@ -1,0 +1,19 @@
+cask "vibedock" do
+  version "0.1.2"
+  sha256 "3fd3aa347395d7c3bfbbbae0ce5ffcd7b9dce999bd8552414bb6da9ee9debbce"
+
+  url "https://dl.vibedock.dev/Vibedock-#{version}.dmg"
+  name "Vibedock"
+  desc "Menu bar manager for Claude Code MCP servers"
+  homepage "https://vibedock.dev"
+
+  depends_on macos: ">= :ventura"
+
+  app "Vibedock.app"
+
+  zap trash: [
+    "~/Library/Application Support/Vibedock",
+    "~/Library/Preferences/dev.vibedock.plist",
+    "~/Library/Caches/dev.vibedock",
+  ]
+end


### PR DESCRIPTION
  - [x] The submission is for a [stable                                                    
  version](https://docs.brew.sh/Acceptable-Casks#stable-versions).                         
  - [x] `brew audit --cask --online vibedock` is error-free.                               
  - [x] `brew style --fix vibedock` reports no offenses.                                   
                                         
  Additionally, for new cask:                                                              
                                         
  - [x] Named the cask according to the [token                                             
  reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
  - [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomeb
  rew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).                       
  - [x] `brew audit --cask --new vibedock` worked successfully.
  - [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask vibedock` worked successfully. 
  - [x] `brew uninstall --cask vibedock` worked successfully.                              
   
  ---                                                                                      
                                         
  - [x] AI was used to generate or assist with generating this PR. The cask formula was    
  generated with Claude Code. The SHA256 was computed with `shasum -a 256` on the notarized
   DMG hosted at `dl.vibedock.dev`. The `zap` stanza paths were verified against the app's 
  keychain service identifier (`dev.vibedock`) and standard macOS app support directories.