### PR TITLE
wetype: fix input method installation

### DIFF
--- a/Casks/w/wetype.rb
+++ b/Casks/w/wetype.rb
@@ -26,7 +26,7 @@ cask "wetype" do
   auto_updates true
   depends_on :macos
 
-  app "WeType.app"
+  input_method "WeType.app"
 
   zap trash: [
     "~/Library/Application Support/WeType",


### PR DESCRIPTION
Install `WeType.app` to `/Library/Input Methods/` instead of `/Applications/` using the `input_method` artifact, so macOS can discover and register it as an input source.

Fixes #264600.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code with GLM-5.1) helped identify the bug and prepare the fix. The zap stanza was not modified from the existing cask and its paths were verified to be consistent with the original.

-----
