### PR TITLE
pgen 1.7.0 (new cask)

### DIFF
--- a/Casks/p/pgen.rb
+++ b/Casks/p/pgen.rb
@@ -4,7 +4,7 @@ cask "pgen" do
 
   url "https://pgendb.com/download/v#{version}/pgen.dmg"
   name "pgen"
-  desc "Modern, AI-powered PostgreSQL desktop client"
+  desc "PostgreSQL client"
   homepage "https://pgendb.com/"
 
   livecheck do
@@ -13,7 +13,7 @@ cask "pgen" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "pgen.app"
 
@@ -22,6 +22,5 @@ cask "pgen" do
     "~/Library/Caches/com.tragen.pgendb",
     "~/Library/HTTPStorages/com.tragen.pgendb",
     "~/Library/Preferences/com.tragen.pgendb.plist",
-    "~/Library/Saved Application State/com.tragen.pgendb.savedState",
   ]
 end

--- a/Casks/p/pgen.rb
+++ b/Casks/p/pgen.rb
@@ -1,0 +1,27 @@
+cask "pgen" do
+  version "1.7.0"
+  sha256 "dea091bc5cdebabbea8d37daa7b8adabf57e0eef5a825d926fe63d3ae438b4b3"
+
+  url "https://pgendb.com/download/v#{version}/pgen.dmg"
+  name "pgen"
+  desc "Modern, AI-powered PostgreSQL desktop client"
+  homepage "https://pgendb.com/"
+
+  livecheck do
+    url "https://pgendb.com/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "pgen.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.tragen.pgendb",
+    "~/Library/Caches/com.tragen.pgendb",
+    "~/Library/HTTPStorages/com.tragen.pgendb",
+    "~/Library/Preferences/com.tragen.pgendb.plist",
+    "~/Library/Saved Application State/com.tragen.pgendb.savedState",
+  ]
+end


### PR DESCRIPTION
After making changes to the cask:

- [x] `brew audit --new --strict --online --cask pgen` is error-free.
- [x] `brew style --cask pgen` is error-free.
- [x] The cask was installed successfully (`brew install --cask pgen`).
- [x] App is signed with a Developer ID Application certificate and notarized.
- [x] `livecheck` is configured (Sparkle appcast).
- [x] Distribution channel is stable (Firebase Storage fronted by pgendb.com, pinned per-version URL).

pgen is a modern, AI-powered PostgreSQL desktop client built with Flutter for macOS. Closed-source, distributed as a notarized DMG. Sparkle handles in-app updates; cask's `auto_updates true` keeps Homebrew out of Sparkle's way.

Homepage: https://pgendb.com/