### PR TITLE
Update monocle-app from 3.0.3 to 3.5

### DIFF
--- a/Casks/m/monocle-app.rb
+++ b/Casks/m/monocle-app.rb
@@ -1,6 +1,6 @@
 cask "monocle-app" do
-  version "3.0.3"
-  sha256 "a18b42ef927fe1d1cbc1521cc77c20222beabffb5c16e5240aba7363dc69cb21"
+  version "3.5"
+  sha256 "cdc34f0d2843a9fca79f1f4a4351930db937144868560c77910bc8588552bcd8"
 
   url "https://files.heyiam.dk/updates/monocle/Monocle-#{version.dots_to_hyphens}.zip"
   name "Monocle"


### PR DESCRIPTION
Update monocle-app from 3.0.3 to 3.5.

After making any changes to a cask:

- [x] `brew audit --cask --online monocle-app` is error-free.
- [x] The submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [latest where a stable version is not provided](https://docs.brew.sh/Acceptable-Casks#unstable-versions).
- [x] The new artifact downloads cleanly from the updated URL.