### PR TITLE
cisco-proximity: disable

### DIFF
--- a/Casks/c/cisco-proximity.rb
+++ b/Casks/c/cisco-proximity.rb
@@ -7,10 +7,7 @@ cask "cisco-proximity" do
   desc "Content sharing and video conference system control"
   homepage "https://proximity.cisco.com/"
 
-  livecheck do
-    url "https://proximity.cisco.com/mac/version.txt"
-    regex(/^desktop[._-]v?(\d+(?:\.\d+)+)$/i)
-  end
+  disable! date: "2026-05-18", because: :discontinued
 
   depends_on :macos
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`cisco-proximity` has been discontinued upstream, with the homepage stating:

> Cisco has discontinued the development of the Cisco Proximity application. This complimentary tool will no longer receive software updates or support.

I noticed this because the URL that the `livecheck` block checks returns a 404 (Not found) response. The asset URL also returns a 404, so this disables the cask as it's effectively unusable in this state.