### PR TITLE
j 9.7.1

### DIFF
--- a/Casks/j/j.rb
+++ b/Casks/j/j.rb
@@ -1,25 +1,26 @@
 cask "j" do
-  version "9.6.3"
-  sha256 "4a39e4f3f90382c04387bf46bcc7c2331461368dd08cc40cc647e05430572461"
+  version "9.7.1"
+  sha256 "fc34fe96fc19520c9f317ecb6b318aeb3bd83a4994b505dfa1216cf1775fd3e3"
 
-  url "https://www.jsoftware.com/download/j#{version.major_minor}/install/j#{version}_mac64.zip"
+  url "https://www.jsoftware.com/download/j#{version.major_minor}/install/j#{version}_mac.zip"
   name "J"
   desc "Programming language for mathematical, statistical and logical analysis of data"
   homepage "https://www.jsoftware.com/"
 
+  # The installation page (https://code.jsoftware.com/wiki/System/Installation)
+  # is behind Cloudflare and is inaccessible, so we check the main page. The
+  # content is rendered client-side from a Markdown file, so we fetch that.
   livecheck do
-    url "https://code.jsoftware.com/wiki/System/Installation"
-    regex(/Jv?(\d+(?:\.\d+)+)\s+release/i)
+    url "https://www.jsoftware.com/main.md"
+    regex(/href=.*?j[._-]?v?(\d+(?:\.\d+)+)[._-]mac/i)
     strategy :page_match do |page, regex|
-      # Identify partial release version (e.g., J1.2) on installation page
-      release = page.scan(regex)
-                    .flatten
-                    .max_by { |v| Version.new(v) }
-      next if release.blank?
+      # Identify partial release version (e.g., J1.2)
+      release = page.match(/latest\s+release\s+is\s+J(\d+(?:\.\d+)+)/i)
+      next unless release
 
       # Fetch the release install page (containing full versions like 1.2.3)
-      install_page = Homebrew::Livecheck::Strategy.page_content("https://www.jsoftware.com/download/j#{release}/install/")
-      install_page[:content]&.scan(/href=.*?j[._-]?v?(\d+(?:\.\d+)+)[._-]mac/i)
+      install_page = Homebrew::Livecheck::Strategy.page_content("https://www.jsoftware.com/download/j#{release[1]}/install/")
+      install_page[:content]&.scan(regex)
                             &.map { |match| match[0] }
     end
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`j` is autobumped but the workflow failed to update to version 9.7.1 because the `livecheck` block is producing an "Unable to get versions" error due to the installation page now being inaccessible. The page loads in a browser but is reliably inaccessible outside of that because of Cloudflare protections (regardless of user agent, IP address, etc.).

This updates the version and modifies the `livecheck` block to check the content of the main page instead. This page is rendered client-side from a Markdown file, so we have to fetch that instead. Unfortunately, the only way to identify the latest stable major/minor is from loose text like "The latest release is J9.7" and that may not be reliable over time. However, that's still better than fetching multiple version directory install pages to find the latest stable version.

As a side note, this swaps the `livecheck` block regex with the one that's used to identify the full version from the file name. The `regex` call was using the regex that only identifies the partial (major/minor) version, which is only used to generate the install URL to check, so it's not really the regex that's used to identify the version. The latter is a better reflection of how this check works and is more meaningful as the `regex` value.