### PR TITLE
rockxy 0.20.0,31

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.19.2,30"
-  sha256 "362cbd80a1cee864ae6fa1308e11a31ee3583c21a5befe829ad4aab0bf05b588"
+  version "0.20.0,31"
+  sha256 "6e70ea7fa74178f61762855049aa8c106c5b88eff76436e57540a5515061fc88"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.20.0 build 31.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.20.0/Rockxy-0.20.0-31.dmg
- SHA-256: 6e70ea7fa74178f61762855049aa8c106c5b88eff76436e57540a5515061fc88
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
