### PR TITLE
Add termipet

### DIFF
--- a/Casks/t/termipet.rb
+++ b/Casks/t/termipet.rb
@@ -1,0 +1,13 @@
+cask "termipet" do
+  version "0.1"
+  sha256 "ae281c823068398bdfd553f00f6484a36f8763dd522a386641311920a0ad7f6a"
+
+  url "https://github.com/bleeeet/TermiPet/releases/download/v#{version}/TermiPet-v#{version}-macOS.zip"
+  name "TermiPet"
+  desc "Desktop pet assistant for terminals and AI coding tools"
+  homepage "https://github.com/bleeeet/TermiPet"
+
+  depends_on macos: :sonoma
+
+  app "TermiPet.app"
+end


### PR DESCRIPTION
Created with `brew create --cask`-style metadata for TermiPet.

TermiPet is a desktop pet assistant for terminals and AI coding tools.

Validation run locally:
- `ruby -c Casks/t/termipet.rb`
- `brew style --cask bleeeet/termipet-source/termipet` passed against the same cask content in the source tap

Note: `brew audit --new --cask termipet` could not complete locally because Homebrew stops before cask auditing on this machine due to outdated Command Line Tools metadata (`CLT: 15.4`, Xcode 26.5 installed). I did not run the suggested destructive CLT removal command.
