### PR TITLE
Add binary stanza for SourceGit

### DIFF
--- a/Casks/s/sourcegit.rb
+++ b/Casks/s/sourcegit.rb
@@ -18,6 +18,7 @@ cask "sourcegit" do
   depends_on macos: :big_sur
 
   app "SourceGit.app"
+  binary "#{appdir}/SourceGit.app/Contents/MacOS/SourceGit", target: "sourcegit"
 
   zap trash: [
     "~/Library/Application Support/SourceGit",


### PR DESCRIPTION
It's handy to open SourceGit from the command line, see https://github.com/sourcegit-scm/sourcegit?tab=readme-ov-file#commandline-arguments.

This change will add a symlink from `/opt/homebrew/bin/sourcegit` to `/Applications/SourceGit.app/Contents/MacOS/SourceGit`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
