### PR TITLE
supaterm 1.2.2 (new cask)

### DIFF
--- a/Casks/s/supaterm.rb
+++ b/Casks/s/supaterm.rb
@@ -1,0 +1,36 @@
+cask "supaterm" do
+  version "1.2.2"
+  sha256 "558a1ce1029af7ddeff5c8b1c0ca12ba8a25702f627b95b0dd49806f0c68d7ec"
+
+  url "https://github.com/supabitapp/supaterm/releases/download/v#{version}/supaterm.dmg",
+      verified: "github.com/supabitapp/supaterm/"
+  name "Supaterm"
+  desc "Terminal for the coding agents age"
+  homepage "https://supaterm.com/"
+
+  livecheck do
+    url "https://supaterm.com/download/latest/appcast.xml"
+    strategy :sparkle do |items|
+      items.map do |item|
+        next unless item.channel.nil?
+
+        item.short_version
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :tahoe
+  depends_on arch: :arm64
+
+  app "supaterm.app"
+  binary "#{appdir}/supaterm.app/Contents/Resources/bin/sp"
+
+  zap trash: [
+    "~/Library/Application Support/app.supabit.supaterm",
+    "~/Library/Caches/app.supabit.supaterm",
+    "~/Library/HTTPStorages/app.supabit.supaterm",
+    "~/Library/HTTPStorages/app.supabit.supaterm.binarycookies",
+    "~/Library/Preferences/app.supabit.supaterm.plist",
+  ]
+end


### PR DESCRIPTION
A new cask for https://supaterm.com/. I followed the pattern in https://github.com/Homebrew/homebrew-cask/pull/248519


After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Codex assisted with drafting the cask and running local verification. Verified audit, style, livecheck, temporary-appdir install, uninstall, release asset metadata, app bundle metadata, and `zap` paths.

-----