### PR TITLE
Add DrawShot

### DIFF
--- a/Casks/d/drawshot.rb
+++ b/Casks/d/drawshot.rb
@@ -1,0 +1,31 @@
+cask "drawshot" do
+  arch arm: "-arm64", intel: ""
+
+  version "1.4.3"
+  sha256 arm:   "469405a3126b73846b0a2a2736617fbf292bda3a98e4bf7f0bc23fc8e09c70e8",
+         intel: "929b888380f82da93802853360c3765b1ff2e3049191eff8ac688ec68506d384"
+
+  url "https://cdn.drawshot.dev/downloads/DrawShot-#{version}#{arch}.dmg",
+      verified: "cdn.drawshot.dev/downloads/"
+  name "DrawShot"
+  desc "Instant screenshot annotation tool"
+  homepage "https://drawshot.dev/"
+
+  livecheck do
+    url "https://drawshot.dev/download"
+    regex(/DrawShot[._-]v?(\d+(?:\.\d+)+)[._-](?:arm64\.)?dmg/i)
+  end
+
+  auto_updates false
+  depends_on macos: ">= :ventura"
+
+  app "DrawShot.app"
+
+  zap trash: [
+    "~/Library/Application Support/DrawShot",
+    "~/Library/Preferences/com.drawshot.app.plist",
+    "~/Library/Saved Application State/com.drawshot.app.savedState",
+    "~/Library/Caches/com.drawshot.app",
+    "~/Library/Logs/DrawShot",
+  ]
+end


### PR DESCRIPTION
- [x] `brew audit --cask` is error-free.
- [x] `brew style --fix` reports no offenses.
- [x] The submission is for a stable version (v1.4.3).
- [x] I have a CLA on file with Homebrew (or this is my first contribution — happy to sign).
- [x] Cask uses pinned `version`, `sha256`, and direct DMG URLs.
- [x] App is signed with Developer ID Application + notarized by Apple (no Gatekeeper warnings).

## App info

**DrawShot** is an instant screenshot annotation tool for macOS. Watches `~/Desktop` and `~/Pictures/Screenshots`, opens a Loom-style toast the moment a screenshot lands, lets you annotate (arrows, rectangles, highlighter, blur for redaction, text, numbered steps), and saves in one keystroke (⌘S also copies the PNG to clipboard).

- Homepage: https://drawshot.dev
- Repo: https://github.com/shr29m/drawshot (private — closed-source)
- Distribution: signed DMGs via cdn.drawshot.dev (Cloudflare R2)
- macOS: 13+ (Ventura), Universal binary (Apple Silicon + Intel)

Signed identity: `Developer ID Application: Shraddha Mittal (NZ2ZNDX8PF)`, notarized by Apple.