### PR TITLE
Add guidgen 1.0.1

### DIFF
--- a/Casks/g/guidgen.rb
+++ b/Casks/g/guidgen.rb
@@ -1,0 +1,24 @@
+cask "guidgen" do
+  version "1.0.1"
+  sha256 "4330451fcfa2d6bc50fabd0f5f4188256beb5f175e4eb3bd7a6d08dc7e0cdd5c"
+
+  url "https://github.com/AGrefslie/guidgen/releases/download/v#{version}/GuidGen-#{version}.dmg"
+  name "GuidGen"
+  desc "Menu bar GUID/UUID generator with global hotkey and history"
+  homepage "https://github.com/AGrefslie/guidgen"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "GuidGen.app"
+
+  zap trash: [
+    "~/Library/Caches/axelgrefslie.GuidGen",
+    "~/Library/Preferences/axelgrefslie.GuidGen.plist",
+    "~/Library/Saved Application State/axelgrefslie.GuidGen.savedState",
+  ]
+end


### PR DESCRIPTION
After making changes to this Cask:

- [x] `brew audit --cask guidgen` is error-free.
- [x] `brew style --cask guidgen` is error-free.
- [x] The commit message includes the Cask's name.

Additional information:

GuidGen is a small macOS menu bar utility that generates GUIDs/UUIDs (v4, v7, Nil) in multiple output formats (standard, no-hyphens, braces, parens, base64, C# literal, SQL literal). It also offers a configurable global keyboard shortcut to paste a new GUID into the focused application, and keeps a persistent history of the last 50 generated values.

Upstream: https://github.com/AGrefslie/guidgen
Release: https://github.com/AGrefslie/guidgen/releases/tag/v1.0.1

The DMG and the .app inside it are signed with a Developer ID Application certificate (Team 22ADC8SJAT) and notarized + stapled by Apple. Verified locally with `spctl -a -t open --context context:primary-signature -vv` (source: Notarized Developer ID).