### PR TITLE
antigravity 2.0.1

### DIFF
--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -2,19 +2,19 @@ cask "antigravity" do
   arch arm: "arm", intel: "x64"
   livecheck_arch = on_arch_conditional arm: "-arm64"
 
-  version "1.23.2,4781536860569600"
-  sha256 arm:   "caa35ad282741cc9350fb6234e9b86aef54cd4d2f75715a21ef27180182aa50f",
-         intel: "4ec781e8e94ec714c307a06c4ce925bf761dd0e610ba45e173747fbbe3423ad6"
+  version "2.0.0,6324554176528384"
+  sha256 arm:   "f96c360be0dc419186f987276b0aa1f8c22def1b76eec0892537c193e6bf4fdd",
+         intel: "7416561b81866656453d51810ff64c19bfdc41b5fabca2ca253e9f835e7b20a6"
 
-  url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/darwin-#{arch}/Antigravity.dmg",
-      verified: "edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/"
+  url "https://storage.googleapis.com/antigravity-public/antigravity-hub/#{version.csv.first}-#{version.csv.second}/darwin-#{arch}/Antigravity.dmg",
+      verified: "storage.googleapis.com/antigravity-public/antigravity-hub/"
   name "Google Antigravity"
-  desc "AI Coding Agent IDE"
-  homepage "https://antigravity.google/"
+  desc "Agent orchestration platform"
+  homepage "https://antigravity.google/product/antigravity-2"
 
   livecheck do
     url "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/darwin#{livecheck_arch}/stable/latest"
-    regex(%r{/stable/([^/]+)/}i)
+    regex(%r{/antigravity-hub/([^/]+)/}i)
     strategy :json do |json, regex|
       match = json["url"]&.match(regex)
       next if match.blank?
@@ -27,21 +27,12 @@ cask "antigravity" do
   depends_on macos: :monterey
 
   app "Antigravity.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  agy_shimscript = "#{staged_path}/agy.wrapper.sh"
-  binary agy_shimscript, target: "agy"
-
-  preflight do
-    File.write agy_shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/Antigravity.app/Contents/Resources/app/bin/antigravity' "$@"
-    EOS
-  end
 
   uninstall quit: "com.google.antigravity"
 
   zap trash: [
     "~/.antigravity/",
+    "~/.gemini/antigravity/",
     "~/Library/Application Support/Antigravity",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.antigravity.sfl*",
     "~/Library/Caches/com.google.antigravity",

--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -2,9 +2,9 @@ cask "antigravity" do
   arch arm: "arm", intel: "x64"
   livecheck_arch = on_arch_conditional arm: "-arm64"
 
-  version "2.0.0,6324554176528384"
-  sha256 arm:   "f96c360be0dc419186f987276b0aa1f8c22def1b76eec0892537c193e6bf4fdd",
-         intel: "7416561b81866656453d51810ff64c19bfdc41b5fabca2ca253e9f835e7b20a6"
+  version "2.0.1,6566078776737792"
+  sha256 arm:   "2878f16713550600a71c25f3ea56007c472a7962bb75d58ae41a9219afb1e3d2",
+         intel: "dd4b060a98b56b66bd122c3152eadc0cd9b02e6a0b46748c95cb3ea13a7d457b"
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-hub/#{version.csv.first}-#{version.csv.second}/darwin-#{arch}/Antigravity.dmg",
       verified: "storage.googleapis.com/antigravity-public/antigravity-hub/"


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

Companion PRs: #265183 adds the separated CLI cask, and #265184 adds the separated IDE cask.

Changes:
- Update `antigravity` to Google Antigravity 2.0.1 from the new Antigravity 2 product page and `antigravity-hub` download channel.
- Update SHA-256 values for Apple Silicon and Intel DMGs from the official artifacts.
- Switch livecheck to the Antigravity 2 updater URL and `antigravity-hub` version path.
- Remove the legacy `agy` shim because the CLI is now distributed separately, and add the new `~/.gemini/antigravity/` zap path.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online antigravity` is error-free.
- [x] `brew style --fix antigravity` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI-assisted work prepared the cask edit. I manually verified the official product page and download URLs, SHA-256 values for both macOS artifacts, `Antigravity.app`, bundle identifier `com.google.antigravity`, updater metadata, `LSMinimumSystemVersion` `12.0`, removal of the old CLI binary path, and the zap paths. Install/uninstall were not run because this cask is already installed locally.

-----