### PR TITLE
antigravity-cli 1.0.0 (new cask)

### DIFF
--- a/Casks/a/antigravity-cli.rb
+++ b/Casks/a/antigravity-cli.rb
@@ -1,0 +1,33 @@
+cask "antigravity-cli" do
+  folder_arch = on_arch_conditional arm: "arm", intel: "x64"
+  file_arch = on_arch_conditional arm: "arm64", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "amd64"
+
+  version "1.0.0,5288553236791296"
+  sha256 arm:   "65c2f7b5e27a21ef983b161ed75866e89139a682adf679000e1a5d9d374e320a",
+         intel: "744a1a25dcf0bf6628e3add764d2155c44d7d174edf8b181a7427f7d9fb3fb53"
+
+  url "https://storage.googleapis.com/antigravity-public/antigravity-cli/#{version.csv.first}-#{version.csv.second}/darwin-#{folder_arch}/cli_mac_#{file_arch}.tar.gz",
+      verified: "storage.googleapis.com/antigravity-public/antigravity-cli/"
+  name "Google Antigravity CLI"
+  desc "Terminal interface for Antigravity agents"
+  homepage "https://antigravity.google/product/antigravity-cli"
+
+  livecheck do
+    url "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_#{livecheck_arch}.json"
+    regex(%r{/antigravity-cli/([^/]+)/}i)
+    strategy :json do |json, regex|
+      match = json["url"]&.match(regex)
+      next if match.blank?
+
+      match[1]&.tr("-", ",").to_s
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  binary "antigravity", target: "agy"
+
+  zap trash: "~/.gemini/antigravity-cli"
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

Companion to #265182, which removes the legacy `agy` shim from `antigravity` because the CLI is now packaged separately.

Changes:
- Add `antigravity-cli` for the official Google Antigravity CLI tarballs.
- Support Apple Silicon and Intel artifacts with separate archive path and filename architecture fragments.
- Install the upstream `antigravity` executable as `agy`.
- Add JSON manifest livecheck and the `~/.gemini/antigravity-cli` zap path.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online antigravity-cli` is error-free.
- [x] `brew style --fix antigravity-cli` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new antigravity-cli` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask antigravity-cli` worked successfully.
- [x] `brew uninstall --cask antigravity-cli` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI-assisted work prepared the cask. I manually verified the official product page, install script metadata, manifest livecheck URLs, SHA-256 values for both macOS tarballs, executable name/version, and zap path. Install/uninstall were not run because `agy` conflicts with the currently installed pre-split `antigravity` cask until #265182 lands.

-----