### PR TITLE
antigravity-ide 2.0.2

### DIFF
--- a/Casks/a/antigravity-ide.rb
+++ b/Casks/a/antigravity-ide.rb
@@ -1,0 +1,47 @@
+cask "antigravity-ide" do
+  arch arm: "arm", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "-arm64"
+
+  version "2.0.2,5949548972081152"
+  sha256 arm:   "4b236061e80494b9e516bd78b457fd41cc28e7b6e6f7110e31a35bf9ec675013",
+         intel: "8b40ae965ada7dbe5eb7638e41c686bcd67026d0045da8f8e628fb6aeb0d0858"
+
+  url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/darwin-#{arch}/Antigravity%20IDE.dmg",
+      verified: "edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/"
+  name "Google Antigravity IDE"
+  desc "AI Coding Agent IDE"
+  homepage "https://antigravity.google/product/antigravity-ide"
+
+  livecheck do
+    url "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/api/update/darwin#{livecheck_arch}/stable/latest"
+    regex(%r{/stable/([^/]+)/}i)
+    strategy :json do |json, regex|
+      match = json["url"]&.match(regex)
+      next if match.blank?
+
+      match[1]&.tr("-", ",").to_s
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Antigravity IDE.app"
+  binary "#{appdir}/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide", target: "agy-ide"
+  binary "#{appdir}/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide"
+
+  uninstall quit: "com.google.antigravity-ide"
+
+  zap trash: [
+    "~/.antigravity-ide-server/",
+    "~/.antigravity-ide/",
+    "~/.gemini/antigravity-ide/",
+    "~/Library/Application Support/Antigravity IDE",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.antigravity-ide.sfl*",
+    "~/Library/Caches/com.google.antigravity-ide",
+    "~/Library/Caches/com.google.antigravity-ide.ShipIt",
+    "~/Library/HTTPStorages/com.google.antigravity-ide",
+    "~/Library/Preferences/com.google.antigravity-ide.plist",
+    "~/Library/Saved Application State/com.google.antigravity-ide.savedState",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

Companion to #265182, which moves the `antigravity` token to the new Antigravity 2 app. This PR adds the separated IDE product as its own cask.

Changes:
- Add `antigravity-ide` for the official Google Antigravity IDE DMGs.
- Support Apple Silicon and Intel artifacts from the IDE download channel.
- Install `Antigravity IDE.app` and expose both `antigravity-ide` and `agy-ide` command-line launchers.
- Add IDE updater livecheck, bundle quit identifier, and zap paths verified from the app metadata.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online antigravity-ide` is error-free.
- [x] `brew style --fix antigravity-ide` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new antigravity-ide` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask antigravity-ide` worked successfully.
- [x] `brew uninstall --cask antigravity-ide` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI-assisted work prepared the cask. I manually verified the official product page/download URLs, SHA-256 values for both macOS DMGs, `Antigravity IDE.app`, bundle identifier `com.google.antigravity-ide`, command-line launchers from `product.json`, updater metadata, and zap paths. Install/uninstall were not run to avoid mutating the local Applications and Homebrew binary state.

-----