### PR TITLE
kicad 10.0.3

### DIFF
--- a/Casks/k/kicad.rb
+++ b/Casks/k/kicad.rb
@@ -1,6 +1,6 @@
 cask "kicad" do
-  version "10.0.2"
-  sha256 "f992d8179a94154808c8331a8ca4397880fae71b4869b78efacf21919d71f425"
+  version "10.0.3"
+  sha256 "065344be912b121e7afd853a21ea29526234830661e1b7a7b7df042163e6cd01"
 
   url "https://github.com/KiCad/kicad-source-mirror/releases/download/#{version}/kicad-unified-universal-#{version}.dmg",
       verified: "github.com/KiCad/kicad-source-mirror/"


### PR DESCRIPTION
Hey everyone 👋,

as described [here](https://gitlab.com/kicad/code/kicad/-/work_items/24385) there was an issue with the latest release missing on the github mirror of kicad. This resulted in the brew version being stuck at 10.0.2 as it uses said mirror. This issue has just been resolved by a maintainer. So this pr aims to finally bump the version. 

Best regards,
@lukas-runge

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


-----
