### PR TITLE
biglybt 4.1.0.0

### DIFF
--- a/Casks/b/biglybt.rb
+++ b/Casks/b/biglybt.rb
@@ -1,15 +1,17 @@
 cask "biglybt" do
-  arch arm: "Silicon", intel: "Intel"
+  version "4.1.0.0"
+  sha256 "0e57accd9e8efa7198ea909342bce4ac5597df76960516d683e559a5ebbb8df2"
 
-  version "4.0.0.0"
-  sha256 arm:   "f8664211a4f7868b608e906c2162877e8e74165058ff0e4555684e53447869c1",
-         intel: "90d328ebe577bdd4db979996de7071ee24902bbc2412c67cf513d97f9c8bbbd3"
-
-  url "https://github.com/BiglySoftware/BiglyBT/releases/download/v#{version}/GitHub_BiglyBT_Mac_#{arch}_Installer.dmg",
+  url "https://github.com/BiglySoftware/BiglyBT/releases/download/v#{version}/GitHub_BiglyBT_Mac_Universal_Installer.dmg",
       verified: "github.com/BiglySoftware/BiglyBT/"
   name "biglybt"
   desc "Bittorrent client based on the Azureus open source project"
   homepage "https://www.biglybt.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   auto_updates true
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`biglybt` is autobumped but the workflow failed to update to version 4.1.0.0 because upstream now only offers a universal dmg asset (the previous ARM/Intel dmg files are referred to as "legacy"). This updates the version and `url` accordingly. Besides that, this adds a `livecheck` block using the `GithubLatest` strategy, as there was a notable gap of 24 hours between tag and release.