### PR TITLE
royal-tsx@beta 26.0.1.0

### DIFF
--- a/Casks/r/royal-tsx@beta.rb
+++ b/Casks/r/royal-tsx@beta.rb
@@ -1,20 +1,20 @@
 cask "royal-tsx@beta" do
-  version "6.4.3.1000"
-  sha256 "bf0c1bebfc3aed2e67c1fe9cf5e4b06be5d07cc6d916d61185f5818fd79af482"
+  version "26.0.1.0"
+  sha256 "fa2232fb2a266cc2ce3c3e592321709c449eec81b3e91cefdfcf7cce3ec5143e"
 
-  url "https://royaltsx-v#{version.major}.royalapps.com/updates/royaltsx_#{version}.dmg"
+  url "https://royaltsx-v#{version.major}.royalapps.com/app/updates/downloads/royaltsx_#{version}.dmg"
   name "Royal TSX"
   desc "Remote management solution"
-  homepage "https://www.royalapps.com/ts/mac/features"
+  homepage "https://www.royalapps.com/ts/mac/features-beta"
 
   livecheck do
-    url "https://royaltsx-v#{version.major}.royalapps.com/updates_beta.php"
+    url "https://royaltsx-v#{version.major}.royalapps.com/app/updates"
     strategy :sparkle
   end
 
   auto_updates true
   conflicts_with cask: "royal-tsx"
-  depends_on macos: :big_sur
+  depends_on macos: :sonoma
 
   app "Royal TSX.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`royal-tsx@beta` is autobumped but the workflow failed to update to version 26.0.1.0 because the URLs for v26 releases are different than v6 releases. This updates the version and adjusts the cask URLs accordingly.