### PR TITLE
Add local-mcp

### DIFF
--- a/Casks/l/local-mcp.rb
+++ b/Casks/l/local-mcp.rb
@@ -1,0 +1,26 @@
+cask "local-mcp" do
+  version "3.0.206"
+  sha256 "18e0218ba83c9bc5d9897ea06d691e836fe1ac1125f7f6cec82b6294fffbb3a5"
+
+  url "https://download.local-mcp.com/LocalMCP-#{version}.dmg"
+  name "Local MCP"
+  desc "Connect AI agents to Mac apps — Mail, Calendar, Teams, OneDrive and 217 more tools"
+  homepage "https://local-mcp.com"
+
+  livecheck do
+    url "https://office-mcp-production.up.railway.app/latest"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  app "LocalMCPTray.app"
+
+  uninstall launchctl: "com.local-mcp.server",
+            delete:    "#{Dir.home}/Library/LaunchAgents/com.local-mcp.server.plist"
+
+  zap trash: [
+    "~/Library/Application Support/Local MCP",
+    "~/.local/share/local-mcp",
+  ]
+end


### PR DESCRIPTION
## local-mcp

Adds a cask for [Local MCP](https://local-mcp.com) — a macOS menu bar app that connects AI agents (Claude Desktop, Cursor, VS Code, ChatGPT) to local apps without any cloud or API keys.

**221 tools** covering Mail, Calendar, Contacts, Teams, OneDrive, Notes, Reminders, Messages, Safari, OmniFocus, Outlook, Excel, Word, PowerPoint, WhatsApp, Slack, Evernote, ServiceNow and more. 100% local, GDPR compliant by architecture.

### Cask details

| | |
|---|---|
| **Homepage** | https://local-mcp.com |
| **Version** | 3.0.206 |
| **Download** | https://download.local-mcp.com/LocalMCP-3.0.206.dmg |
| **App bundle** | `LocalMCPTray.app` |
| **Signing** | Developer ID Application: Magno Partners Consulting (F7S4WH844B) |
| **Notarized** | Yes — Apple Notarization stapled |

### Checklist

- [x] App is signed with Developer ID Application certificate
- [x] App is notarized and stapled by Apple
- [x] No Gatekeeper warnings
- [x] DMG URL is stable and versioned (`LocalMCP-#{version}.dmg`)
- [x] `livecheck` uses public JSON endpoint
- [x] `uninstall` and `zap` stanzas provided