### PR TITLE
Add rilmazafone

### DIFF
--- a/Casks/r/rilmazafone.rb
+++ b/Casks/r/rilmazafone.rb
@@ -1,0 +1,24 @@
+cask "rilmazafone" do
+  version "1.0"
+  sha256 "59f4cbcbd292e70e5055ef7d7ee3b8ea49b7613896180416f0a74603f1890ffe"
+
+  url "https://github.com/kageroumado/rilmazafone/releases/download/#{version}/Rilmazafone-#{version}.dmg"
+  name "Rilmazafone"
+  desc "Designer for styled DMG installers"
+  homepage "https://github.com/kageroumado/rilmazafone"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :tahoe
+
+  app "Rilmazafone.app"
+
+  zap trash: [
+    "~/Library/Application Support/Rilmazafone",
+    "~/Library/Preferences/glass.kagerou.rilmazafone.plist",
+    "~/Library/Saved Application State/glass.kagerou.rilmazafone.savedState",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online rilmazafone` is error-free.
- [x] `brew style --fix rilmazafone` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+rilmazafone&type=pullrequests).
- [x] `brew audit --cask --new rilmazafone` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask rilmazafone` worked successfully.
- [x] `brew uninstall --cask rilmazafone` worked successfully.

---

- [x] AI was used to generate or assist with generating this PR.

  Claude (Opus 4.7) drafted the cask file under my direction. Manual verification I performed:
  - Confirmed the DMG at the URL is signed and notarized by Developer ID `Elysia Muñoz (52K336H235)` — `spctl -a -vvv -t install` reports `accepted source=Notarized Developer ID`, and `codesign -dv` shows `Authority=Developer ID Application` with `flags=0x10000(runtime)` (hardened runtime).
  - Verified SHA256 against the asset published at the release URL.
  - Ran `brew install --cask rilmazafone` into an isolated `--appdir` and `brew uninstall --cask rilmazafone` cleanly.
  - Verified `~/Library/Preferences/glass.kagerou.rilmazafone.plist` exists on a machine where the app has been used; the other two `zap` paths are conventional macOS locations for `Application Support/<App>` and `Saved Application State/<bundle.id>.savedState` that Cocoa would create as the app accumulates state.
  - Repository (`kageroumado/rilmazafone`) is over 90 days old and has 75 stars, meeting the notability and age thresholds.