### PR TITLE
antigravity: add CLI conflict

### DIFF
--- a/Casks/a/antigravity-cli.rb
+++ b/Casks/a/antigravity-cli.rb
@@ -25,6 +25,7 @@ cask "antigravity-cli" do
   end
 
   auto_updates true
+  conflicts_with cask: "antigravity"
   depends_on macos: :monterey
 
   binary "antigravity", target: "agy"

--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -24,6 +24,7 @@ cask "antigravity" do
   end
 
   auto_updates true
+  conflicts_with cask: "antigravity-cli"
   depends_on macos: :monterey
 
   app "Antigravity.app"


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

Adds reciprocal `conflicts_with` stanzas between `antigravity` and `antigravity-cli`. Antigravity bundles the CLI, while `antigravity-cli` installs the standalone CLI as `agy`, so either install order should fail early with a cask-level conflict instead of relying on artifact collisions or duplicated CLI functionality.

This follows existing Homebrew Cask patterns for similar pairs: `soulver`/`soulver-cli` both declare reciprocal conflicts for the bundled versus standalone CLI, and `zoom`/`zoom-for-it-admins` also declares reciprocal conflicts for mutually exclusive variants.

Validation:
- `brew style --fix Casks/a/antigravity.rb Casks/a/antigravity-cli.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --cask --online antigravity antigravity-cli`
- With `antigravity` installed, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask antigravity-cli` fails with `Cask 'antigravity-cli' conflicts with 'antigravity'.`

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online antigravity antigravity-cli` is error-free.
- [x] `brew style --fix antigravity antigravity-cli` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI-assisted work helped prepare and test this minimal cask fix. I manually reviewed the two-line diff, checked existing reciprocal `conflicts_with` cask patterns such as `soulver`/`soulver-cli` and `zoom`/`zoom-for-it-admins`, ran style and audit, confirmed the install conflict behavior locally, and verified that no `zap` paths were changed.

-----