### PR TITLE
Add Cask pr-monitor

### DIFF
--- a/Casks/p/pr-monitor.rb
+++ b/Casks/p/pr-monitor.rb
@@ -1,0 +1,19 @@
+cask "pr-monitor" do
+  version "1.6.0"
+  sha256 "537c85c80b8284a7c030b484587d5daf04ae5e2d3d380daf289d6bf939790a28"
+
+  url "https://github.com/jeanjacquesaka1980/pr-monitor/releases/download/v#{version}/PR.Monitor-#{version}-universal-mac.zip"
+  name "PR Monitor"
+  desc "GitHub pull request monitor for the macOS menu bar"
+  homepage "https://github.com/jeanjacquesaka1980/pr-monitor"
+
+  depends_on macos: ">= :ventura"
+
+  app "PR Monitor.app"
+
+  zap trash: [
+    "~/Library/Application Support/PR Monitor",
+    "~/Library/LaunchAgents/com.pr-monitor.app.plist",
+    "~/Library/Preferences/com.pr-monitor.app.plist",
+  ]
+end


### PR DESCRIPTION
## What does this PR do?

Adds a new cask for PR Monitor — a macOS menu bar app that shows open GitHub pull requests (authored and under review) with CI status, review decisions, and individual workflow check runs.

## Why is this cask needed?

PR Monitor lives in your menu bar and auto-refreshes every 60 seconds. It supports GitHub.com and GitHub Enterprise, filters by repository and author, and shows unresolved review comment counts. It is useful for developers who want at-a-glance PR visibility without leaving their current app.

## Checklist

- [x] `brew audit --new --cask pr-monitor` passes
- [x] The cask name matches the app name
- [x] The download URL is versioned and stable (GitHub Releases)
- [x] SHA256 verified
- [x] `app` stanza points to the correct `.app` name
- [x] `zap` stanza lists all known app data paths
- [x] `depends_on macos:` set to minimum required version (Ventura — Electron 39 requirement)
- [x] No sudo required