### PR TITLE
phtv 3.1.7 (new cask)

### DIFF
--- a/Casks/p/phtv.rb
+++ b/Casks/p/phtv.rb
@@ -1,0 +1,38 @@
+cask "phtv" do
+  arch arm: "arm64", intel: "intel"
+
+  version "3.1.7"
+  sha256 arm:   "ef52bdbc6c9d3fdc64dda45dba0fc2e8d4ae3449b725ca0fd701fa797613b641",
+         intel: "ab544539a924cfec48796dd227cbf65264bf0fff9fb901185a12f4d8546efeda"
+
+  url "https://github.com/PhamHungTien/PHTV/releases/download/v#{version}/PHTV-#{version}-#{arch}.dmg",
+      verified: "github.com/PhamHungTien/PHTV/"
+  name "PHTV"
+  name "Precision Hybrid Typing Vietnamese"
+  desc "Vietnamese input method"
+  homepage "https://phamhungtien.com/PHTV/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "PHTV.app"
+
+  zap trash: [
+    "~/Library/Application Support/PHTV",
+    "~/Library/Caches/com.phamhungtien.phtv",
+    "~/Library/HTTPStorages/com.phamhungtien.phtv",
+    "~/Library/Logs/PHTV",
+    "~/Library/Preferences/com.phamhungtien.phtv.plist",
+    "~/Library/Saved Application State/com.phamhungtien.phtv.savedState",
+  ]
+
+  caveats <<~EOS
+    PHTV requires Accessibility and Input Monitoring permissions to type reliably.
+    Open PHTV after installation and follow the in-app permission guide.
+  EOS
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you have not performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask being submitted._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or documented exception.
- [x] `brew audit --new --cask --online phtv` is error-free.
- [x] `brew style --fix phtv` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not already refused. Previous PRs were reviewed: #240838, #248283, #246085. The earlier Gatekeeper/signing issue has been addressed in the current notarized Developer ID release.
- [x] `brew audit --new --cask --online phtv` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --appdir=/tmp/phtv-cask-apps phtv` worked successfully. I used an isolated appdir because `/Applications/PHTV.app` already exists on my machine.
- [x] `brew uninstall --cask phtv` worked successfully and removed the isolated app.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. OpenAI Codex helped prepare the cask and checklist text.
- [x] I have personally reviewed, tested and verified all changes/additions, including the `zap` stanza paths.

-----

Additional verification performed:

- `brew livecheck --cask phtv` reports `3.1.7 ==> 3.1.7`.
- `brew lgtm --online` passes after staging the new cask.
- Downloaded both release DMGs and verified Gatekeeper:
  - `PHTV-3.1.7-arm64.dmg`: accepted, source=Notarized Developer ID
  - `PHTV-3.1.7-intel.dmg`: accepted, source=Notarized Developer ID

PHTV is a native macOS Vietnamese input method app distributed from the official GitHub releases page and project website.
