### PR TITLE
iina: fix URL and improve depends_on stanza

### DIFF
--- a/Casks/i/iina.rb
+++ b/Casks/i/iina.rb
@@ -1,5 +1,5 @@
 cask "iina" do
-  version "1.4.3,167"
+  version "1.4.3"
   sha256 "899a15c3cee499d6e5d1a47bce02194a5a2709b3aa1c7ba82fb16a002fa81e02"
 
   on_arm do
@@ -9,14 +9,14 @@ cask "iina" do
     depends_on macos: :catalina
   end
 
-  url "https://dl.iina.io/IINA.v#{version.csv.first}.dmg"
+  url "https://dl.iina.io/IINA.v#{version}.dmg"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"
 
   livecheck do
     url "https://www.iina.io/appcast.xml"
-    strategy :sparkle # IINA sometimes rebuilds with the same short version.
+    strategy :sparkle, &:short_version # IINA sometimes rebuilds with the same short version.
   end
 
   auto_updates true

--- a/Casks/i/iina.rb
+++ b/Casks/i/iina.rb
@@ -1,8 +1,15 @@
 cask "iina" do
-  version "1.4.2,164"
-  sha256 "804e3368518f19039ebfbc3d698e1fabc9cd20f15fc4e42de635456cdf6a7f58"
+  version "1.4.3,167"
+  sha256 "899a15c3cee499d6e5d1a47bce02194a5a2709b3aa1c7ba82fb16a002fa81e02"
 
-  url "https://dl-portal.iina.io/IINA.v#{version.csv.first}-build#{version.csv.second}.dmg"
+  on_arm do
+    depends_on macos: :monterey
+  end
+  on_intel do
+    depends_on macos: :catalina
+  end
+
+  url "https://dl.iina.io/IINA.v#{version.csv.first}.dmg"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"
@@ -13,7 +20,6 @@ cask "iina" do
   end
 
   auto_updates true
-  depends_on :macos
 
   app "IINA.app"
   binary "#{appdir}/IINA.app/Contents/MacOS/iina-cli", target: "iina"

--- a/Casks/i/iina.rb
+++ b/Casks/i/iina.rb
@@ -2,11 +2,13 @@ cask "iina" do
   version "1.4.3"
   sha256 "899a15c3cee499d6e5d1a47bce02194a5a2709b3aa1c7ba82fb16a002fa81e02"
 
-  on_arm do
-    depends_on macos: :monterey
-  end
-  on_intel do
-    depends_on macos: :catalina
+  on_macos do
+    on_arm do
+      depends_on macos: :monterey
+    end
+    on_intel do
+      depends_on macos: :catalina
+    end
   end
 
   url "https://dl.iina.io/IINA.v#{version}.dmg"
@@ -20,6 +22,7 @@ cask "iina" do
   end
 
   auto_updates true
+  depends_on :macos
 
   app "IINA.app"
   binary "#{appdir}/IINA.app/Contents/MacOS/iina-cli", target: "iina"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
As discussed in #259977:
> > Replacing the URL with [https://dl-portal.iina.io/IINA.v#{version.csv.first}-build{version.csv.second}.dmg](https://dl-portal.iina.io/IINA.v#%7Bversion.csv.first%7D-build%7Bversion.csv.second%7D.dmg) will definitely cause issues as soon as a new release comes out.
> 
> Unless this is how all of the paths will be moving forward, we could try it any revert the change in future if required.

the url scheme change has to be reversed for this to work again.

Also, I've changed the download URL because the old URL (https://dl-portal.iina.io/) redirected to the new one (https://dl.iina.io/) anyway. 

And since the iina website says that IINA
> Requires macOS 12.0 for Apple Sillicon Macs, and macOS 10.15 for Intel Macs,

I've updated the depends_on stanza