### PR TITLE
Add NewFile 0.2.0

### DIFF
--- a/Casks/n/newfile.rb
+++ b/Casks/n/newfile.rb
@@ -4,7 +4,7 @@ cask "newfile" do
 
   url "https://github.com/mariusgm/newfile/releases/download/v#{version}/NewFile.dmg"
   name "NewFile"
-  desc "'New File' button for the macOS Finder"
+  desc "'New File' button for Finder"
   homepage "https://github.com/mariusgm/newfile"
 
   livecheck do
@@ -12,7 +12,7 @@ cask "newfile" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "NewFile.app"
 

--- a/Casks/n/newfile.rb
+++ b/Casks/n/newfile.rb
@@ -1,0 +1,24 @@
+cask "newfile" do
+  version "0.2.0"
+  sha256 "2458aa21a538eb00857f32ca17afa575e61381aaf097f1b3fb3ca3d37b02b8ef"
+
+  url "https://github.com/mariusgm/newfile/releases/download/v#{version}/NewFile.dmg"
+  name "NewFile"
+  desc "'New File' button for the macOS Finder"
+  homepage "https://github.com/mariusgm/newfile"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "NewFile.app"
+
+  zap trash: [
+    "~/Library/Containers/dev.newfile.NewFile",
+    "~/Library/Containers/dev.newfile.NewFile.NewFileExtension",
+    "~/Library/Group Containers/Q7VD7MTRL8.group.dev.newfile.NewFile",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

**AI usage / manual verification:** This PR was drafted with Claude (Anthropic) assistance. The sandboxed environment blocked outbound access to rubygems.org, so `brew style` / `brew audit` / local install via `brew install --cask` could not be run end-to-end locally; I'm relying on Homebrew CI to gate those.

I manually verified:
- The cask token `newfile` is lowercase, hyphen/extension-free, and unique in `Casks/n/`.
- `sha256` matches the GitHub-served artifact byte-for-byte (`shasum -a 256` against `https://github.com/mariusgm/newfile/releases/download/v0.2.0/NewFile.dmg`).
- The DMG is signed (`Developer ID Application: MARIUS GARBERG MEVOLD (Q7VD7MTRL8)`), notarized, and stapled (`spctl --assess --type execute` returns `accepted, source=Notarized Developer ID`).
- `zap` paths point to the two sandbox containers (`dev.newfile.NewFile`, `dev.newfile.NewFile.NewFileExtension`) and the App Group container (`Q7VD7MTRL8.group.dev.newfile.NewFile`) — confirmed against the entitlements files in the source repo and the team ID on the signing certificate.
- `livecheck` uses `:github_latest` against the same URL pattern; future versions follow the `v#{version}/NewFile.dmg` shape.

NewFile is a small free + open-source macOS Finder Sync Extension that adds the missing "New File" right-click + toolbar button to Finder. Repo: <https://github.com/mariusgm/newfile>. License: MIT. macOS 13+ (universal). Signed under my Apple Developer ID; v0.1.0 has been live since 2026-05-02.

I'm the cask author and the app author.