### PR TITLE
macfax 0.2.35

### DIFF
--- a/Casks/m/macfax.rb
+++ b/Casks/m/macfax.rb
@@ -1,0 +1,27 @@
+cask "macfax" do
+  version "0.2.35"
+  sha256 :no_check
+
+  url "https://macfax.com/Macfax.dmg"
+  name "Macfax"
+  desc "Tamper-proof verification reports for Macs"
+  homepage "https://macfax.com/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "Macfax.app"
+
+  zap trash: [
+    "~/Library/Application Support/Macfax",
+    "~/Library/Caches/com.macfax.app",
+    "~/Library/HTTPStorages/com.macfax.app",
+    "~/Library/Preferences/com.macfax.app.plist",
+    "~/Library/Saved Application State/com.macfax.app.savedState",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI (Claude Code) drafted the cask file based on the app's distribution metadata (notarized DMG at a stable URL, bundle ID `com.macfax.app`, macOS 14 + Apple Silicon requirements pulled from the app's `Info.plist` and homepage `SoftwareApplication` schema). A human operator then ran the full PR-template checklist manually on a real Mac: `brew style`, `brew audit --cask --new --online macfax`, real `brew install` (verified the app launches and is notarization-accepted by Gatekeeper), and `brew uninstall` (verified the binary is removed). The `zap` paths were cross-checked against the app's actual filesystem use — Swift source uses `~/Library/Application Support/Macfax/` for run data and `com.macfax.app` as the logging subsystem / Keychain service.

About Macfax: tamper-proof verification reports for Macs. Homepage: https://macfax.com/