### PR TITLE
ummaya 0.1.15 (new cask)

### DIFF
--- a/Casks/u/ummaya.rb
+++ b/Casks/u/ummaya.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ummaya" do
-  version "0.1.13"
-  sha256 "1cb322d680342fd5fe8e1f7e82919b8aaa731181fb6ce41cf475f294b797e5f6"
+  version "0.1.14"
+  sha256 "5c6dc87292534e0bbea1acf46831f3bbcf654237f6c07f8174b3d4eac23e8891"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"

--- a/Casks/u/ummaya.rb
+++ b/Casks/u/ummaya.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ummaya" do
-  version "0.1.14"
-  sha256 "5c6dc87292534e0bbea1acf46831f3bbcf654237f6c07f8174b3d4eac23e8891"
+  version "0.1.15"
+  sha256 "83704be590b190dc1045babae85c28a9b4573e70d45b0df96b77df0753428e5d"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"

--- a/Casks/u/ummaya.rb
+++ b/Casks/u/ummaya.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ummaya" do
-  version "0.1.12"
-  sha256 "9e5c3d6ad0d1eb92e021a478656dc1fdf293636ad98a195c73c74b8b0111f40c"
+  version "0.1.13"
+  sha256 "1cb322d680342fd5fe8e1f7e82919b8aaa731181fb6ce41cf475f294b797e5f6"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"

--- a/Casks/u/ummaya.rb
+++ b/Casks/u/ummaya.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+cask "ummaya" do
+  version "0.1.12"
+  sha256 "9e5c3d6ad0d1eb92e021a478656dc1fdf293636ad98a195c73c74b8b0111f40c"
+
+  url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
+      verified: "registry.npmjs.org/ummaya/"
+  name "UMMAYA"
+  desc "Conversational multi-agent harness for Korean public-service channels"
+  homepage "https://ummaya-docs.pages.dev/"
+
+  depends_on formula: "node"
+  depends_on formula: "uv"
+
+  binary "ummaya"
+
+  preflight do
+    install_args = ["install", "--omit=dev", "--legacy-peer-deps", "--prefix", "#{staged_path}/package"]
+    npm_env = {
+      "PATH" => PATH.new("#{HOMEBREW_PREFIX}/bin", "#{HOMEBREW_PREFIX}/opt/node/bin", ENV.fetch("PATH")),
+    }
+
+    system_command "#{HOMEBREW_PREFIX}/bin/npm",
+                   args: [*install_args, "--ignore-scripts"],
+                   env:  npm_env
+    system_command "#{HOMEBREW_PREFIX}/bin/npm",
+                   args: [*install_args, "--no-save", "bun@1.3.14"],
+                   env:  npm_env
+
+    wrapper = staged_path/"ummaya"
+    wrapper.write <<~SH
+      #!/bin/bash
+      export PATH="#{staged_path}/package/node_modules/.bin:#{HOMEBREW_PREFIX}/opt/uv/bin:$PATH"
+      exec "#{staged_path}/package/node_modules/.bin/bun" "#{staged_path}/package/bin/ummaya" "$@"
+    SH
+    FileUtils.chmod 0755, wrapper
+  end
+
+  zap trash: "~/.ummaya"
+end


### PR DESCRIPTION
Adds UMMAYA, a terminal agent for Korean public-service workflows.

Release/source:
- npm package: https://www.npmjs.com/package/ummaya/v/0.1.12
- docs homepage: https://ummaya-docs.pages.dev/
- upstream source: https://github.com/umyunsang/UMMAYA

Validation performed locally:
- `brew style --fix --cask ummaya`
- `brew audit --new --cask ummaya`
- `brew fetch --cask --force ummaya`

Packaging note:
UMMAYA is open source and CLI-first. I also checked a formula route, but the current runtime requires Bun >= 1.3.0 and `bun` is not available in `homebrew/core` yet; a core formula candidate fails audit because it would need the external `oven-sh/bun/bun` dependency. This cask follows existing binary CLI cask patterns while the core Bun formula is still pending.
