### PR TITLE
companion 4.3.3

### DIFF
--- a/Casks/c/companion.rb
+++ b/Casks/c/companion.rb
@@ -2,18 +2,18 @@ cask "companion" do
   arch arm: "arm64", intel: "x64"
   livecheck_arch = on_arch_conditional arm: "arm", intel: "intel"
 
-  version "4.2.6,8823,4ecdfe70ba"
-  sha256 arm:   "edd2d333780cee7a85bf1cbda09ac193806b8540575ecb05e3a5f51e0d8ffaee",
-         intel: "2c340fa178ec741b3cb607bc5ad7a255a9026086ea6610a2ae24d7c76533bbba"
+  version "4.3.3,9230,06a7406709"
+  sha256 arm:   "dad3e56c7374ecaf7fcf4bc9587d2432e41d9a1aab78bcb14bdbf7750c9bfaea",
+         intel: "fd49525040ce6d803bea0d4e60ca1b8394e122d9acbb547c82edba6989f5ab27"
 
-  url "https://s4.bitfocus.io/builds/companion/companion-mac-#{arch}-#{version.csv.first}+#{version.csv.second}-stable-#{version.csv.third}.dmg"
+  url "https://cf-pub.bitfocus.io/companion/companion/companion-mac-#{arch}-#{version.csv.first}-#{version.csv.second}-stable-#{version.csv.third}.dmg"
   name "Bitfocus Companion"
   desc "Streamdeck extension and emulation software"
   homepage "https://bitfocus.io/companion"
 
   livecheck do
     url "https://api.bitfocus.io/v1/product/companion/packages?branch=stable&limit=150"
-    regex(/companion[._-]mac[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)[._-]stable[._-](\h+)\.dmg/i)
+    regex(/companion[._-]mac[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)[+-](\d+(?:\.\d+)*)[._-]stable[._-](\h+)\.dmg/i)
     strategy :json do |json, regex|
       json["packages"]&.map do |package|
         next if package["target"] != "mac-#{livecheck_arch}"


### PR DESCRIPTION
Bitfocus has changed to a new CDN for versions past 4.3.0 which changed the Companion download URL schema, and this broke both the download URL and the livecheck regex, so this patch fixes both of those.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

I have not updated the version of this cask, since the purpose of this patch is to fix livecheck and the download URL so the cask can be auto-updated. Let me know if I should include a version update in this patch.

- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
