### PR TITLE
keyscreen 2.2.0 (new cask)

### DIFF
--- a/Casks/k/keyscreen.rb
+++ b/Casks/k/keyscreen.rb
@@ -1,0 +1,28 @@
+cask "keyscreen" do
+  version "2.2.0"
+  sha256 "30e04bc9b85f6c8ecaf0793a194e2a5106da2feb4454dd20618d8da1f47a9cdc"
+
+  url "https://rampatra.github.io/keyscreen-updates/KeyScreen-#{version}.dmg",
+      verified: "rampatra.github.io/keyscreen-updates/"
+  name "KeyScreen"
+  desc "Show key presses on screen"
+  homepage "https://keyscreenapp.com/"
+
+  livecheck do
+    url "https://rampatra.github.io/keyscreen-updates/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sequoia
+
+  app "KeyScreen.app"
+
+  zap trash: [
+    "~/Library/Caches/io.softal.KeyScreen",
+    "~/Library/HTTPStorages/io.softal.KeyScreen",
+    "~/Library/Preferences/io.softal.KeyScreen.plist",
+    "~/Library/Saved Application State/io.softal.KeyScreen.savedState",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online keyscreen` is error-free.
- [x] `brew style --fix keyscreen` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask name to the end of the search field).
- [x] `brew audit --cask --new keyscreen` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask keyscreen` worked successfully.
- [x] `brew uninstall --cask keyscreen` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI helped draft the cask and run local verification. I verified the appcast at `https://rampatra.github.io/keyscreen-updates/appcast.xml` returns `2.2.0`, the DMG contains `KeyScreen.app`, the app bundle identifier is `io.softal.KeyScreen`, the executable is arm64-only, the app is accepted as Notarized Developer ID, `brew livecheck --cask keyscreen` returns `2.2.0`, audit/style pass, and install/uninstall work using a temporary appdir. The `zap` paths are based on the verified bundle identifier and expected Caches, HTTPStorages, Preferences, and Saved Application State locations.

-----
