### PR TITLE
antigravity 2.0.6

### DIFF
--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -1,6 +1,5 @@
 cask "antigravity" do
   arch arm: "arm", intel: "x64"
-  livecheck_arch = on_arch_conditional arm: "-arm64"
 
   version "2.0.6,5413878570549248"
   sha256 arm:   "bf2ec5b31f03d1fbc98213e45a613319e7527d97badb7f09cb8357d9c1e86a9d",
@@ -13,13 +12,14 @@ cask "antigravity" do
   homepage "https://antigravity.google/product/antigravity-2"
 
   livecheck do
-    url "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/darwin#{livecheck_arch}/stable/latest"
-    regex(%r{/antigravity-hub/([^/]+)/}i)
-    strategy :json do |json, regex|
-      match = json["url"]&.match(regex)
-      next if match.blank?
+    url "https://antigravity.google/product/antigravity-2"
+    regex(%r{/antigravity-hub/(\d+(?:\.\d+)+)-(\d+)/darwin-(?:arm|x64)/Antigravity\.dmg}i)
+    strategy :page_match do |page, regex|
+      js_file = page[/src=["']([^"']*main[._-][^"']+\.js)["']/i, 1]
+      next if js_file.blank?
 
-      match[1]&.tr("-", ",").to_s
+      js_page = Homebrew::Livecheck::Strategy.page_content(URI.join("https://antigravity.google/", js_file).to_s)
+      js_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -2,9 +2,9 @@ cask "antigravity" do
   arch arm: "arm", intel: "x64"
   livecheck_arch = on_arch_conditional arm: "-arm64"
 
-  version "2.0.1,6566078776737792"
-  sha256 arm:   "2878f16713550600a71c25f3ea56007c472a7962bb75d58ae41a9219afb1e3d2",
-         intel: "dd4b060a98b56b66bd122c3152eadc0cd9b02e6a0b46748c95cb3ea13a7d457b"
+  version "2.0.6,5413878570549248"
+  sha256 arm:   "bf2ec5b31f03d1fbc98213e45a613319e7527d97badb7f09cb8357d9c1e86a9d",
+         intel: "c6f5e1ca86e6dcd4d8b49be6dfab7a38776df243434996ca0c1ba8bedcde40f0"
 
   url "https://storage.googleapis.com/antigravity-public/antigravity-hub/#{version.csv.first}-#{version.csv.second}/darwin-#{arch}/Antigravity.dmg",
       verified: "storage.googleapis.com/antigravity-public/antigravity-hub/"

--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -1,5 +1,6 @@
 cask "antigravity" do
   arch arm: "arm", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "x64"
 
   version "2.0.6,5413878570549248"
   sha256 arm:   "bf2ec5b31f03d1fbc98213e45a613319e7527d97badb7f09cb8357d9c1e86a9d",
@@ -12,14 +13,15 @@ cask "antigravity" do
   homepage "https://antigravity.google/product/antigravity-2"
 
   livecheck do
-    url "https://antigravity.google/product/antigravity-2"
-    regex(%r{/antigravity-hub/(\d+(?:\.\d+)+)-(\d+)/darwin-(?:arm|x64)/Antigravity\.dmg}i)
-    strategy :page_match do |page, regex|
-      js_file = page[/src=["']([^"']*main[._-][^"']+\.js)["']/i, 1]
-      next if js_file.blank?
+    url "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-#{livecheck_arch}-mac.yml?noCache=#{Time.now.to_i}"
+    regex(%r{/v?(\d+(?:\.\d+)+)(?:-(\d+)?)/darwin-#{arch}/Antigravity\.dmg}i)
+    strategy :electron_builder do |yaml, regex|
+      yaml["files"]&.map do |item|
+        match = item["url"]&.match(regex)
+        next if match.blank?
 
-      js_page = Homebrew::Livecheck::Strategy.page_content(URI.join("https://antigravity.google/", js_file).to_s)
-      js_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
     end
   end
 


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

Updated `antigravity` to `2.0.6,5413878570549248` with checksums generated by `brew bump-cask-pr`. Also updated `livecheck` to use the current Electron Builder manifest endpoint from the 2.0.6 app because the previous updater endpoint still reports `2.0.1`.

Validation:
- `brew bump-cask-pr --dry-run --version 2.0.6,5413878570549248 --no-browse antigravity`
- `brew style --fix antigravity.rb`
- `brew livecheck --cask --autobump antigravity --json`
- `brew audit --cask --online antigravity`

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online antigravity` is error-free.
- [x] `brew style --fix antigravity` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. I used AI assistance to inspect the cask, run the Homebrew bump workflow, diagnose the stale livecheck endpoint, and prepare the follow-up livecheck fix. I manually verified the generated checksums, public download source, updater-manifest livecheck result, audit/style results, and confirmed that no `zap` paths changed.