### PR TITLE
Add arm support for Hubstaff Cask

### DIFF
--- a/Casks/h/hubstaff.rb
+++ b/Casks/h/hubstaff.rb
@@ -1,8 +1,11 @@
 cask "hubstaff" do
-  version "1.9.2,12156"
-  sha256 "4554bbba0da2d5ab1a9f61148fa3b8424c247be4e16ef3beec575dfa4c0c020b"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://app.hubstaff.com/download/#{version.csv.second}-standard-mac-os-x-#{version.csv.first.dots_to_hyphens}-release"
+  version "1.9.2,12156"
+  sha256 arm:   "c47c1fd6250770844cf9a85437861a5e17967a279e90de21f5c5bdb9085c0c8e",
+         intel: "4554bbba0da2d5ab1a9f61148fa3b8424c247be4e16ef3beec575dfa4c0c020b"
+
+  url "https://app.hubstaff.com/download/#{version.csv.second}-standard-mac-os-x-#{version.csv.first.dots_to_hyphens}-release/dmg?architecture=#{arch}"
   name "Hubstaff"
   desc "Work time tracker"
   homepage "https://hubstaff.com/"
@@ -26,8 +29,4 @@ cask "hubstaff" do
     "~/Library/Application Support/Hubstaff",
     "~/Library/Preferences/com.netsoft.Hubstaff.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
Introduce `arm64` arch to HubStaff cask
ref: https://app.hubstaff.com/appcast.xml

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] ` brew audit --strict --online --skip-style --cask homebrew/cask/hubstaff` is error-free.
- [x] `brew style --fix hubstaff` reports no offenses.
- [x] `brew lgtm --online` 
-----

- [ ] AI was used to generate or assist with generating this PR.
-----