### PR TITLE
ummaya 0.1.17 (new cask)

### DIFF
--- a/Casks/u/ummaya.rb
+++ b/Casks/u/ummaya.rb
@@ -1,9 +1,9 @@
 cask "ummaya" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.1.17"
-  sha256 arm:   "88280d98f256fac399726adbc794723593e11ff4f2d4a060d8fda71e8137bc88",
-         intel: "6823e69f32de101e2d4826c3eb9e73e8aa85bd5d793789637dbf49b570a94660"
+  version "0.1.18"
+  sha256 arm:   "84fee75d4fe826ef66cd56e8c48f551c4f00d753f7b4cb07af10e4488b4de0f8",
+         intel: "99ff8d2051b5e5e2f9e3cf1377717d3a6c0097c1fa1f6d55a369d2c589443c35"
 
   url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"
@@ -18,11 +18,9 @@ cask "ummaya" do
   end
 
   depends_on :macos
-  depends_on formula: "bun"
-  depends_on formula: "node"
   depends_on formula: "uv"
 
-  binary "package/bin/ummaya", target: "ummaya"
+  binary "ummaya"
 
   zap trash: "~/.ummaya"
 end

--- a/Casks/u/ummaya.rb
+++ b/Casks/u/ummaya.rb
@@ -1,0 +1,32 @@
+cask "ummaya" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.1.17"
+  sha256 arm:   "88280d98f256fac399726adbc794723593e11ff4f2d4a060d8fda71e8137bc88",
+         intel: "6823e69f32de101e2d4826c3eb9e73e8aa85bd5d793789637dbf49b570a94660"
+
+  url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
+  name "UMMAYA"
+  desc "Conversational multi-agent harness for Korean public-service channels"
+  homepage "https://ummaya-docs.pages.dev/"
+
+  livecheck do
+    url "https://ummaya-docs.pages.dev/downloads/homebrew/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  depends_on :macos
+  depends_on formula: "uv"
+
+  binary "ummaya"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", staged_path.to_s],
+                   sudo: false
+  end
+
+  zap trash: "~/.ummaya"
+end

--- a/Casks/u/ummaya.rb
+++ b/Casks/u/ummaya.rb
@@ -18,15 +18,11 @@ cask "ummaya" do
   end
 
   depends_on :macos
+  depends_on formula: "bun"
+  depends_on formula: "node"
   depends_on formula: "uv"
 
-  binary "ummaya"
-
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", staged_path.to_s],
-                   sudo: false
-  end
+  binary "package/bin/ummaya", target: "ummaya"
 
   zap trash: "~/.ummaya"
 end


### PR DESCRIPTION
Built and tested locally on macOS 26.2.

This addresses the previous #265674 feedback by installing a prebuilt macOS archive instead of running an install-time package manager step.

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ummaya` is error-free.
- [x] `brew style --fix ummaya` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked prior refused PR #265674; the previous install-time build issue is addressed by prebuilt archives.
- [x] `brew audit --cask --new ummaya` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ummaya` worked successfully.
- [x] `brew uninstall --cask ummaya` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. I reviewed the final one-file diff and verified the cask with `brew audit`, `brew style`, install, `ummaya --version`, `ummaya --help`, and uninstall. The `zap` stanza targets the user-level UMMAYA state directory.

-----
