### PR TITLE
Add machodown

### DIFF
--- a/Casks/m/machodown.rb
+++ b/Casks/m/machodown.rb
@@ -1,0 +1,24 @@
+cask "machodown" do
+  version "1.0.0"
+
+  on_arm do
+    sha256 "18093b33f4145a8f53825c08460a96838bb8d11c79c91aaf2f485ed978871ebf"
+    url "https://github.com/hongmacho/machodown/releases/download/v#{version}/Machodown-#{version}-arm64.dmg"
+  end
+  on_intel do
+    sha256 "a8f6397cf6f699eda249fcb566fc02d19167c9091086ce79fd6ea9980644f80d"
+    url "https://github.com/hongmacho/machodown/releases/download/v#{version}/Machodown-#{version}-x64.dmg"
+  end
+
+  name "Machodown"
+  desc "Monaco Editor-based Markdown editor"
+  homepage "https://github.com/hongmacho/machodown"
+
+  app "Machodown.app"
+
+  zap trash: [
+    "~/Library/Application Support/Machodown",
+    "~/Library/Preferences/com.machodown.app.plist",
+    "~/Library/Logs/Machodown",
+  ]
+end


### PR DESCRIPTION
## Description

Adds a new cask for **Machodown**, a Monaco Editor-based Markdown editor for macOS.

## Cask Info

- **Cask name**: `machodown`
- **Version**: `1.0.0`
- **Homepage**: https://github.com/hongmacho/machodown
- **License**: MIT

## Verification

- [x] I have verified the SHA256 checksums match the downloaded files
- [x] The app installs and runs correctly on macOS (arm64 and x64)
- [x] The app is code-signed and notarized by Apple
- [x] The cask follows Homebrew Cask conventions

## Download URLs

- arm64: https://github.com/hongmacho/machodown/releases/download/v1.0.0/Machodown-1.0.0-arm64.dmg
- x64: https://github.com/hongmacho/machodown/releases/download/v1.0.0/Machodown-1.0.0-x64.dmg