### PR TITLE
Add cask definition for Trickster

### DIFF
--- a/Casks/t/trickster.rb
+++ b/Casks/t/trickster.rb
@@ -1,0 +1,26 @@
+cask "trickster" do
+  version "3.9.11"
+  sha256 "3d0026adac43bf8d40584ee6150cbe327b46c609508f07f2ecc2a19692495232"
+
+  url "https://dl.apparentsoft.com/TricksterUpdates/Trickster_#{version}.zip"
+  name "Trickster"
+  desc "Quickly access recently changed or modified files with a keyboard shortcut"
+  homepage "https://www.apparentsoft.com/trickster"
+
+  livecheck do
+    url "https://dl.apparentsoft.com/TricksterUpdates/appcast.rss"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Trickster.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.apparentsoft.trickster",
+    "~/Library/Application Scripts/com.apparentsoft.TricksterLauncher",
+    "~/Library/Containers/com.apparentsoft.trickster",
+    "~/Library/Containers/com.apparentsoft.TricksterLauncher",
+  ]
+end


### PR DESCRIPTION
Trickster is one of my default go-to apps. I'm centralizing on homebrew for managing my default computer setup and but it's not available via `brew` yet.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

```
❯ brew style --fix trickster

1 file inspected, no offenses detected

❯ brew audit --cask --new trickster
==> Downloading and extracting artifacts
==> Downloading https://dl.apparentsoft.com/TricksterUpdates/Trickster_3.9.11.zip
Already downloaded: /.../Library/Caches/Homebrew/downloads/59d83460a217cfc6c144608e2d563bd5bcdc8d798db97dc7cd9442d1867f31bc--Trickster_3.9.11.zip
==> Downloading https://dl.apparentsoft.com/TricksterUpdates/Trickster_3.9.11.zip
Already downloaded: /.../Library/Caches/Homebrew/downloads/59d83460a217cfc6c144608e2d563bd5bcdc8d798db97dc7cd9442d1867f31bc--Trickster_3.9.11.zip

❯ brew uninstall --cask trickster
==> Uninstalling Cask trickster
==> Backing App 'Trickster.app' up to '/opt/homebrew/Caskroom/trickster/latest/Trickster.app'
==> Removing App '/Applications/Trickster.app'
==> Purging files for version latest of Cask trickster

❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask trickster
==> Auto-updating Homebrew...
Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with
`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Fetching downloads for: trickster
✔︎ Cask trickster (3.9.11)                                                                                                                                                                                                                                                                          Verifying     6.0MB/  6.0MB
==> Installing Cask trickster
==> Moving App 'Trickster.app' to '/Applications/Trickster.app'
🍺  trickster was successfully installed!
```