### PR TITLE
chronoid 1.0.84 (new cask)

### DIFF
--- a/Casks/c/chronoid.rb
+++ b/Casks/c/chronoid.rb
@@ -1,0 +1,28 @@
+cask "chronoid" do
+  version "1.0.84"
+  sha256 "2ea57155de8c1ea76177debd62dcad17a9a3e0bd48124a6f72ab998dda8bfc06"
+
+  url "https://download.chronoid.app/Chronoid-#{version}.dmg"
+  name "Chronoid"
+  desc "Automatic time tracker and productivity insights app"
+  homepage "https://chronoid.app/"
+
+  livecheck do
+    url "https://download.chronoid.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Chronoid.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.vu.Chronoid",
+    "~/Library/Caches/com.vu.Chronoid",
+    "~/Library/HTTPStorages/com.vu.Chronoid",
+    "~/Library/Preferences/com.vu.Chronoid.plist",
+    "~/Library/Saved Application State/com.vu.Chronoid.savedState",
+    "~/Library/WebKit/com.vu.Chronoid",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.3.1.

The submission is for a stable version distributed as a prebuilt notarized macOS DMG.

- `brew audit --cask --online vunguyentuan/homebrew-cask/chronoid` is error-free.
- `brew style --fix Casks/c/chronoid.rb` reports no offenses.

Additionally, as this adds a new cask:

- Named the cask according to the token reference.
- Checked prior refused PRs and did not find an earlier refused Chronoid cask submission.
- `brew audit --cask --new vunguyentuan/homebrew-cask/chronoid` worked successfully.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask vunguyentuan/homebrew-cask/chronoid --appdir=~/Applications/HomebrewTest` worked successfully.
- `HOMEBREW_NO_INSTALL_FROM_API=1 HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask chronoid` worked successfully.
- AI was used to assist with this PR. I reviewed the final one-file diff and verified the cask with `brew audit --cask --online`, `brew audit --cask --new`, `brew style --fix`, install, and uninstall. Chronoid is a GUI app bundle, so CLI checks such as `chronoid --version` and `chronoid --help` do not apply. The `zap` stanza was narrowed to paths verified locally for `com.vu.Chronoid` in `~/Library` and cross-checked against app behavior in the source, including bundle-ID-based Application Support and preferences storage plus the app's `WKWebView` usage.
