### PR TITLE
Add Kashot 0.3.7

### DIFF
--- a/Casks/k/kashot.rb
+++ b/Casks/k/kashot.rb
@@ -1,0 +1,20 @@
+cask "kashot" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.3.7"
+  sha256  arm:   "7b17875f27a85aac152cd9e121dd3e3a26f375d85f6d2b0535f16d77f0b25e68",
+          intel: "e5f13152b2ab26895d8448851f56150660dcd22fb423dafdd3613dcc514f5f59"
+
+  url       "https://github.com/singhpratech/kashot/releases/download/v#{version}/Kashot-macos-#{arch}.dmg",
+            verified: "github.com/singhpratech/kashot/"
+  name      "Kashot"
+  desc      "Fast screenshots with annotations — tray-resident, hotkey-driven, free"
+  homepage  "https://kashot.org/"
+
+  app "Kashot.app"
+
+  zap trash: [
+    "~/Library/Application Support/Kashot",
+    "~/Library/Preferences/org.kashot.app.plist",
+  ]
+end


### PR DESCRIPTION
## Checklist

- [x] I am submitting a new cask for an existing application that is not already on Homebrew Cask.
- [x] I have read the [Adding a Cask](https://docs.brew.sh/Adding-Software-to-Homebrew#adding-a-cask) section of the Homebrew Cask documentation.
- [x] The cask sources from a stable, versioned release.
- [x] The artifact stanza is correct (`app "Kashot.app"` from the DMG).
- [x] Both architectures (`arm64` + `x64`) are covered with verified SHA256s.
- [x] `zap` cleans up the app's settings + plist on uninstall.

## About Kashot

Fast, free, tray-resident screenshot tool with a built-in annotation editor — one Rust binary on macOS / Windows / Linux, this cask is the macOS install.

- **Homepage:** https://kashot.org/
- **Source:** https://github.com/singhpratech/kashot
- **License:** Apache-2.0
- **Release:** v0.3.7 (2026-05-24)

Artifacts are signed-free .app bundles inside a DMG (built by GitHub Actions on tag push). Both arm64 + x64 .dmg SHAs come straight from the published SHA256SUMS.