### PR TITLE
Add mcp-curator

### DIFF
--- a/Casks/m/mcp-curator.rb
+++ b/Casks/m/mcp-curator.rb
@@ -1,0 +1,26 @@
+cask "mcp-curator" do
+  version "0.1.0"
+  sha256 "1b50b5fd4a92af3774ad3fa54631caf9512597fb4d96e4bc8da4b66035566f81"
+
+  url "https://github.com/strawberry-code/mcp-curator/releases/download/v#{version}/MCP.Curator_#{version}_aarch64.dmg"
+  name "MCP Curator"
+  desc "Desktop manager for Claude Code MCP server configurations"
+  homepage "https://github.com/strawberry-code/mcp-curator"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+  depends_on arch: :arm64
+
+  app "MCP Curator.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.strawberry-code.mcp-curator",
+    "~/Library/Caches/com.strawberry-code.mcp-curator",
+    "~/Library/Preferences/com.strawberry-code.mcp-curator.plist",
+    "~/Library/Saved Application State/com.strawberry-code.mcp-curator.savedState",
+  ]
+end


### PR DESCRIPTION
## Cask PR Checklist

- [x] `brew audit --cask mcp-curator` passes
- [x] `brew style Casks/m/mcp-curator.rb` passes (0 offenses)
- [x] App is open-source (MIT): https://github.com/strawberry-code/mcp-curator
- [x] App is notarized for macOS (`source=Notarized Developer ID`)
- [x] GitHub release with DMG attached: https://github.com/strawberry-code/mcp-curator/releases/tag/v0.1.0
- [x] SHA256 verified
- [x] `depends_on arch: :arm64` — arm64 only (Apple Silicon), no Intel build
- [x] `depends_on macos: :ventura` — minimum macOS 13

## Notes

MCP Curator is a native macOS desktop app (Tauri v2 + Go sidecar, no Electron) for managing Claude Code MCP server configurations across all four config scopes from a single sidebar.