### PR TITLE
Add notchy 1.0.8

### DIFF
--- a/Casks/n/notchy.rb
+++ b/Casks/n/notchy.rb
@@ -1,0 +1,27 @@
+cask "notchy" do
+  version "1.0.8"
+  sha256 "e220bf327395727eaea85cccb890a17c6136da68ae12b6149ffaef721b224c19"
+
+  url "https://notchy.dev/Notchy-#{version}.zip"
+  name "Notchy"
+  desc "Fluid Dynamic Island utility for the notch"
+  homepage "https://notchy.dev/"
+
+  livecheck do
+    url "https://notchy.dev/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "Notchy.app"
+
+  zap trash: [
+    "~/Library/Application Support/Notchy",
+    "~/Library/Caches/com.vishvavariya.Notchy",
+    "~/Library/HTTPStorages/com.vishvavariya.Notchy",
+    "~/Library/Preferences/com.vishvavariya.Notchy.plist",
+    "~/Library/Saved Application State/com.vishvavariya.Notchy.savedState",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online notchy` is error-free.
- [x] `brew style --fix notchy` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new notchy` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask notchy` worked successfully.
- [x] `brew uninstall --cask notchy` worked successfully.

- [x] AI was used to generate or assist with generating this PR.

AI assisted in drafting the initial structure and syntax of the cask formula (including Sparkle appcast livecheck block).

Manually verified by:
1. Confirming the `livecheck` block target matches the public Sparkle feed at https://notchy.dev/appcast.xml.
2. Checking the exact bundle identifier (`com.vishvavariya.Notchy`) inside the macOS application container structure to verify the correctness of the `zap` paths.
3. Manually confirming that the application creates preferences, HTTP cache storage, and saved state files at the standard sandboxed paths listed:
   - `~/Library/Application Support/Notchy`
   - `~/Library/Caches/com.vishvavariya.Notchy`
   - `~/Library/HTTPStorages/com.vishvavariya.Notchy`
   - `~/Library/Preferences/com.vishvavariya.Notchy.plist`
   - `~/Library/Saved Application State/com.vishvavariya.Notchy.savedState`
4. Successfully running local commands (`brew audit --new`, `brew install`, and `brew uninstall`) on a macOS Ventura test machine to ensure smooth installation and clean removal.
