### PR TITLE
1password-cli: Fix `zap` stanza

### DIFF
--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -28,5 +28,5 @@ cask "1password-cli" do
 
   binary "op"
 
-  zap trash: "~/.op"
+  zap trash: "~/.config/op"
 end


### PR DESCRIPTION
According to https://www.1password.dev/cli/config-directories, the default config directory is `~/.config/op` when $XDG_CONFIG_HOME is not set. The 1Password CLI will also use `~/.op`, but it won't automatically create it, so it shouldn't be zapped.

This aligns 1password-cli with 1password-cli@beta.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.