### PR TITLE
macfax 0.2.56 (new cask)

### DIFF
--- a/Casks/m/macfax.rb
+++ b/Casks/m/macfax.rb
@@ -1,0 +1,27 @@
+cask "macfax" do
+  version "0.2.56"
+  sha256 "b6d9aeb8b8ec033807ff74535a80287ff431a1d71074117fc4da3d7c0ab6e99a"
+
+  url "https://macfax.com/Macfax-#{version}.dmg"
+  name "Macfax"
+  desc "Tamper-proof verification reports for Macs"
+  homepage "https://macfax.com/"
+
+  livecheck do
+    url "https://macfax.com/Macfax.dmg"
+    strategy :extract_plist
+  end
+
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "Macfax.app"
+
+  zap trash: [
+    "~/Library/Application Support/Macfax",
+    "~/Library/Caches/com.macfax.app",
+    "~/Library/HTTPStorages/com.macfax.app",
+    "~/Library/Preferences/com.macfax.app.plist",
+    "~/Library/Saved Application State/com.macfax.app.savedState",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version.
- [x] `brew audit --cask --online macfax` is error-free.
- [x] `brew style --fix macfax` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new macfax` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask macfax` worked successfully.
- [x] `brew uninstall --cask macfax` worked successfully.

- [ ] AI was used to generate or assist with generating this PR.

-----

Cask for Macfax. Free Mac diagnostic that produces a signed verification report covering Activation Lock state, Apple Coverage, serial match, and hardware spec.

Verified on my M2 Air, Sequoia:

- `brew style --fix Casks/m/macfax.rb`: clean
- `brew audit --cask --new --online macfax`: no errors
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask macfax`: installs, app launches, Gatekeeper accepts (notarization staple present)
- `brew uninstall --cask macfax`: clean
- `zap` paths match where the app writes
