### PR TITLE
Add batorrent

### DIFF
--- a/Casks/b/batorrent.rb
+++ b/Casks/b/batorrent.rb
@@ -1,0 +1,19 @@
+cask "batorrent" do
+  version "2.5.1"
+  sha256 "639798814ad7236f0e989458bb0811033e7999aae581be85ef746faeea7fc36b"
+
+  url "https://github.com/Mateuscruz19/BAT-Torrent/releases/download/v#{version}/BATorrent-macos-arm64.dmg"
+  name "BATorrent"
+  desc "Open-source BitTorrent client with VPN kill switch, anti-Xunlei, Tor, and 7 languages"
+  homepage "https://github.com/Mateuscruz19/BAT-Torrent"
+
+  depends_on macos: ">= :monterey"
+  depends_on arch: :arm64
+
+  app "BATorrent.app"
+
+  zap trash: [
+    "~/Library/Application Support/BATorrent",
+    "~/Library/Preferences/com.batorrent.app.plist",
+  ]
+end


### PR DESCRIPTION
BATorrent is a free, open-source BitTorrent client built with C++, Qt 6, and libtorrent-rasterbar.

- **Homepage:** https://github.com/Mateuscruz19/BAT-Torrent
- **License:** MIT
- **Platform:** macOS 12+ (Apple Silicon)
- **Download:** DMG from GitHub Releases