### PR TITLE
phoenix-slides 1.6

### DIFF
--- a/Casks/p/phoenix-slides.rb
+++ b/Casks/p/phoenix-slides.rb
@@ -1,14 +1,14 @@
 cask "phoenix-slides" do
-  version "1.5.9"
-  sha256 "2798254b06080b41770d5ac383ec5998bd8920227a85121f505b290262e72e04"
+  version "1.6"
+  sha256 "cac62d9b99dca6f9820c275f0ba90db22c31cf7495564cedabadfff6303a82e9"
 
-  url "https://github.com/gobbledegook/creevey/releases/download/v#{version}/phoenix-slides-#{version.no_dots}.dmg",
+  url "https://github.com/gobbledegook/creevey/releases/download/v#{version}/phoenix-slides-#{version.no_dots.ljust(3, "0")}.dmg",
       verified: "github.com/gobbledegook/creevey/"
   name "Phoenix Slides"
   desc "Full-screen slideshow program"
   homepage "https://blyt.net/phxslides/"
 
-  depends_on :macos
+  depends_on macos: :big_sur
 
   app "Phoenix Slides.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`phoenix-slides` is autobumped but the workflow failed to update to version 1.6 because the dmg file name uses "160" as the no-dots version but the cask URL will use "16". This was also the case in the previous minor update (i.e., "150" for 1.5), so this seems to be a predictable pattern that we can account for. This updates the version and modifies the `url` to add trailing zeroes to the interpolated no-dots version when it's fewer than three digits.