### PR TITLE
semeru-jdk-open@21 21.0.11.0

### DIFF
--- a/Casks/s/semeru-jdk-open@21.rb
+++ b/Casks/s/semeru-jdk-open@21.rb
@@ -1,11 +1,11 @@
 cask "semeru-jdk-open@21" do
   arch arm: "aarch64", intel: "x64"
 
-  version "21.0.10.1,21.0.10,7.1,openj9-0.57.0"
-  sha256 arm:   "d9fc00a70d691e529e4577db3d6b93c3524317186957de96dab3a746efd92d22",
-         intel: "dd9d3bf01a38163c8ddc00182018c0c6719d08ff35d1687131f41f2a3e32e17a"
+  version "21.0.11.0"
+  sha256 arm:   "3e4a095806c1413ed3e54aad638391ee3ed0a4378d52b12e9dbd66d3985591c7",
+         intel: "63ddaa9f02e0a5b1155584093a13cabd7871013348dfcd01500cdb5ff9e9724a"
 
-  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version.csv.second}%2B#{version.csv.third}_#{version.csv.fourth}/ibm-semeru-open-jdk_#{arch}_mac_#{version.csv.first}.pkg",
+  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version}/ibm-semeru-open-jdk_#{arch}_mac_#{version}.pkg",
       verified: "github.com/ibmruntimes/semeru#{version.major}-binaries/"
   name "IBM Semeru Runtime (JDK 21) Open Edition"
   desc "Production-ready JDK with the OpenJDK class libraries and the Eclipse OpenJ9 JVM"
@@ -13,23 +13,12 @@ cask "semeru-jdk-open@21" do
 
   livecheck do
     url :url
-    regex(%r{
-      /jdk[._-]v?(\d+(?:\.\d+)*)%2B(\d+(?:\.\d+)*)[._-]([^/]+)/
-      ibm[._-]semeru[._-]open[._-]jdk[._-]#{arch}[._-]mac[._-]v?(\d+(?:\.\d+)+)\.pkg
-    }ix)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["browser_download_url"]&.match(regex)
-        next if match.blank?
-
-        "#{match[4]},#{match[1]},#{match[2]},#{match[3]}"
-      end
-    end
+    strategy :github_latest
   end
 
   depends_on :macos
 
-  pkg "ibm-semeru-open-jdk_#{arch}_mac_#{version.csv.first}.pkg"
+  pkg "ibm-semeru-open-jdk_#{arch}_mac_#{version}.pkg"
 
   uninstall pkgutil: "net.ibm-semeru-open.#{version.major}.jdk"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`semeru-jdk-open@21` is autobumped but the workflow failed to update to version 21.0.11.0 because upstream is using a simple version format for this release and the complicated `livecheck` block regex doesn't match it. This updates the version and adjusts the cask accordingly. The tag version and file name version match, so this simplifies the `livecheck` block to use the default `GithubLatest` strategy logic for now.