### PR TITLE
semeru-jdk-open@8 8.0.492.0

### DIFF
--- a/Casks/s/semeru-jdk-open@8.rb
+++ b/Casks/s/semeru-jdk-open@8.rb
@@ -1,34 +1,23 @@
 cask "semeru-jdk-open@8" do
-  version "8.0.482.1,8u482,b08.1,openj9-0.57.0"
-  sha256 "3273fca81b8a06265cc9ca6d973785adbe4bcc995798009da7c2ef07e2a3f972"
+  version "8.0.492.0"
+  sha256 "eab5c53f1f980a851a63a7793b3bb4bf0e9af22e97acd33c2b0f8e11999d4da9"
 
-  url "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk#{version.csv.second}-#{version.csv.third}_#{version.csv.fourth}/ibm-semeru-open-jdk_x64_mac_#{version.csv.first}.pkg",
-      verified: "github.com/ibmruntimes/semeru8-binaries/"
+  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version}/ibm-semeru-open-jdk_x64_mac_#{version}.pkg",
+      verified: "github.com/ibmruntimes/semeru#{version.major}-binaries/"
   name "IBM Semeru Runtime (JDK 8) Open Edition"
   desc "Production-ready JDK with the OpenJDK class libraries and the Eclipse OpenJ9 JVM"
   homepage "https://developer.ibm.com/languages/semeru-runtimes/"
 
   livecheck do
     url :url
-    regex(%r{
-      /(?:jdk)?(\d+u\d+)[._-](b(?:\d+(?:\.\d+)*))[._-]([^/]+)/
-      ibm[._-]semeru[._-]open[._-]jdk[._-]x64[._-]mac[._-]v?(\d+(?:\.\d+)+)\.pkg
-    }ix)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["browser_download_url"]&.match(regex)
-        next if match.blank?
-
-        "#{match[4]},#{match[1]},#{match[2]},#{match[3]}"
-      end
-    end
+    strategy :github_latest
   end
 
   depends_on :macos
 
-  pkg "ibm-semeru-open-jdk_x64_mac_#{version.csv.first}.pkg"
+  pkg "ibm-semeru-open-jdk_x64_mac_#{version}.pkg"
 
-  uninstall pkgutil: "net.ibm-semeru-open.8.jdk"
+  uninstall pkgutil: "net.ibm-semeru-open.#{version.major}.jdk"
 
   # No zap stanza required
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`semeru-jdk-open@8` is autobumped but the workflow failed to update to version 8.0.492.0 because upstream is using a simple version format for this release and the complicated `livecheck` block regex doesn't match it. This updates the version and adjusts the cask accordingly. The tag version and file name version match, so this simplifies the `livecheck` block to use the default `GithubLatest` strategy logic for now.

Besides that, this also makes some tweaks to bring the cask more in line with the other `semeru-jdk-open@*` casks.