### PR TITLE
generate_cask_token: re-exec under brew ruby on old Ruby

### DIFF
--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -11,6 +11,8 @@
 # merge entirely into "brew create" command
 #
 
+exec "brew", "ruby", __FILE__, *ARGV if RUBY_VERSION < "4.0"
+
 ###
 ### dependencies
 ###


### PR DESCRIPTION
Closes #265896. Re-execs under `brew ruby` when invoked from a Ruby older than the Portable Ruby Homebrew ships, so `Pathname` (autoloaded in Ruby 4.0+) is available regardless of which `ruby` the shebang picks up from PATH.