### PR TITLE
grok-build 0.1.220 (new cask)

### DIFF
--- a/Casks/g/grok-build.rb
+++ b/Casks/g/grok-build.rb
@@ -1,12 +1,12 @@
-cask "grok-build@beta" do
+cask "grok-build" do
   arch arm: "aarch64", intel: "x86_64"
   os macos: "macos", linux: "linux"
 
-  version "0.1.219"
-  sha256 arm:          "2b640258cc0f33140afce7b6cb16ffa86d4c9102e74954b44788e90a2d4d727d",
-         intel:        "ec68e45bd8c62c488f81bb31467544ccfca934f01b1083b6118bd0eb7a73dd2a",
-         arm64_linux:  "7dde7fc1ec8154edb9f2ff2dab2a8683916306892bba03098d1706552e717266",
-         x86_64_linux: "c71370e7408f9969bb2c44833efb85943d271758eeaaf62108e70b78e2130acb"
+  version "0.1.220"
+  sha256 arm:          "1320310df276ef7883675236b0d2600f957c929d3ab49674f1c019c5981a0a94",
+         intel:        "3c0392e5f04152f220022c05ac24a9dbc0868604be6db83c42bb6ce304b7dc44",
+         arm64_linux:  "3b15efc258f4219d01736acee70c575a8167f970cb4d497a3b0c218440db58ff",
+         x86_64_linux: "98d331d64dfc4fb1dae862475218cccdd195f76839b8361a0678af2fd388364b"
 
   url "https://x.ai/cli/grok-#{version}-#{os}-#{arch}"
   name "Grok Build"

--- a/Casks/g/grok-build@beta.rb
+++ b/Casks/g/grok-build@beta.rb
@@ -1,0 +1,27 @@
+cask "grok-build@beta" do
+  arch arm: "aarch64", intel: "x86_64"
+  os macos: "macos", linux: "linux"
+
+  version "0.1.219"
+  sha256 arm:          "2b640258cc0f33140afce7b6cb16ffa86d4c9102e74954b44788e90a2d4d727d",
+         intel:        "ec68e45bd8c62c488f81bb31467544ccfca934f01b1083b6118bd0eb7a73dd2a",
+         arm64_linux:  "7dde7fc1ec8154edb9f2ff2dab2a8683916306892bba03098d1706552e717266",
+         x86_64_linux: "c71370e7408f9969bb2c44833efb85943d271758eeaaf62108e70b78e2130acb"
+
+  url "https://x.ai/cli/grok-#{version}-#{os}-#{arch}"
+  name "Grok Build"
+  desc "Extensible coding agent for the terminal"
+  homepage "https://x.ai/cli"
+
+  livecheck do
+    url "https://x.ai/cli/stable"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  binary "grok-#{version}-#{os}-#{arch}", target: "grok"
+  binary "grok-#{version}-#{os}-#{arch}", target: "agent"
+
+  generate_completions_from_executable "grok-#{version}-#{os}-#{arch}", "completions", base_name: "grok"
+
+  zap rmdir: "~/.grok"
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

Adds the Grok Build CLI from xAI's published stable channel.

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with authoring the cask and applying review feedback. I reviewed the official download/version source and the `zap rmdir: "~/.grok"` path, and verified `grok-build` version `0.1.220` using `brew style --fix`, both required audits, installation, command invocation, and uninstallation.

-----
