### PR TITLE
rockxy 0.22.0,35

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.21.1,34"
-  sha256 "be198ac5d1af3f509b1a8a9c123cda601d235b22f332fa7a5e280f74fd025f87"
+  version "0.22.0,35"
+  sha256 "dcb5e6f1b0a86d641ee6009855c4dad9b6cf56d96501c9abe91a3e63b2b284fa"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.22.0 build 35.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.22.0/Rockxy-0.22.0-35.dmg
- SHA-256: dcb5e6f1b0a86d641ee6009855c4dad9b6cf56d96501c9abe91a3e63b2b284fa
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
