### PR TITLE
smoothcapture 1.2.47 (new cask)

### DIFF
--- a/Casks/s/smoothcapture.rb
+++ b/Casks/s/smoothcapture.rb
@@ -1,0 +1,29 @@
+cask "smoothcapture" do
+  version "1.2.47"
+  sha256 "cd91ddecbf186d8b11a93356852ab45e0c9d83be1b49b9c0bfd3ea1b6176901c"
+
+  url "https://download.smoothcapture.app/SmoothCapture-#{version}.dmg"
+  name "Smooth Capture"
+  name "SmoothCapture"
+  desc "Screen recorder and video editor"
+  homepage "https://www.smoothcapture.app/"
+
+  livecheck do
+    url "https://download.smoothcapture.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sequoia
+
+  app "SmoothCapture.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.vu.SmoothCapture",
+    "~/Library/Caches/com.vu.SmoothCapture",
+    "~/Library/HTTPStorages/com.vu.SmoothCapture",
+    "~/Library/HTTPStorages/com.vu.SmoothCapture.binarycookies",
+    "~/Library/Preferences/com.vu.SmoothCapture.plist",
+    "~/Library/WebKit/com.vu.SmoothCapture",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

The submission is for a stable version distributed as a prebuilt macOS DMG.

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online smoothcapture` is error-free.
- [x] `brew style --fix smoothcapture` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new smoothcapture` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask smoothcapture -- appdir=~/Applications/HomebrewTest` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask smoothcapture` worked successfully.
- [x] AI was used to generate or assist with generating this PR.

AI assisted with drafting the one-file cask. I manually reviewed the final diff and verified `brew style --fix`, `brew audit --cask --online`, `brew audit --cask --new`, install, and uninstall locally. The `zap` stanza was narrowed to current paths verified from the app source and local `~/Library` data for `com.vu.SmoothCapture`; a legacy `~/Library/Application Support/SmoothCapture` path was intentionally removed because it is outdated for the current app.
