### PR TITLE
activitywatch@beta 0.14.0b1 (new cask)

### DIFF
--- a/Casks/a/activitywatch@beta.rb
+++ b/Casks/a/activitywatch@beta.rb
@@ -1,0 +1,36 @@
+cask "activitywatch@beta" do
+  version "0.14.0b1"
+  sha256 "50a9cffaf7833bb0221c9b7889db50ee432310a536e9302d12d2bb9ac393c48d"
+
+  url "https://github.com/ActivityWatch/activitywatch/releases/download/v#{version}/activitywatch-tauri-v#{version}-macos-arm64.dmg",
+      verified: "github.com/ActivityWatch/activitywatch/"
+  name "ActivityWatch"
+  desc "Time tracker"
+  homepage "https://activitywatch.net/"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
+  conflicts_with cask: "activitywatch"
+  depends_on macos: :big_sur, arch: :arm64
+
+  app "ActivityWatch.app"
+
+  zap trash: [
+    "~/Library/Application Support/activitywatch",
+    "~/Library/Caches/activitywatch",
+    "~/Library/Logs/activitywatch",
+  ]
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,4 +1,5 @@
 {
+  "activitywatch@beta": "any",
   "aerial@beta": "any",
   "agent-tars": "all",
   "amethyst": "any",


### PR DESCRIPTION
Built and tested locally on macOS 15.5 (arm64). `brew audit --cask --new --online`, `brew style`, `brew install`, and `brew uninstall` all pass.

Adds an `@beta` sibling for the existing `activitywatch` cask, tracking the upstream pre-release line. v0.14.0b1 is the first ActivityWatch release with an arm64-native macOS build (Tauri-based), so the cask installs the `activitywatch-tauri-v#{version}-macos-arm64.dmg` asset, declares `arch: :arm64`, and `conflicts_with cask: "activitywatch"` since both ship the same `ActivityWatch.app` (`net.activitywatch.ActivityWatch`).

The livecheck uses the `:github_releases` strategy and keeps pre-releases (pattern lifted from `utm@beta`). Added to `audit_exceptions/github_prerelease_allowlist.json` accordingly.

---

AI disclosure: This PR was drafted with Claude Code. I personally reviewed every change, ran the full validation suite (`brew audit --cask --new --online`, `brew style --fix`, `brew install --cask`, `brew uninstall --cask`) on macOS 15.5 (arm64), and confirmed the `ActivityWatch.app` bundle ID matches the existing cask (justifying `conflicts_with`). The zap stanza mirrors the existing stable cask; I have not exhaustively verified every path the Tauri build writes to.