### PR TITLE
airi 0.10.2 (new cask)

### DIFF
--- a/Casks/a/airi.rb
+++ b/Casks/a/airi.rb
@@ -18,7 +18,7 @@ cask "airi" do
 
   depends_on macos: :monterey
 
-  app "airi.app", target: "AIRI.app"
+  app "AIRI.app"
 
   zap trash: [
     "~/Library/Application Support/ai.moeru.airi",

--- a/Casks/a/airi.rb
+++ b/Casks/a/airi.rb
@@ -1,0 +1,27 @@
+cask "airi" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.10.2"
+  sha256 arm:   "494c2c441e5993fa9d87673f6de6c493d7bcd9a952af7cdd621cd499349ad341",
+         intel: "b0e5b3bf3a3623ab0b2df335fe43e258cf97e287741898952e6a28c4f2a23713"
+
+  url "https://github.com/moeru-ai/airi/releases/download/v#{version}/AIRI-#{version}-darwin-#{arch}.dmg",
+      verified: "github.com/moeru-ai/airi/"
+  name "AIRI"
+  desc "AI companion and VTuber application"
+  homepage "https://airi.moeru.ai/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+
+  app "airi.app", target: "AIRI.app"
+
+  zap trash: [
+    "~/Library/Application Support/ai.moeru.airi",
+    "~/Library/Preferences/ai.moeru.airi.plist",
+  ]
+end


### PR DESCRIPTION
-----
Built and tested locally on macOS 26.5.
Adds AIRI, an AI companion and VTuber application.

Related:
  - https://github.com/moeru-ai/airi/issues/866
  - https://github.com/moeru-ai/airi/pull/1431
  
  -----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to help draft and review the cask. I manually verified the download, install, launch, Gatekeeper checks, uninstall, and `zap` paths. The app creates `~/Library/Application Support/ai.moeru.airi` and `~/Library/Preferences/ ai.moeru.airi.plist` after launch.

-----
