### PR TITLE
aerial 4.0.8

### DIFF
--- a/Casks/a/aerial.rb
+++ b/Casks/a/aerial.rb
@@ -1,11 +1,11 @@
 cask "aerial" do
-  version "3.6.3"
-  sha256 "d0548c8485b57fbab2b04446058df725e8a233c07a2b87b857738971c546ece4"
+  version "4.0.8"
+  sha256 "0d9f3ec4a6e40d3f5fa7d0b1776d2f840fe97a0a1ff3fd5facd069cdea5c510a"
 
-  url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip",
-      verified: "github.com/JohnCoates/Aerial/"
-  name "Aerial Screensaver"
-  desc "Apple TV Aerial screensaver"
+  url "https://github.com/AerialScreensaver/Aerial/releases/download/v#{version}/Aerial-#{version}.zip",
+      verified: "github.com/AerialScreensaver/Aerial/"
+  name "Aerial"
+  desc "Apple TV Aerial screensaver, now as a full macOS app"
   homepage "https://aerialscreensaver.github.io/"
 
   livecheck do
@@ -13,20 +13,41 @@ cask "aerial" do
     strategy :github_latest
   end
 
+  auto_updates true
   conflicts_with cask: "aerial@beta"
-  depends_on :macos
+  depends_on macos: :sequoia
 
-  screen_saver "Aerial.saver"
+  app "Aerial.app"
+
+  uninstall quit: "com.glouel.Aerial-App"
 
   zap trash: [
+    "/Users/Shared/Aerial",
     "~/Library/Application Support/Aerial",
-    "~/Library/Caches/Aerial",
+    "~/Library/Caches/com.glouel.Aerial-App",
     "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Application Support/Aerial",
     "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Caches/Aerial",
     "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/Aerial",
     "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Caches/Aerial",
     "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Preferences/ByHost/com.JohnCoates.Aerial*.plist",
+    "~/Library/Containers/com.glouel.Aerial-App",
+    "~/Library/Containers/com.glouel.Aerial-App.ScreenSaverExtension",
+    "~/Library/HTTPStorages/com.glouel.Aerial-App",
+    "~/Library/Logs/Aerial",
     "~/Library/Preferences/ByHost/com.JohnCoates.Aerial*",
+    "~/Library/Preferences/com.glouel.Aerial-App.plist",
+    "~/Library/Saved Application State/com.glouel.Aerial-App.savedState",
     "~/Library/Screen Savers/Aerial.saver",
   ]
+
+  caveats <<~EOS
+    Aerial is now a full macOS app (was previously a .saver plug-in).
+
+    Launch Aerial.app once after install — it will install its bundled
+    screen saver extension and migrate settings from any previous .saver
+    install. Then enable "Aerial" in System Settings → Screen Saver
+    (or set it as a wallpaper).
+
+    Requires macOS Sequoia (15) or later.
+  EOS
 end

--- a/Casks/a/aerial.rb
+++ b/Casks/a/aerial.rb
@@ -39,15 +39,4 @@ cask "aerial" do
     "~/Library/Saved Application State/com.glouel.Aerial-App.savedState",
     "~/Library/Screen Savers/Aerial.saver",
   ]
-
-  caveats <<~EOS
-    Aerial is now a full macOS app (was previously a .saver plug-in).
-
-    Launch Aerial.app once after install — it will install its bundled
-    screen saver extension and migrate settings from any previous .saver
-    install. Then enable "Aerial" in System Settings → Screen Saver
-    (or set it as a wallpaper).
-
-    Requires macOS Sequoia (15) or later.
-  EOS
 end

--- a/Casks/a/aerial.rb
+++ b/Casks/a/aerial.rb
@@ -5,7 +5,7 @@ cask "aerial" do
   url "https://github.com/AerialScreensaver/Aerial/releases/download/v#{version}/Aerial-#{version}.zip",
       verified: "github.com/AerialScreensaver/Aerial/"
   name "Aerial"
-  desc "Apple TV Aerial screensaver, now as a full macOS app"
+  desc "Apple TV Aerial screensaver"
   homepage "https://aerialscreensaver.github.io/"
 
   livecheck do

--- a/Casks/a/aerial@beta.rb
+++ b/Casks/a/aerial@beta.rb
@@ -1,30 +1,54 @@
 cask "aerial@beta" do
-  version "3.6.3"
-  sha256 "d0548c8485b57fbab2b04446058df725e8a233c07a2b87b857738971c546ece4"
+  version "4.0.8"
+  sha256 "0d9f3ec4a6e40d3f5fa7d0b1776d2f840fe97a0a1ff3fd5facd069cdea5c510a"
 
-  url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip",
-      verified: "github.com/JohnCoates/Aerial/"
-  name "Aerial Screensaver"
+  url "https://github.com/AerialScreensaver/Aerial/releases/download/v#{version}/Aerial-#{version}.zip",
+      verified: "github.com/AerialScreensaver/Aerial/"
+  name "Aerial"
   desc "Apple TV Aerial screensaver"
   homepage "https://aerialscreensaver.github.io/"
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)*(?:[._-]?beta\d+)?)$/i)
+    strategy :github_releases
+    regex(/^v?(\d+(?:\.\d+)+(?:[._-]?beta\d+)?)$/i)
   end
 
+  auto_updates true
   conflicts_with cask: "aerial"
-  depends_on :macos
+  depends_on macos: :sequoia
 
-  screen_saver "Aerial.saver"
+  app "Aerial.app"
+
+  uninstall quit: "com.glouel.Aerial-App"
 
   zap trash: [
+    "/Users/Shared/Aerial",
     "~/Library/Application Support/Aerial",
-    "~/Library/Caches/Aerial",
-    "~/Library/Containers/com.apple.ScreenSaver.*/Data/Library/Application Support/Aerial",
-    "~/Library/Containers/com.apple.ScreenSaver.*/Data/Library/Caches/Aerial",
-    "~/Library/Containers/com.apple.ScreenSaver.*/Data/Library/Preferences/ByHost/com.JohnCoates.Aerial*.plist",
+    "~/Library/Caches/com.glouel.Aerial-App",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Application Support/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Caches/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Caches/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Preferences/ByHost/com.JohnCoates.Aerial*.plist",
+    "~/Library/Containers/com.glouel.Aerial-App",
+    "~/Library/Containers/com.glouel.Aerial-App.ScreenSaverExtension",
+    "~/Library/HTTPStorages/com.glouel.Aerial-App",
+    "~/Library/Logs/Aerial",
     "~/Library/Preferences/ByHost/com.JohnCoates.Aerial*",
+    "~/Library/Preferences/com.glouel.Aerial-App.plist",
+    "~/Library/Saved Application State/com.glouel.Aerial-App.savedState",
     "~/Library/Screen Savers/Aerial.saver",
   ]
+
+  caveats <<~EOS
+    Aerial is now a full macOS app (was previously a .saver plug-in).
+
+    Launch Aerial.app once after install — it will install its bundled
+    screen saver extension and migrate settings from any previous .saver
+    install. Then enable "Aerial" in System Settings → Screen Saver
+    (or set it as a wallpaper).
+
+    Requires macOS Sequoia (15) or later.
+  EOS
 end

--- a/Casks/a/aerial@beta.rb
+++ b/Casks/a/aerial@beta.rb
@@ -40,15 +40,4 @@ cask "aerial@beta" do
     "~/Library/Saved Application State/com.glouel.Aerial-App.savedState",
     "~/Library/Screen Savers/Aerial.saver",
   ]
-
-  caveats <<~EOS
-    Aerial is now a full macOS app (was previously a .saver plug-in).
-
-    Launch Aerial.app once after install — it will install its bundled
-    screen saver extension and migrate settings from any previous .saver
-    install. Then enable "Aerial" in System Settings → Screen Saver
-    (or set it as a wallpaper).
-
-    Requires macOS Sequoia (15) or later.
-  EOS
 end


### PR DESCRIPTION
Bumps `aerial` from 3.6.3 to 4.0.8 and migrates the cask from the legacy `.saver` plug-in
(`JohnCoates/Aerial`) to a full macOS app (`AerialScreensaver/Aerial`).

### Changes
- `screen_saver "Aerial.saver"` → `app "Aerial.app"`
- URL repository: `JohnCoates/Aerial` → `AerialScreensaver/Aerial`
- `depends_on :macos` → `depends_on macos: ">= :sequoia"` (Aerial 4.x targets macOS 15)
- Bundle ID: `com.JohnCoates.Aerial` → `com.glouel.Aerial-App`, with `uninstall quit:` for the menu-bar
process
- `auto_updates true` — Aerial ships its own Sparkle updater, so the on-disk binary version may diverge
from the cask version
- `zap` updated for the new bundle paths; legacy `.saver` paths retained so users upgrading from 3.x get
 a clean filesystem
- Added `caveats` explaining the `.saver` → `.app` transition and the macOS 15 requirement

### Checklist
- [x] `brew style --fix aerial` — no offenses
- [x] `brew audit --cask --strict aerial` — no errors
- [x] `brew install --cask aerial` — app installs to `/Applications`, launches, first-launch wizard
appears, screen saver extension registers via pluginkit
- [x] `brew uninstall --cask --zap aerial` — app and listed zap paths cleared
- [x] `livecheck` (`:github_latest`) confirmed working against the new `AerialScreensaver/Aerial`
releases