### PR TITLE
Add informity-ai cask

### DIFF
--- a/Casks/i/informity-ai.rb
+++ b/Casks/i/informity-ai.rb
@@ -1,0 +1,23 @@
+cask "informity-ai" do
+  arch arm: "aarch64"
+
+  version "0.13.3"
+  sha256 arm: "6b860b60e87e0547e7bec3953042864acef0dfbb9eea70da0abea0bbfe5598eb"
+
+  url "https://www.informity.ai/download/Informity_AI_#{version}_#{arch}.dmg"
+  name "Informity AI"
+  desc "Privacy-first local document intelligence"
+  homepage "https://www.informity.ai"
+
+  livecheck do
+    url "https://github.com/informity/informity-ai"
+    strategy :github_latest
+  end
+
+  app "Informity AI.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.informity.ai",
+    "~/.informity",
+  ]
+end


### PR DESCRIPTION
## Description
Adds a new cask for Informity AI.

- Homepage: https://www.informity.ai
- Download URL pattern: https://www.informity.ai/download/Informity_AI_<version>_aarch64.dmg
- Livecheck source: https://github.com/informity/informity-ai (github_latest)

## Verification
- brew audit --cask --new --tap homebrew/cask Casks/i/informity-ai.rb
