### PR TITLE
mactools 1.0.13 (new cask)

### DIFF
--- a/Casks/m/mactools.rb
+++ b/Casks/m/mactools.rb
@@ -13,7 +13,7 @@ cask "mactools" do
   end
 
   auto_updates true
-  depends_on macos: :sonoma
+  depends_on macos: ">= :sonoma"
 
   app "MacTools.app"
 

--- a/Casks/m/mactools.rb
+++ b/Casks/m/mactools.rb
@@ -13,7 +13,7 @@ cask "mactools" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "MacTools.app"
 

--- a/Casks/m/mactools.rb
+++ b/Casks/m/mactools.rb
@@ -7,11 +7,6 @@ cask "mactools" do
   desc "Menu bar toolbox"
   homepage "https://github.com/ggbond268/MacTools"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
   depends_on macos: :sonoma
 

--- a/Casks/m/mactools.rb
+++ b/Casks/m/mactools.rb
@@ -1,0 +1,29 @@
+cask "mactools" do
+  version "1.0.13"
+  sha256 "3d030537e6b1cd532376dad15c3e1ec69518465198dab6cc6810efb81cdbf0d6"
+
+  url "https://github.com/ggbond268/MacTools/releases/download/v#{version}/MacTools.dmg"
+  name "MacTools"
+  desc "Menu bar toolbox"
+  homepage "https://github.com/ggbond268/MacTools"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "MacTools.app"
+
+  uninstall quit: "cc.ggbond.mactools"
+
+  zap trash: [
+    "~/Library/Application Support/MacTools",
+    "~/Library/Caches/cc.ggbond.mactools",
+    "~/Library/HTTPStorages/cc.ggbond.mactools",
+    "~/Library/Preferences/cc.ggbond.mactools.plist",
+    "~/Library/Saved Application State/cc.ggbond.mactools.savedState",
+  ]
+end


### PR DESCRIPTION
Created with `brew create --cask`? No

- [x] Have you followed the guidelines in the [Contributing](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request) document?
- [x] Have you checked that there are no other open pull requests for the same cask?
- [x] Have you checked the cask has not already been refused in [closed issues](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues)?
- [x] Have you run `brew audit --cask --new mactools` locally?
- [x] Have you run `brew style Casks/m/mactools.rb` locally?
- [x] Have you successfully run `brew install --cask ./Casks/m/mactools.rb` and `brew uninstall --cask --zap mactools` locally?

MacTools is a native macOS menu bar toolbox. The upstream repository currently has 103 GitHub stars and latest release v1.0.13.