### PR TITLE
Add sid-jukebox cask

### DIFF
--- a/Casks/s/sid-jukebox.rb
+++ b/Casks/s/sid-jukebox.rb
@@ -1,0 +1,15 @@
+cask "sid-jukebox" do
+  version "1.0"
+  sha256 "f4a5175c3b43c82f053ec62ed08e4d753545161a1165ca58e88ae161070943ea"
+
+  url "https://github.com/serkantanriverdi/sidJukeBox/releases/download/v#{version}/SIDJukebox_v#{version}.dmg"
+  name "SID Jukebox"
+  desc "Native macOS player for Commodore 64 SID music"
+  homepage "https://github.com/serkantanriverdi/sidJukeBox"
+
+  app "SID Jukebox.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.serkantanriverdi.SIDJukebox.plist",
+  ]
+end


### PR DESCRIPTION
## Description

Adds [SID Jukebox](https://github.com/serkantanriverdi/sidJukeBox), a native macOS player for Commodore 64 SID music.

- Emulates the MOS 6581/8580 SID chip using the cSID engine
- Ships with 100 curated tracks ranked by community consensus (HVSC, Lemon64)
- Universal binary (Apple Silicon + Intel)
- Code signed and notarized (Developer ID: VIV TEKNOLOJI LIMITED SIRKETI)
- Open source (MIT license)

**Download:** [SIDJukebox_v1.0.dmg](https://github.com/serkantanriverdi/sidJukeBox/releases/download/v1.0/SIDJukebox_v1.0.dmg)