### PR TITLE
Add sid-jukebox cask

### DIFF
--- a/Casks/s/sid-jukebox.rb
+++ b/Casks/s/sid-jukebox.rb
@@ -1,0 +1,15 @@
+cask "sid-jukebox" do
+  version "1.0"
+  sha256 "f4a5175c3b43c82f053ec62ed08e4d753545161a1165ca58e88ae161070943ea"
+
+  url "https://github.com/serkantanriverdi/sidJukeBox/releases/download/v#{version}/SIDJukebox_v#{version}.dmg"
+  name "SID Jukebox"
+  desc "Native macOS player for Commodore 64 SID music"
+  homepage "https://github.com/serkantanriverdi/sidJukeBox"
+
+  app "SID Jukebox.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.serkantanriverdi.SIDJukebox.plist",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online sid-jukebox` is error-free.
- [x] `brew style --fix sid-jukebox` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+sid-jukebox&type=pullrequests).
- [x] `brew audit --cask --new sid-jukebox` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask sid-jukebox` worked successfully.
- [x] `brew uninstall --cask sid-jukebox` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR.

-----

Adds [SID Jukebox](https://github.com/serkantanriverdi/sidJukeBox), a native macOS player for Commodore 64 SID music. The app emulates the MOS 6581/8580 SID chip and ships with 100 curated C64 tracks. Code signed and notarized (Developer ID: VIV TEKNOLOJI LIMITED SIRKETI). Universal binary. Open source under MIT license.