### PR TITLE
atomcode 4.23.1 (new cask)

### DIFF
--- a/Casks/a/atomcode.rb
+++ b/Casks/a/atomcode.rb
@@ -13,8 +13,12 @@ cask "atomcode" do
   name "AtomCode"
   desc "Open-source terminal AI coding agent"
   homepage "https://atomgit.com/atomgit_atomcode/atomcode"
-  binary "atomcode"
-  
-  zap rmdir: "~/.atomcode"
 
+  livecheck do
+    skip "Version detection requires authentication on AtomGit"
+  end
+
+  binary "atomcode"
+
+  zap rmdir: "~/.atomcode"
 end

--- a/Casks/a/atomcode.rb
+++ b/Casks/a/atomcode.rb
@@ -1,0 +1,20 @@
+cask "atomcode" do
+  arch arm: "arm64", intel: "x64"
+  os macos: "darwin", linux: "linux"
+
+  version "4.23.1"
+  sha256 arm:          "f094b5b59d938ac542f7e3abf57b4b5684eb6c15e2f591148288b77a04ff6f1c",
+         intel:        "91bd40eef18a18912293fed9423777f500fe2ad7330a3827578c25e6355bd5e9",
+         arm64_linux:  "9b66851888c74d489146b28624d6191e43484f5e79fb9ed2d2428953f5b5a91e",
+         x86_64_linux: "f01730e6d83815bb42279d77979260dd6faee3a970f5218f13b4740c1b7a4787"
+
+  url "https://atomgit.com/atomgit_atomcode/atomcode/releases/download/v#{version}/atomcode-v#{version}-#{os}-#{arch}.tar.gz"
+
+  name "AtomCode"
+  desc "Open-source terminal AI coding agent"
+  homepage "https://atomgit.com/atomgit_atomcode/atomcode"
+  license "MIT"
+
+  binary "atomcode"
+
+end

--- a/Casks/a/atomcode.rb
+++ b/Casks/a/atomcode.rb
@@ -15,7 +15,7 @@ cask "atomcode" do
 
   livecheck do
     url "https://atomgit.com/atomgit_atomcode/atomcode.git"
-    regex(/^v(\d+\.\d+\.\d+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
     strategy :git
   end
 

--- a/Casks/a/atomcode.rb
+++ b/Casks/a/atomcode.rb
@@ -13,8 +13,8 @@ cask "atomcode" do
   name "AtomCode"
   desc "Open-source terminal AI coding agent"
   homepage "https://atomgit.com/atomgit_atomcode/atomcode"
-  license "MIT"
-
   binary "atomcode"
+  
+  zap rmdir: "~/.atomcode"
 
 end

--- a/Casks/a/atomcode.rb
+++ b/Casks/a/atomcode.rb
@@ -1,18 +1,23 @@
 cask "atomcode" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
+
   version "4.23.1"
   sha256 arm:          "f094b5b59d938ac542f7e3abf57b4b5684eb6c15e2f591148288b77a04ff6f1c",
          intel:        "91bd40eef18a18912293fed9423777f500fe2ad7330a3827578c25e6355bd5e9",
          arm64_linux:  "9b66851888c74d489146b28624d6191e43484f5e79fb9ed2d2428953f5b5a91e",
          x86_64_linux: "f01730e6d83815bb42279d77979260dd6faee3a970f5218f13b4740c1b7a4787"
+
   url "https://atomgit.com/atomgit_atomcode/atomcode/releases/download/v#{version}/atomcode-v#{version}-#{os}-#{arch}.tar.gz"
   name "AtomCode"
   desc "Open-source terminal AI coding agent"
   homepage "https://atomgit.com/atomgit_atomcode/atomcode"
+
   livecheck do
     skip "Version detection requires authentication on AtomGit"
   end
+
   binary "atomcode"
+
   zap rmdir: "~/.atomcode"
 end

--- a/Casks/a/atomcode.rb
+++ b/Casks/a/atomcode.rb
@@ -1,24 +1,18 @@
 cask "atomcode" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
-
   version "4.23.1"
   sha256 arm:          "f094b5b59d938ac542f7e3abf57b4b5684eb6c15e2f591148288b77a04ff6f1c",
          intel:        "91bd40eef18a18912293fed9423777f500fe2ad7330a3827578c25e6355bd5e9",
          arm64_linux:  "9b66851888c74d489146b28624d6191e43484f5e79fb9ed2d2428953f5b5a91e",
          x86_64_linux: "f01730e6d83815bb42279d77979260dd6faee3a970f5218f13b4740c1b7a4787"
-
   url "https://atomgit.com/atomgit_atomcode/atomcode/releases/download/v#{version}/atomcode-v#{version}-#{os}-#{arch}.tar.gz"
-
   name "AtomCode"
   desc "Open-source terminal AI coding agent"
   homepage "https://atomgit.com/atomgit_atomcode/atomcode"
-
   livecheck do
     skip "Version detection requires authentication on AtomGit"
   end
-
   binary "atomcode"
-
   zap rmdir: "~/.atomcode"
 end

--- a/Casks/a/atomcode.rb
+++ b/Casks/a/atomcode.rb
@@ -14,7 +14,9 @@ cask "atomcode" do
   homepage "https://atomgit.com/atomgit_atomcode/atomcode"
 
   livecheck do
-    skip "Version detection requires authentication on AtomGit"
+    url "https://atomgit.com/atomgit_atomcode/atomcode.git"
+    regex(/^v(\d+\.\d+\.\d+)$/)
+    strategy :git
   end
 
   binary "atomcode"


### PR DESCRIPTION
The version distributed via a source build (homebrew-core formula) cannot
be code signed by us, which is why we are submitting this as a cask instead.

AtomCode stores OAuth tokens in the system keychain, which requires
Apple Developer ID code signing. A source build would lose the signature
and force repeated password prompts for keychain access.

Pre-built binaries are signed and notarized via our CI pipeline
(sign-macos.sh + Apple notary service).

- [x] The submission is for a stable version
- [x] `brew audit --cask --online atomcode` is error-free
- [x] `brew style --fix atomcode` reports no offenses
- [x] Named the cask according to the token reference
- [x] Checked the cask was not already refused
- [x] `brew audit --cask --new atomcode` worked successfully
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask atomcode` worked successfully
- [ ] `brew uninstall --cask atomcode` worked successfully

- [x] AI was used to generate code signing justification and cask file.
  Manually verified: `zap rmdir: "~/.atomcode"` only removes the data
  directory. `brew audit --cask --new` and `brew audit --cask --online`
  both pass.