### PR TITLE
codexbar: allow Intel Macs

### DIFF
--- a/Casks/c/codexbar.rb
+++ b/Casks/c/codexbar.rb
@@ -8,7 +8,6 @@ cask "codexbar" do
   desc "Menu bar usage monitor for Codex and Claude"
   homepage "https://codexbar.app/"
 
-  depends_on arch: :arm64
   depends_on macos: :sonoma
 
   app "CodexBar.app"


### PR DESCRIPTION
-----
removes the `arm64` architecture requirement because the current CodexBar release ships universal macOS binaries.

Verified on Apple Silicon Mac:

- `brew audit --cask --online codexbar`
- `brew audit --cask --strict --online codexbar`
- `brew style codexbar.rb`

Verified on Intel Mac:

- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask codexbar`
- `file /Applications/CodexBar.app/Contents/MacOS/CodexBar`
- `file /Applications/CodexBar.app/Contents/Helpers/CodexBarCLI`
- `brew uninstall --cask codexbar`

Both `CodexBar` and `CodexBarCLI` are universal binaries containing `x86_64` and `arm64` slices

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to help interpret Homebrew audit output and draft the PR description.
I manually verified the cask on Apple Silicon and Intel Macs using the commands listed above. No `zap` stanza paths were changed.

-----
