### PR TITLE
facescreen 2.2.0 (new cask)

### DIFF
--- a/Casks/f/facescreen.rb
+++ b/Casks/f/facescreen.rb
@@ -1,0 +1,28 @@
+cask "facescreen" do
+  version "2.2.0"
+  sha256 "ce5c41da4b373cfbfd257428274a8cd05927e3565aebfa6b8d0945ce00addda5"
+
+  url "https://rampatra.github.io/facescreen-updates/FaceScreen-#{version}.dmg",
+      verified: "rampatra.github.io/facescreen-updates/"
+  name "FaceScreen"
+  desc "Show your face and brand on screen"
+  homepage "https://facescreenapp.com/"
+
+  livecheck do
+    url "https://rampatra.github.io/facescreen-updates/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sequoia
+
+  app "FaceScreen.app"
+
+  zap trash: [
+    "~/Library/Caches/io.softal.FaceScreen",
+    "~/Library/HTTPStorages/io.softal.FaceScreen",
+    "~/Library/Preferences/io.softal.FaceScreen.plist",
+    "~/Library/Saved Application State/io.softal.FaceScreen.savedState",
+  ]
+end

--- a/Casks/f/facescreen.rb
+++ b/Casks/f/facescreen.rb
@@ -5,7 +5,7 @@ cask "facescreen" do
   url "https://rampatra.github.io/facescreen-updates/FaceScreen-#{version}.dmg",
       verified: "rampatra.github.io/facescreen-updates/"
   name "FaceScreen"
-  desc "App to show your face and brand on screen"
+  desc "Camera and text overlay for presentations and screen sharing"
   homepage "https://facescreenapp.com/"
 
   livecheck do

--- a/Casks/f/facescreen.rb
+++ b/Casks/f/facescreen.rb
@@ -5,7 +5,7 @@ cask "facescreen" do
   url "https://rampatra.github.io/facescreen-updates/FaceScreen-#{version}.dmg",
       verified: "rampatra.github.io/facescreen-updates/"
   name "FaceScreen"
-  desc "Show your face and brand on screen"
+  desc "Mac app to show your face and brand on screen"
   homepage "https://facescreenapp.com/"
 
   livecheck do

--- a/Casks/f/facescreen.rb
+++ b/Casks/f/facescreen.rb
@@ -5,7 +5,7 @@ cask "facescreen" do
   url "https://rampatra.github.io/facescreen-updates/FaceScreen-#{version}.dmg",
       verified: "rampatra.github.io/facescreen-updates/"
   name "FaceScreen"
-  desc "Mac app to show your face and brand on screen"
+  desc "App to show your face and brand on screen"
   homepage "https://facescreenapp.com/"
 
   livecheck do


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online facescreen` is error-free.
- [x] `brew style --fix facescreen` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask name to the end of the search field).
- [x] `brew audit --cask --new facescreen` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask facescreen` worked successfully.
- [x] `brew uninstall --cask facescreen` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI helped draft the cask and run local verification. I verified the appcast at `https://rampatra.github.io/facescreen-updates/appcast.xml` returns `2.2.0`, the DMG contains `FaceScreen.app`, the app bundle identifier is `io.softal.FaceScreen`, the executable is arm64-only, `brew livecheck facescreen` returns `2.2.0`, audit/style pass, and install/uninstall work using a temporary appdir. The `zap` paths are based on the verified bundle identifier and expected Caches, HTTPStorages, Preferences, and Saved Application State locations.

-----
