### PR TITLE
eddie: fix broken download URL

### DIFF
--- a/Casks/e/eddie.rb
+++ b/Casks/e/eddie.rb
@@ -5,7 +5,7 @@ cask "eddie" do
   sha256 arm:   "821aafcaffea695bf938f671cce343d86416989f7f21d8db2d8bfe9aaa609d9c",
          intel: "d46a8e8cffce5b05708e2a096fad825487920d2d57e6eede1a523b0862a82291"
 
-  url "https://eddie.website/download/?platform=macos-10.15&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}"
+  url "https://eddie.website/repository/eddie/#{version}/eddie-ui_#{version}_macos-10.15_#{arch}_disk.dmg"
   name "Air VPN"
   name "Eddie"
   desc "OpenVPN UI"


### PR DESCRIPTION
Error
```sh
❯ brew install --cask eddie
==> Fetching downloads for: eddie
✘ Cask eddie (2.24.6)                                                                                                Verifying   167.0 B/-------
Error: Cask reports different checksum:     821aafcaffea695bf938f671cce343d86416989f7f21d8db2d8bfe9aaa609d9c
       SHA-256 checksum of downloaded file: 3de056257a69a92e44b7cad214c1621990f528b268940e6b00848b759be32007
```

Investigating
```sh
# what is the URL in the formula ?
❯ curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew-cask/main/Casks/e/eddie.rb | grep url
  url "https://eddie.website/download/?platform=macos-10.15&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}"

# what is served at this URL ?
❯ curl -fSsL "https://eddie.website/download/?platform=macos-10.15&arch=arm64&ui=ui&format=disk.dmg&version=2.24.6"
  {
      "filename": "eddie-ui_2.24.6_macos-10.15_arm64_disk.dmg",
      "url": "https://eddie.website/repository/eddie/2.24.6/eddie-ui_2.24.6_macos-10.15_arm64_disk.dmg"
  }%

# checksum mismatch
❯ curl -fSsL "https://eddie.website/download/?platform=macos-10.15&arch=arm64&ui=ui&format=disk.dmg&version=2.24.6" | sha256sum -
3de056257a69a92e44b7cad214c1621990f528b268940e6b00848b759be32007  -

❯ curl -fSsL https://eddie.website/repository/eddie/2.24.6/eddie-ui_2.24.6_macos-10.15_arm64_disk.dmg | sha256sum -
821aafcaffea695bf938f671cce343d86416989f7f21d8db2d8bfe9aaa609d9c  -
```

It seems that the `/download/?...` endpoint was changed, and now serves JSON instead of the file directly.

The mismatch is detected by Homebrew downloading the JSON and computing its shasum, which now differs from the expected shasum.

We fix the download URL, then retry

```sh
❯ op run -- brew audit --cask --online eddie
==> Downloading and extracting artifacts
==> Downloading https://eddie.website/repository/eddie/2.24.6/eddie-ui_2.24.6_macos-10.15_arm64_disk.dmg
Already downloaded: /Users/gforien/Library/Caches/Homebrew/downloads/ef5b0e47ae6ac5ec5a313c2280caf3f41019c7777e73e1cae0ae7f3cfcb9fc45--eddie-ui_
2.24.6_macos-10.15_arm64_disk.dmg
==> Downloading https://eddie.website/repository/eddie/2.24.6/eddie-ui_2.24.6_macos-10.15_arm64_disk.dmg
Already downloaded: /Users/gforien/Library/Caches/Homebrew/downloads/ef5b0e47ae6ac5ec5a313c2280caf3f41019c7777e73e1cae0ae7f3cfcb9fc45--eddie-ui_
2.24.6_macos-10.15_arm64_disk.dmg

❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask eddie
==> Fetching downloads for: eddie
✔︎ Cask eddie (2.24.6)                                                                                                Verified     49.4MB/ 49.4MB
==> Installing Cask eddie
Warning: --no-quarantine bypasses macOS’s Gatekeeper, reducing system security. Do not use this flag unless you understand the risks.
==> Moving App 'Eddie.app' to '/Applications/Eddie.app'
🍺  eddie was successfully installed!

❯ brew style --fix eddie
1 file inspected, no offenses detected
```

We also check manually that this new URL produces the expected shasum for the intel binary
```sh
❯ curl -fSsL https://eddie.website/repository/eddie/2.24.6/eddie-ui_2.24.6_macos-10.15_x64_disk.dmg | sha256sum -
d46a8e8cffce5b05708e2a096fad825487920d2d57e6eede1a523b0862a82291  -
```

- [x] Stable version
- [x] `brew audit --cask --online eddie` passes
- [x] `brew style --fix eddie` no offenses
- [x] AI usage: Opus 4.7 did everything. Change reviewed manually.