### PR TITLE
vimcal 1.0.47 (intel only)

### DIFF
--- a/Casks/v/vimcal.rb
+++ b/Casks/v/vimcal.rb
@@ -3,8 +3,8 @@ cask "vimcal" do
   host_suffix = on_arch_conditional arm: "m1", intel: "production"
 
   version "1.0.46"
-  sha256 arm:   "5317ff903de1e2f3958298b55824cf9cf848511c416ff5b3a7a3b798a2a44fb6",
-         intel: "8bfbb3a9f41060cbf0865ccc2d52a4fff5c49048ada74bfb076f9a37eb6d790d"
+  sha256 arm:   "f15a308db275cedb42e32897d85ec91a39d134407a11295169c4577f71b9aadc",
+         intel: "6b7196106a88a0aaf5e8c5cc439b4210074c07913015f9e6017cf994e95925ef"
 
   url "https://vimcal-#{host_suffix}.s3.amazonaws.com/Vimcal-#{version}#{arch}.dmg",
       verified: "vimcal-#{host_suffix}.s3.amazonaws.com/"

--- a/Casks/v/vimcal.rb
+++ b/Casks/v/vimcal.rb
@@ -2,9 +2,18 @@ cask "vimcal" do
   arch arm: "-arm64"
   host_suffix = on_arch_conditional arm: "m1", intel: "production"
 
-  version "1.0.46"
-  sha256 arm:   "f15a308db275cedb42e32897d85ec91a39d134407a11295169c4577f71b9aadc",
-         intel: "6b7196106a88a0aaf5e8c5cc439b4210074c07913015f9e6017cf994e95925ef"
+  on_arm do
+    version "1.0.46"
+    sha256 "f15a308db275cedb42e32897d85ec91a39d134407a11295169c4577f71b9aadc"
+
+    depends_on macos: :monterey
+  end
+  on_intel do
+    version "1.0.47"
+    sha256 "00596285cbe1f34aa171a02f6cb9ce043e501ea83e8783dd54e1864b0f6de897"
+
+    depends_on macos: :big_sur
+  end
 
   url "https://vimcal-#{host_suffix}.s3.amazonaws.com/Vimcal-#{version}#{arch}.dmg",
       verified: "vimcal-#{host_suffix}.s3.amazonaws.com/"
@@ -18,7 +27,7 @@ cask "vimcal" do
   end
 
   auto_updates true
-  depends_on macos: :monterey
+  depends_on :macos
 
   app "Vimcal.app"
 


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] \`brew audit --cask --online vimcal\` is error-free.
- [x] \`brew style --fix vimcal\` reports no offenses.

---

Vimcal re-uploaded the 1.0.46 DMGs to S3 without bumping the version, so the pinned sha256 values no longer match the files served at the cask URLs. \`brew install --cask vimcal\` currently fails with a checksum mismatch.

This updates both the arm and intel sha256 to match the current uploads:

- arm:   \`f15a308db275cedb42e32897d85ec91a39d134407a11295169c4577f71b9aadc\` (\`Vimcal-1.0.46-arm64.dmg\`)
- intel: \`6b7196106a88a0aaf5e8c5cc439b4210074c07913015f9e6017cf994e95925ef\` (\`Vimcal-1.0.46.dmg\`)

The autobump bot does not catch this because \`latest-mac.yml\` still reports \`version: 1.0.46\`, so the \`:electron_builder\` livecheck does not trigger a version bump.

Verified locally:

\`\`\`
\$ shasum -a 256 Vimcal-1.0.46-arm64.dmg
f15a308db275cedb42e32897d85ec91a39d134407a11295169c4577f71b9aadc
\$ shasum -a 256 Vimcal-1.0.46.dmg
6b7196106a88a0aaf5e8c5cc439b4210074c07913015f9e6017cf994e95925ef
\$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask vimcal
🍺  vimcal was successfully installed!
\`\`\`

---

- [x] AI was used to generate or assist with generating this PR. I used Claude Code to identify the checksum mismatch, fetch and hash the current arm64 and intel DMGs from S3, and prepare this PR. I manually verified the arm sha256 by installing the cask locally on Apple Silicon (\`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask vimcal\`) using the updated value. The intel sha256 was verified by hashing the file directly (I do not have an Intel machine to install on). No zap stanza changes were made.