### PR TITLE
airtime 2.8.0 (new cask)

### DIFF
--- a/Casks/a/airtime.rb
+++ b/Casks/a/airtime.rb
@@ -1,0 +1,28 @@
+cask "airtime" do
+  version "2.8.0"
+  sha256 :no_check
+  url "https://updates.airtimetools.com/mac/hybrid/Airtime.dmg"
+  name "Airtime"
+  desc "Video tools for camera, recording, and presentation"
+  homepage "https://www.airtime.com/"
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "Airtime.app"
+
+  uninstall quit: "app.mmhmm.hybrid"
+
+  zap trash: [
+    "~/Library/Application Support/mmhmm",
+    "~/Library/Application Scripts/M3KUT44L48.app.mmhmm.hybrid",
+    "~/Library/Application Scripts/M3KUT44L48.app.mmhmm.hybrid.menu",
+    "~/Library/Caches/app.mmhmm.hybrid",
+    "~/Library/Caches/app.mmhmm.hybrid.helper.plugin",
+    "~/Library/Caches/mmhmm",
+    "~/Library/Caches/SentryCrash/Airtime",
+    "~/Library/Containers/M3KUT44L48.app.mmhmm.hybrid.menu",
+    "~/Library/Group Containers/M3KUT44L48.app.mmhmm.hybrid",
+    "~/Library/HTTPStorages/app.mmhmm.hybrid",
+    "~/Library/Preferences/app.mmhmm.hybrid.plist",
+  ]
+end

--- a/Casks/a/airtime.rb
+++ b/Casks/a/airtime.rb
@@ -1,21 +1,24 @@
 cask "airtime" do
   version "2.8.0"
   sha256 :no_check
-  url "https://updates.airtimetools.com/mac/hybrid/Airtime.dmg"
+
+  url "https://updates.airtimetools.com/mac/hybrid/Airtime.dmg",
+      verified: "airtimetools.com/"
   name "Airtime"
   desc "Video tools for camera, recording, and presentation"
   homepage "https://www.airtime.com/"
+
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Airtime.app"
 
   uninstall quit: "app.mmhmm.hybrid"
 
   zap trash: [
-    "~/Library/Application Support/mmhmm",
     "~/Library/Application Scripts/M3KUT44L48.app.mmhmm.hybrid",
     "~/Library/Application Scripts/M3KUT44L48.app.mmhmm.hybrid.menu",
+    "~/Library/Application Support/mmhmm",
     "~/Library/Caches/app.mmhmm.hybrid",
     "~/Library/Caches/app.mmhmm.hybrid.helper.plugin",
     "~/Library/Caches/mmhmm",


### PR DESCRIPTION
## airtime

Airtime is a suite of video tools for camera, recording, and 
presentation, made by mmhmm inc. It is the successor to the mmhmm app.

- Homepage: https://www.airtime.com/
- URL: https://updates.airtimetools.com/mac/hybrid/Airtime.dmg
- Version: 2.8.0

### Checklist
- [x] brew install --cask tested and working
- [x] brew uninstall --cask tested and working
- [x] brew audit --cask --new passed cleanly
- [x] brew style --fix passed cleanly (6 auto-corrections applied)