### PR TITLE
perplexity (new cask)

### DIFF
--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,0 +1,30 @@
+cask "perplexity" do
+  arch arm: "arm64", intel: "x64"
+
+  version "145.2.7632.4581"
+  sha256 "d7628822dc8ee48a673df43112a183194f1cf8b724e0497f048cb44f89f15fee"
+
+  url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_#{arch}"
+  name "Perplexity"
+  desc "AI-powered search and answer engine"
+  homepage "https://www.perplexity.ai/"
+
+  livecheck do
+    url "https://www.perplexity.ai/rest/browser/update?browser=1.1.1.1&channel=stable&platform=mac_#{arch}&machine=0"
+    strategy :json do |json|
+      json.dig("body", "browser_version")
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Perplexity.app"
+
+  zap trash: [
+    "~/Library/Application Support/ai.perplexity.pro",
+    "~/Library/Caches/ai.perplexity.pro",
+    "~/Library/Preferences/ai.perplexity.pro.plist",
+    "~/Library/Saved Application State/ai.perplexity.pro.savedState",
+  ]
+end

--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,5 +1,5 @@
 cask "perplexity" do
-  version "145.2.7632.4581"
+  version "26.20.0"
   sha256 :no_check
 
   url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_#{arch}"

--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -22,9 +22,9 @@ cask "perplexity" do
   app "Perplexity.app"
 
   zap trash: [
-    "~/Library/Application Support/ai.perplexity.pro",
-    "~/Library/Caches/ai.perplexity.pro",
-    "~/Library/Preferences/ai.perplexity.pro.plist",
-    "~/Library/Saved Application State/ai.perplexity.pro.savedState",
+    "~/Library/Application Support/ai.perplexity.macv3",
+    "~/Library/Caches/ai.perplexity.macv3",
+    "~/Library/Preferences/ai.perplexity.macv3.plist",
+    "~/Library/Saved Application State/ai.perplexity.macv3.savedState",
   ]
 end

--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,12 +1,10 @@
 cask "perplexity" do
-  arch arm: "arm64", intel: "x64"
-
   version "145.2.7632.4581"
-  sha256 "d7628822dc8ee48a673df43112a183194f1cf8b724e0497f048cb44f89f15fee"
+  sha256 :no_check
 
   url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_#{arch}"
   name "Perplexity"
-  desc "AI-powered search and answer engine"
+  desc "AI-powered answer engine with agentic search capabilities"
   homepage "https://www.perplexity.ai/"
 
   livecheck do
@@ -17,13 +15,15 @@ cask "perplexity" do
   end
 
   auto_updates true
-  depends_on macos: :monterey
+  depends_on macos: :sonoma
 
   app "Perplexity.app"
 
   zap trash: [
-    "~/Library/Application Support/ai.perplexity.macv3",
+    "~/Library/Application Support/Perplexity",
     "~/Library/Caches/ai.perplexity.macv3",
+    "~/Library/HTTPStorages/ai.perplexity.macv3",
+    "~/Library/Logs/Perplexity",
     "~/Library/Preferences/ai.perplexity.macv3.plist",
     "~/Library/Saved Application State/ai.perplexity.macv3.savedState",
   ]

--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,4 +1,6 @@
 cask "perplexity" do
+  arch arm: "arm64", intel: "x64"
+
   version :latest
   sha256 :no_check
 

--- a/Casks/p/perplexity.rb
+++ b/Casks/p/perplexity.rb
@@ -1,5 +1,5 @@
 cask "perplexity" do
-  version "26.20.0"
+  version :latest
   sha256 :no_check
 
   url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_#{arch}"


### PR DESCRIPTION
Perplexity is a native macOS AI answer engine app.

Built and tested locally on macOS.

Closes #263797

---

Related: A previous PR (#263797) was closed without explanation. That approach used:
- Direct URL to macos-download.perplexity.ai (blocked by Cloudflare 403)
- Sparkle appcast for livecheck (also blocked by Cloudflare)
- Specific version with sha256

Our approach differs:
- Uses www.perplexity.ai/rest/browser/download which works (returns 307 redirect to Cloudflare Storage)
- version :latest with sha256 :no_check since DMG URL redirects make checksum verification impossible
- JSON-based livecheck that extracts internal build number for tracking
- Works with brew upgrade --greedy for auto-updates