### PR TITLE
Add cask for longbridge-terminal

### DIFF
--- a/Casks/l/longbridge-terminal.rb
+++ b/Casks/l/longbridge-terminal.rb
@@ -1,0 +1,33 @@
+cask "longbridge-terminal" do
+  version "0.22.1"
+
+  on_arm do
+    url "https://github.com/longbridge/longbridge-terminal/releases/download/v#{version}/longbridge-terminal-darwin-arm64.tar.gz"
+    sha256 "5f8a2b74bc55e2624183c61bdf18c635f8f8991c262f92f7be33907eb7ef12c4"
+  end
+
+  on_intel do
+    url "https://github.com/longbridge/longbridge-terminal/releases/download/v#{version}/longbridge-terminal-darwin-amd64.tar.gz"
+    sha256 "4b4445c088e7a40517bbbb1a609426351c77c6ed23ab42d792b4c236005b390d"
+  end
+
+  name "Longbridge Terminal"
+  desc "AI-native CLI for Longbridge Securities — real-time market data, portfolio, and trading"
+  homepage "https://open.longbridge.com/docs/cli"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  binary "longbridge"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+      args: ["-dr", "com.apple.quarantine", staged_path]
+  end
+
+  zap trash: [
+    "~/.config/longbridge",
+  ]
+end

--- a/Casks/l/longbridge-terminal.rb
+++ b/Casks/l/longbridge-terminal.rb
@@ -2,12 +2,14 @@ cask "longbridge-terminal" do
   version "0.22.1"
 
   on_arm do
-    url "https://github.com/longbridge/longbridge-terminal/releases/download/v#{version}/longbridge-terminal-darwin-arm64.tar.gz"
+    url "https://github.com/longbridge/longbridge-terminal/releases/download/v#{version}/longbridge-terminal-darwin-arm64.tar.gz",
+        verified: "github.com/longbridge/longbridge-terminal/"
     sha256 "5f8a2b74bc55e2624183c61bdf18c635f8f8991c262f92f7be33907eb7ef12c4"
   end
 
   on_intel do
-    url "https://github.com/longbridge/longbridge-terminal/releases/download/v#{version}/longbridge-terminal-darwin-amd64.tar.gz"
+    url "https://github.com/longbridge/longbridge-terminal/releases/download/v#{version}/longbridge-terminal-darwin-amd64.tar.gz",
+        verified: "github.com/longbridge/longbridge-terminal/"
     sha256 "4b4445c088e7a40517bbbb1a609426351c77c6ed23ab42d792b4c236005b390d"
   end
 
@@ -16,7 +18,7 @@ cask "longbridge-terminal" do
   homepage "https://open.longbridge.com/docs/cli"
 
   livecheck do
-    url :url
+    url "https://github.com/longbridge/longbridge-terminal/releases/latest"
     strategy :github_latest
   end
 


### PR DESCRIPTION
## Cask info

- **Name:** longbridge-terminal
- **Version:** 0.22.1
- **Homepage:** https://open.longbridge.com/docs/cli
- **Repo:** https://github.com/longbridge/longbridge-terminal (838 stars)
- **License:** MIT

## About

Longbridge Terminal is an AI-native CLI for Longbridge Securities (licensed broker), providing real-time market data, portfolio analysis, and trading across HK, US, A-share (SH/SZ), and Singapore markets. Built with Rust and ratatui.

## Checklist

- [x] `brew audit --new --cask longbridge-terminal` passes
- [x] Both arm64 and amd64 SHA256 verified from official GitHub Releases
- [x] `binary "longbridge"` maps correctly
- [x] `livecheck` configured with `github_latest` strategy
- [x] `zap` removes `~/.config/longbridge`