### PR TITLE
marked-app 3.0.19,1148

### DIFF
--- a/Casks/m/marked-app.rb
+++ b/Casks/m/marked-app.rb
@@ -1,31 +1,31 @@
 cask "marked-app" do
-  version "2.6.46,1071"
-  sha256 "9d67af603347b00f6c4b2b40eea6c0aef7f3b4c88abc3c77453a7d836f050626"
+  version "3.0.19,1148"
+  sha256 "2d5baece48794ced3fc1b48da59e1682e51dabce8fe2691e71d71363b3639587"
 
-  url "https://updates.marked2app.com/Marked#{version.delete(",")}.dmg"
+  url "https://updates.markedapp.com/updates/Marked%20#{version.csv.first}.zip"
   name "Marked"
   desc "Previewer for Markdown, MultiMarkdown and other text markup languages"
-  homepage "https://marked2app.com/"
+  homepage "https://markedapp.com/"
 
   livecheck do
-    url "https://updates.marked2app.com/marked.xml"
+    url "https://updates.markedapp.com/updates/marked3.xml"
     strategy :sparkle
   end
 
   auto_updates true
-  depends_on :macos
+  depends_on macos: :monterey
 
-  app "Marked #{version.major}.app"
+  app "Marked.app"
 
-  uninstall quit: "com.brettterpstra.marked#{version.major}"
+  uninstall quit: "com.brettterpstra.marked"
 
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.brettterpstra.marked#{version.major}.sfl*",
-    "~/Library/Application Support/Marked #{version.major}",
-    "~/Library/Caches/com.brettterpstra.marked#{version.major}",
-    "~/Library/Caches/Marked #{version.major}",
-    "~/Library/Logs/Marked #{version.major}",
-    "~/Library/Preferences/com.brettterpstra.marked#{version.major}.plist",
-    "~/Library/Saved Application State/com.brettterpstra.marked#{version.major}.savedState",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.brettterpstra.marked.sfl*",
+    "~/Library/Application Support/Marked",
+    "~/Library/Caches/com.brettterpstra.marked",
+    "~/Library/Caches/Marked",
+    "~/Library/Logs/Marked",
+    "~/Library/Preferences/com.brettterpstra.marked.plist",
+    "~/Library/Saved Application State/com.brettterpstra.marked.savedState",
   ]
 end


### PR DESCRIPTION
Built and tested locally on macOS 26.5.

Updates `marked-app` from Marked 2 to Marked 3. Marked 3 is the successor to Marked 2 from the same developer ([Brett Terpstra's announcement](https://www.producthunt.com/products/marked-2?comment=5405128)); it is now distributed from `markedapp.com`/`updates.markedapp.com` as a zip, the bundle id returns to `com.brettterpstra.marked`, the bundle is named `Marked.app`, and the minimum macOS is 12.4.

A separate `marked-app@2` cask for users who wish to remain on Marked 2 may follow as a separate PR.

- [x] Submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version)
- [x] `brew audit --cask --online marked-app` is error-free
- [x] `brew style --fix Casks/m/marked-app.rb` reports no offenses

AI-assisted: Claude Code drafted the stanza updates from values read out of `Marked.app/Contents/Info.plist` (CFBundleIdentifier, CFBundleShortVersionString, CFBundleVersion, SUFeedURL, LSMinimumSystemVersion) and the Sparkle appcast. I personally reviewed the diff, verified the Sparkle feed responds and serves the declared version, and exercised `brew install --cask --adopt marked-app` and `brew uninstall --cask marked-app` end-to-end. The zap paths were derived from the new bundle id/name; I did not exhaustively verify each path on disk and would welcome a maintainer's review of that stanza.