### PR TITLE
mpv-macWrapper 1.0.0 (new cask)

### DIFF
--- a/Casks/m/mpv-macWrapper.rb
+++ b/Casks/m/mpv-macWrapper.rb
@@ -1,6 +1,9 @@
 cask "mpv-macWrapper" do
   version "1.0.0"
-  sha256 "3ccb716615bd5e2f90093835569be85f3ff31dc76abf255c9206cf2734846398"
+
+  on_arm do
+    sha256 "3ccb716615bd5e2f90093835569be85f3ff31dc76abf255c9206cf2734846398"
+  end
 
   url "https://github.com/IstPlayer/mpv-macWrapper/releases/download/v#{version}/mpv.dmg"
   name "mpv-macWrapper"
@@ -19,7 +22,5 @@ cask "mpv-macWrapper" do
     prompt you to locate it on first launch.  The chosen path
     is saved to ~/.config/mpv-macWrapper/path.conf so you only
     need to do this once.
-
-    This cask provides an Apple Silicon (arm64) binary only.
   EOS
 end

--- a/Casks/m/mpv-macWrapper.rb
+++ b/Casks/m/mpv-macWrapper.rb
@@ -7,6 +7,8 @@ cask "mpv-macWrapper" do
   desc "Wrap mpv CLI as a native macOS .app bundle"
   homepage "https://github.com/IstPlayer/mpv-macWrapper"
 
+  depends_on macos: ">= :monterey"
+
   app "mpv.app"
 
   caveats <<~EOS
@@ -17,5 +19,7 @@ cask "mpv-macWrapper" do
     prompt you to locate it on first launch.  The chosen path
     is saved to ~/.config/mpv-macWrapper/path.conf so you only
     need to do this once.
+
+    This cask provides an Apple Silicon (arm64) binary only.
   EOS
 end

--- a/Casks/m/mpv-macWrapper.rb
+++ b/Casks/m/mpv-macWrapper.rb
@@ -1,0 +1,21 @@
+cask "mpv-macWrapper" do
+  version "1.0.0"
+  sha256 "3ccb716615bd5e2f90093835569be85f3ff31dc76abf255c9206cf2734846398"
+
+  url "https://github.com/IstPlayer/mpv-macWrapper/releases/download/v#{version}/mpv.dmg"
+  name "mpv-macWrapper"
+  desc "Wrap mpv CLI as a native macOS .app bundle"
+  homepage "https://github.com/IstPlayer/mpv-macWrapper"
+
+  app "mpv.app"
+
+  caveats <<~EOS
+    mpv must be installed separately:
+      brew install mpv
+
+    If mpv is not found at the default paths, the app will
+    prompt you to locate it on first launch.  The chosen path
+    is saved to ~/.config/mpv-macWrapper/path.conf so you only
+    need to do this once.
+  EOS
+end


### PR DESCRIPTION
## Description

Wraps mpv CLI as a native macOS `.app` bundle with Dock support, file associations, and idle window.  Tested on macOS Tahoe 26.5 (Apple Silicon).

## Checklist

- [x] Cask follows the [Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
- [x] App is not a duplicate
- [x] App is not signed (ad-hoc linker-signed; Gatekeeper workaround documented in README)
- [x] Cask is submitted to the correct repo (`homebrew-cask`)