### PR TITLE
droid: add auto_updates true

### DIFF
--- a/Casks/d/droid.rb
+++ b/Casks/d/droid.rb
@@ -15,6 +15,7 @@ cask "droid" do
     regex(/v?(\d+(?:\.\d+)+)/i)
   end
 
+  auto_updates true
   depends_on :macos
   depends_on formula: "ripgrep"
 


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used AI to make the change & validate it

-----

The `droid` CLI auto-updates but the cask definition doesn't reflect this. They don't document it super well but if you <kbd>cmd f</kbd> on [their changelog](https://docs.factory.ai/changelog/release-notes) for "auto-update" you can see a few references to the CLI's auto-update behavior.