### PR TITLE
omniwm 0.4.9.6 (new cask)

### DIFF
--- a/Casks/o/omniwm.rb
+++ b/Casks/o/omniwm.rb
@@ -1,0 +1,24 @@
+cask "omniwm" do
+  version "0.4.9.6"
+  sha256 "d17867d5e3eb321da549523d3d029c9f1180ae551cbff5e32fe2641759410bf2"
+
+  url "https://github.com/BarutSRB/OmniWM/releases/download/v#{version}/OmniWM-v#{version}.zip"
+  name "OmniWM"
+  desc "Tiling window manager with Niri-inspired column-based layout"
+  homepage "https://github.com/BarutSRB/OmniWM"
+
+  depends_on macos: :sequoia
+
+  app "OmniWM.app"
+  binary "#{appdir}/OmniWM.app/Contents/MacOS/omniwmctl", target: "omniwmctl"
+
+  uninstall quit: "com.barut.OmniWM"
+
+  zap trash: [
+    "~/.config/omniwm",
+    "~/.local/state/omniwm",
+    "~/Library/Caches/com.barut.OmniWM",
+    "~/Library/HTTPStorages/com.barut.OmniWM",
+    "~/Library/Preferences/com.barut.OmniWM.plist",
+  ]
+end

--- a/Casks/o/omniwm.rb
+++ b/Casks/o/omniwm.rb
@@ -10,7 +10,7 @@ cask "omniwm" do
   depends_on macos: :sequoia
 
   app "OmniWM.app"
-  binary "#{appdir}/OmniWM.app/Contents/MacOS/omniwmctl", target: "omniwmctl"
+  binary "#{appdir}/OmniWM.app/Contents/MacOS/omniwmctl"
 
   uninstall quit: "com.barut.OmniWM"
 


### PR DESCRIPTION
-----

Built and tested locally on macOS 26.5.

Adds OmniWM, a tiling window manager for macOS.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online omniwm` is error-free.
- [x] `brew style --fix omniwm` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new omniwm` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask omniwm` worked successfully.
- [x] `brew uninstall --cask omniwm` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to help draft and review the cask. I manually verified the release URL, SHA-256, app bundle, CLI binary, Gatekeeper/notarization status, install/uninstall behavior, and zap paths created after launching the app.


-----
