### PR TITLE
Add minimal cask for Speechify AI Assistant

### DIFF
--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -1,12 +1,13 @@
 cask "speechify" do
   version "3.3.0"
-  sha256 "ed22099543618d62041bf9c381b7dce976526093a12e0a9cff82997dd6fca63b"
+  sha256 :no_check
 
-  url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg"
+  url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg",
+      verified: "speechify.com"
   name "Speechify AI Assistant"
   homepage "https://www.speechify.com/"
 
-  depends_on :macos
+  depends_on macos: "sonoma"
 
   app "Speechify AI Assistant.app"
 end

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -1,10 +1,12 @@
-cask 'speechify' do
-  version '3.3.0'
-  sha256 'ed22099543618d62041bf9c381b7dce976526093a12e0a9cff82997dd6fca63b'
+cask "speechify" do
+  version "3.3.0"
+  sha256 "ed22099543618d62041bf9c381b7dce976526093a12e0a9cff82997dd6fca63b"
 
-  url 'https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg'
-  name 'Speechify AI Assistant'
-  homepage 'https://www.speechify.com/'
+  url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg"
+  name "Speechify AI Assistant"
+  homepage "https://www.speechify.com/"
 
-  app 'Speechify AI Assistant.app'
+  depends_on :macos
+
+  app "Speechify AI Assistant.app"
 end

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -12,4 +12,15 @@ cask "speechify" do
   depends_on macos: :sonoma
 
   app "Speechify AI Assistant.app"
+
+  zap delete: [
+               "~/Library/Caches/com.cliffweitzman.speechifydesktop1",
+               "~/Library/Caches/com.crashlytics.data/com.cliffweitzman.speechifydesktop1",
+               "~/Library/Caches/io.fabric.sdk.mac.data/com.cliffweitzman.speechifydesktop1",
+               "~/Library/Cookies/com.cliffweitzman.speechifydesktop1.binarycookies",
+             ],
+      trash:  [
+               "~/Library/Application Support/com.cliffweitzman.speechifydesktop1",
+               "~/Library/Preferences/com.cliffweitzman.speechifydesktop1.plist",
+             ]
 end

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -1,0 +1,11 @@
+cask 'speechify' do
+  version '3.3.0'
+  sha256 'ed22099543618d62041bf9c381b7dce976526093a12e0a9cff82997dd6fca63b'
+
+  url 'https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg'
+  appcast 'https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/appcast.xml'
+  name 'Speechify AI Assistant'
+  homepage 'https://www.speechify.com/'
+
+  app 'Speechify AI Assistant.app'
+end

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -1,9 +1,11 @@
 cask "speechify" do
+  desc "AI-powered reading and voice assistant"
   version "3.3.0"
   sha256 :no_check
 
   url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg",
       verified: "speechify.com"
+  # Appcast for reference: https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/appcast.xml
   name "Speechify AI Assistant"
   homepage "https://www.speechify.com/"
 

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -5,7 +5,6 @@ cask "speechify" do
 
   url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg",
       verified: "storage.googleapis.com/speechifymobile.appspot.com"
-  # Appcast for reference: https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/appcast.xml
   name "Speechify AI Assistant"
   homepage "https://www.speechify.com/"
 
@@ -14,13 +13,12 @@ cask "speechify" do
   app "Speechify AI Assistant.app"
 
   zap delete: [
-               "~/Library/Caches/com.cliffweitzman.speechifydesktop1",
-               "~/Library/Caches/com.crashlytics.data/com.cliffweitzman.speechifydesktop1",
-               "~/Library/Caches/io.fabric.sdk.mac.data/com.cliffweitzman.speechifydesktop1",
-               "~/Library/Cookies/com.cliffweitzman.speechifydesktop1.binarycookies",
-             ],
+    "~/Library/Caches/com.cliffweitzman.speechifymacagent",
+    "~/Library/Caches/com.crashlytics.data/com.cliffweitzman.speechifymacagent",
+  ],
       trash:  [
-               "~/Library/Application Support/com.cliffweitzman.speechifydesktop1",
-               "~/Library/Preferences/com.cliffweitzman.speechifydesktop1.plist",
-             ]
+        "~/Library/Application Support/com.cliffweitzman.speechifymacagent",
+        "~/Library/Preferences/com.cliffweitzman.speechifymacagent.plist",
+      ]
+
 end

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -3,7 +3,6 @@ cask 'speechify' do
   sha256 'ed22099543618d62041bf9c381b7dce976526093a12e0a9cff82997dd6fca63b'
 
   url 'https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg'
-  appcast 'https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/appcast.xml'
   name 'Speechify AI Assistant'
   homepage 'https://www.speechify.com/'
 

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -9,7 +9,7 @@ cask "speechify" do
   name "Speechify AI Assistant"
   homepage "https://www.speechify.com/"
 
-  depends_on macos: "sonoma"
+  depends_on macos: :sonoma
 
   app "Speechify AI Assistant.app"
 end

--- a/Casks/speechify.rb
+++ b/Casks/speechify.rb
@@ -4,7 +4,7 @@ cask "speechify" do
   sha256 :no_check
 
   url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg",
-      verified: "speechify.com"
+      verified: "storage.googleapis.com/speechifymobile.appspot.com"
   # Appcast for reference: https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/appcast.xml
   name "Speechify AI Assistant"
   homepage "https://www.speechify.com/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

```
Copilot was used to assist with generating the initial cask Ruby code and provide guidance on the Homebrew cask review checklist. All cask metadata (version, app name, URL, and verification steps) were manually verified using the official Speechify DMG and Info.plist. Installation, uninstallation, and zap paths were manually verified on macOS using files created by the app in ~/Library/Application Support, ~/Library/Caches, Crashlytics cache data, and ~/Library/Preferences.
```
-----
