### PR TITLE
Add agent-cli

### DIFF
--- a/Casks/a/agent-cli.rb
+++ b/Casks/a/agent-cli.rb
@@ -1,0 +1,29 @@
+cask "agent-cli" do
+  version "0.95.8"
+  sha256 "60273504f3c4bea181db64033790e0290bf1b53b86a1386afa3d41216a172029"
+
+  url "https://github.com/basnijholt/agent-cli/releases/download/v#{version}/AgentCLI.dmg"
+  name "Agent CLI"
+  desc "Local-first AI voice and text tools with menu bar integration"
+  homepage "https://github.com/basnijholt/agent-cli"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on arch: :arm64
+  depends_on macos: :ventura
+
+  app "AgentCLI.app"
+
+  uninstall launchctl: "com.agent_cli.whisper",
+            quit:      "lt.nijho.agent-cli.menubar"
+
+  zap trash: [
+    "~/Library/Application Support/AgentCLI",
+    "~/Library/LaunchAgents/com.agent_cli.whisper.plist",
+    "~/Library/Logs/agent-cli-whisper",
+    "~/Library/Preferences/lt.nijho.agent-cli.menubar.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance was used to draft the cask and keep track of the verification commands. I manually verified the v0.95.8 GitHub release asset and SHA-256, ran `brew style --fix agent-cli`, `brew audit --cask --online agent-cli`, `brew audit --cask --new agent-cli`, `brew livecheck --cask agent-cli`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask agent-cli`, `codesign --verify --deep --strict /Applications/AgentCLI.app`, `/Applications/AgentCLI.app/Contents/MacOS/AgentCLI --agentcli-self-test`, and `brew uninstall --cask agent-cli`. The `zap` paths match the app's support directory, launchd label, log directory, and bundle identifier preferences.

xref: https://github.com/basnijholt/agent-cli

-----
