### PR TITLE
excalidrawz: update livecheck, url

### DIFF
--- a/Casks/e/excalidrawz.rb
+++ b/Casks/e/excalidrawz.rb
@@ -1,18 +1,19 @@
 cask "excalidrawz" do
-  version "2.0.0"
-  sha256 "066e1f372720a123a05a0e0df094c9d6bf057f5de94c131f38db4a0f186a84b8"
+  version "2.0.2,78"
+  sha256 "35e59204750ae016825bfac1adc765539ae07db0c9d9a7c5c434367f47bd27ff"
 
-  url "https://github.com/chocoford/ExcalidrawZ/releases/download/v#{version}/ExcalidrawZ.#{version}.dmg",
+  url "https://github.com/chocoford/ExcalidrawZ/releases/download/v#{version.csv.first}/ExcalidrawZ.#{version.tr(",", ".")}.dmg",
       verified: "github.com/chocoford/ExcalidrawZ/releases/download/"
   name "ExcalidrawZ"
   desc "Excalidraw client"
   homepage "https://excalidrawz.chocoford.com/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://excalidrawz.chocoford.com/downloads/appcast.xml"
+    strategy :sparkle
   end
 
+  auto_updates true
   depends_on macos: :ventura
 
   app "ExcalidrawZ.app"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`excalidrawz` has updated its internal application Sparkle feed, and a new version format was used in the URL.

This switches the `livecheck` to use the in-app Sparkle feed for updates.