### PR TITLE
boss: update 9.2.0

### DIFF
--- a/Casks/b/boss.rb
+++ b/Casks/b/boss.rb
@@ -1,6 +1,6 @@
 cask "boss" do
-  version "9.1.11"
-  sha256 "97c69235d4ccb90f099632d7e79fb93a1a2651c5ecbc939ca425a30944e46c27"
+  version "9.2.0"
+  sha256 "5f5f17009f6319d2d3dce79fd546804e1e1f73e065bc39ca651d7df9b66caf46"
 
   url "https://github.com/risa-labs-inc/BOSS-Releases/releases/download/v#{version}/BOSS-#{version}-Universal.dmg",
       verified: "github.com/risa-labs-inc/BOSS-Releases/"


### PR DESCRIPTION
Updates boss cask to version 9.2.0

  **Release Information:**
  - Version: 9.2.0  
  - SHA256: `5f5f17009f6319d2d3dce79fd546804e1e1f73e065bc39ca651d7df9b66caf46`
  - Release URL: https://github.com/risa-labs-inc/BossConsole-Releases/releases/tag/v9.2.0

  **Changes:**
  - Updated version from previous to 9.2.0
  - Updated SHA256 hash for new release asset

  BOSS is an AI-powered workspace for complex business operations.