### PR TITLE
dotnet-reactor 7.5.0.0 (new cask)

### DIFF
--- a/Casks/d/dotnet-reactor.rb
+++ b/Casks/d/dotnet-reactor.rb
@@ -8,10 +8,18 @@ cask "dotnet-reactor" do
   homepage "https://www.eziriz.com/dotnet_reactor.htm"
 
   livecheck do
-    url "https://www.eziriz.com/reactor_history.htm"
-    regex(/\b(\d+(?:\.\d+){3})\b/)
+    url "https://www.eziriz.com/reactor_download.htm"
+    regex(/href=.*?dotnet[._-]reactor[._-]v?(\d+(?:[._]\d+)+)[._-]macos/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
+    end
   end
 
   binary "dotNET_Reactor"
   binary "dotNET_Reactor.Console"
+
+  zap trash: [
+    "~/Library/Application Support/Eziriz/.NET Reactor",
+    "~/Library/Preferences/dotNET_Reactor.plist",
+  ]
 end

--- a/Casks/d/dotnet-reactor.rb
+++ b/Casks/d/dotnet-reactor.rb
@@ -1,0 +1,17 @@
+cask "dotnet-reactor" do
+  version "7.5.0.0"
+  sha256 "cb3ec024fd7ae2690c72b538b5f6810288825205636e03db520dead0b0fbb2c2"
+
+  url "https://www.eziriz.com/downloads/dotnet_reactor_#{version.dots_to_underscores}_macos-x64_signed.zip"
+  name ".NET Reactor"
+  desc ".NET code protection and obfuscation tool"
+  homepage "https://www.eziriz.com/dotnet_reactor.htm"
+
+  livecheck do
+    url "https://www.eziriz.com/reactor_history.htm"
+    regex(/\b(\d+(?:\.\d+){3})\b/)
+  end
+
+  binary "dotNET_Reactor"
+  binary "dotNET_Reactor.Console"
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online dotnet-reactor` is error-free.
- [x] `brew style --fix dotnet-reactor` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+dotnet-reactor&type=pullrequests).
- [x] `brew audit --cask --new dotnet-reactor` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask dotnet-reactor` worked successfully.
- [x] `brew uninstall --cask dotnet-reactor` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Claude Code (claude-opus-4-8) helped draft the cask and verify the build. Manually verified: codesign/spctl/notarization checks on all binaries, brew audit --new (signature check passes), install, run, and clean uninstall on Apple Silicon.*

-----

## Note

This resubmits #266588, which @bevanjkay closed because the binaries were not adequately signed ("If it becomes adequately signed in future, you are welcome to resubmit the cask").

I contacted Eziriz (the upstream developer) and they have re-signed and notarized the macOS distribution:

- `dotNET_Reactor`, `dotNET_Reactor.Console`, and all bundled dylibs are signed with `Developer ID Application: Denis Mierzwiak (7TS9LWRQ48)`, with Hardened Runtime enabled and a secure timestamp.
- `spctl --assess --type install` returns `accepted, source=Notarized Developer ID`.
- `brew audit --cask --new dotnet-reactor` now passes with no errors (signature requirement satisfied).
- The cask points to the signed/notarized archive (`..._macos-x64_signed.zip`); no `xattr` quarantine workaround is needed.