### PR TITLE
Autosub 3.6.0 (new cask)

### DIFF
--- a/Casks/a/auto-subs.rb
+++ b/Casks/a/auto-subs.rb
@@ -1,0 +1,42 @@
+cask "auto-subs" do
+  arch arm: "ARM", intel: "Intel"
+
+  version "3.6.0"
+  sha256 arm:   "61e2917f7ade604d2d07f37ddcbedf7313a132ddc9d5800f01d85faed70974b6",
+         intel: "889e8812f72a5fccc8acdab157750cba06b39b8dfa9fb25efcbcd38bdd562186"
+
+  url "https://github.com/tmoroney/auto-subs/releases/download/v#{version}/AutoSubs-Mac-#{arch}.pkg"
+  name "AutoSubs"
+  desc "Subtitle generator for audio and video files"
+  homepage "https://github.com/tmoroney/auto-subs/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  pkg "AutoSubs-Mac-#{arch}.pkg"
+
+  uninstall quit:    "com.autosubs",
+            pkgutil: "com.tom-moroney.autosubs",
+            delete:  [
+              "/Applications/AutoSubs.app",
+              "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Workflow Integration Plugins/AutoSubs.lua",
+              "~/Library/Application Support/Adobe/CEP/extensions/com.autosubs.adobe",
+              "~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/AutoSubs",
+              "~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/AutoSubs.lua",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/com.autosubs",
+    "~/Library/Caches/com.autosubs",
+    "~/Library/HTTPStorages/com.autosubs",
+    "~/Library/Logs/com.autosubs",
+    "~/Library/Preferences/com.autosubs.plist",
+    "~/Library/Saved Application State/com.autosubs.savedState",
+    "~/Library/WebKit/com.autosubs",
+  ]
+end

--- a/Casks/a/auto-subs.rb
+++ b/Casks/a/auto-subs.rb
@@ -23,7 +23,6 @@ cask "auto-subs" do
   uninstall quit:    "com.autosubs",
             pkgutil: "com.tom-moroney.autosubs",
             delete:  [
-              "/Applications/AutoSubs.app",
               "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Workflow Integration Plugins/AutoSubs.lua",
               "~/Library/Application Support/Adobe/CEP/extensions/com.autosubs.adobe",
               "~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/AutoSubs",


### PR DESCRIPTION
-----
Built and tested locally on macOS Tahoe 26.5.
Adds AutoSubs, a subtitle generator for audio and video files.


<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online auto-subs` is error-free.
- [x] `brew style --fix auto-subs` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask auto-subs` worked successfully.
- [x] `brew uninstall --cask auto-subs` worked successfully.

-----
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with drafting the cask and identifying package metadata. I manually verified the release asset, checksums, package receipt identifier, bundle identifier, install/uninstall paths, zap paths, and Gatekeeper/codesign status.

-----
