### PR TITLE
Add dbx 0.5.24

### DIFF
--- a/Casks/d/dbx.rb
+++ b/Casks/d/dbx.rb
@@ -1,0 +1,35 @@
+cask "dbx" do
+  version "0.5.24"
+
+  on_arm do
+    url "https://github.com/t8y2/dbx/releases/download/v#{version}/DBX_#{version}_aarch64.dmg",
+        verified: "github.com/t8y2/dbx/"
+    sha256 "67aec2bbf3d82d1ea1b42719de1dd7bbf3cdab4152334d9884e8d9fabda99edc"
+  end
+
+  on_intel do
+    url "https://github.com/t8y2/dbx/releases/download/v#{version}/DBX_#{version}_x64.dmg",
+        verified: "github.com/t8y2/dbx/"
+    sha256 "e1078dc50b53c44eafa4c06d41670a79d89b98ed0b1c9e239a944c73aef6d06b"
+  end
+
+  name "DBX"
+  desc "Lightweight, cross-platform database management tool"
+  homepage "https://dbxio.com"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "DBX.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.dbx.app",
+    "~/Library/Caches/com.dbx.app",
+    "~/Library/Preferences/com.dbx.app.plist",
+    "~/Library/Logs/com.dbx.app",
+  ]
+end

--- a/Casks/d/dbx.rb
+++ b/Casks/d/dbx.rb
@@ -3,12 +3,13 @@ cask "dbx" do
 
   on_arm do
     sha256 "67aec2bbf3d82d1ea1b42719de1dd7bbf3cdab4152334d9884e8d9fabda99edc"
+
     url "https://github.com/t8y2/dbx/releases/download/v#{version}/DBX_#{version}_aarch64.dmg",
         verified: "github.com/t8y2/dbx/"
   end
-
   on_intel do
     sha256 "e1078dc50b53c44eafa4c06d41670a79d89b98ed0b1c9e239a944c73aef6d06b"
+
     url "https://github.com/t8y2/dbx/releases/download/v#{version}/DBX_#{version}_x64.dmg",
         verified: "github.com/t8y2/dbx/"
   end

--- a/Casks/d/dbx.rb
+++ b/Casks/d/dbx.rb
@@ -2,34 +2,34 @@ cask "dbx" do
   version "0.5.24"
 
   on_arm do
+    sha256 "67aec2bbf3d82d1ea1b42719de1dd7bbf3cdab4152334d9884e8d9fabda99edc"
     url "https://github.com/t8y2/dbx/releases/download/v#{version}/DBX_#{version}_aarch64.dmg",
         verified: "github.com/t8y2/dbx/"
-    sha256 "67aec2bbf3d82d1ea1b42719de1dd7bbf3cdab4152334d9884e8d9fabda99edc"
   end
 
   on_intel do
+    sha256 "e1078dc50b53c44eafa4c06d41670a79d89b98ed0b1c9e239a944c73aef6d06b"
     url "https://github.com/t8y2/dbx/releases/download/v#{version}/DBX_#{version}_x64.dmg",
         verified: "github.com/t8y2/dbx/"
-    sha256 "e1078dc50b53c44eafa4c06d41670a79d89b98ed0b1c9e239a944c73aef6d06b"
   end
 
   name "DBX"
   desc "Lightweight, cross-platform database management tool"
-  homepage "https://dbxio.com"
+  homepage "https://dbxio.com/"
 
   livecheck do
     url :url
     strategy :github_latest
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "DBX.app"
 
   zap trash: [
     "~/Library/Application Support/com.dbx.app",
     "~/Library/Caches/com.dbx.app",
-    "~/Library/Preferences/com.dbx.app.plist",
     "~/Library/Logs/com.dbx.app",
+    "~/Library/Preferences/com.dbx.app.plist",
   ]
 end


### PR DESCRIPTION
**DBX** is a lightweight, cross-platform database management tool.

- **Homepage:** https://dbxio.com
- **GitHub:** https://github.com/t8y2/dbx
- **Stars:** 2,435 ⭐
- **License:** AGPL-3.0

**Description:** 15MB, lightweight, cross-platform database client. Supports MySQL, PostgreSQL, SQLite, Redis, MongoDB, DuckDB, ClickHouse, SQL Server and more.

> [!NOTE]
> This cask was previously distributed via `t8y2/tap/dbx` — this PR migrates it to the official homebrew-cask repository.
