### PR TITLE
openpencil 0.12.2 (new cask)

### DIFF
--- a/Casks/o/openpencil.rb
+++ b/Casks/o/openpencil.rb
@@ -11,11 +11,6 @@ cask "openpencil" do
   desc "Open-source design editor compatible with Figma"
   homepage "https://openpencil.dev/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
   depends_on :macos
 

--- a/Casks/o/openpencil.rb
+++ b/Casks/o/openpencil.rb
@@ -1,0 +1,30 @@
+cask "openpencil" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.12.2"
+  sha256 arm:   "4f94ded4a8b2f8a46dadf7e2ae36eaace5858f97ff94ebec9d11e4ca004a770e",
+         intel: "16b20be733d5cf81dc741d6f15c06afb41872fe194bd09ba07e1e844c03a92ef"
+
+  url "https://github.com/open-pencil/open-pencil/releases/download/v#{version}/OpenPencil_#{arch}.app.tar.gz",
+      verified: "github.com/open-pencil/open-pencil/"
+  name "OpenPencil"
+  desc "Open-source design editor compatible with Figma"
+  homepage "https://openpencil.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on :macos
+
+  app "OpenPencil.app"
+
+  zap trash: [
+    "~/Library/Application Support/net.dannote.open-pencil",
+    "~/Library/Caches/net.dannote.open-pencil",
+    "~/Library/Preferences/net.dannote.open-pencil.plist",
+    "~/Library/Saved Application State/net.dannote.open-pencil.savedState",
+  ]
+end


### PR DESCRIPTION
-----
Tested on macOS 26.5 Tahoe
Adds OpenPencil, open-source design editor compatible with Figma

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `open is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online openpencil` is error-free.
- [x] `brew style --fix openpencil` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new openpencil` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask openpencil` worked successfully.
- [x] `brew uninstall --cask openpencil` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to review the cask structure, token naming, architecture-specific URL handling, and the pre-PR validation checklist.

 I manually verified the release asset URLs, checksums, install/uninstall behavior, and confirmed the zap paths correspond to OpenPencil's bundle identifier `net.dannote.open-pencil`.

-----
