### PR TITLE
mpv-macwrapper 1.0.0 (new cask)

### DIFF
--- a/Casks/m/mpv-macwrapper.rb
+++ b/Casks/m/mpv-macwrapper.rb
@@ -14,6 +14,8 @@ cask "mpv-macwrapper" do
 
   app "mpv.app"
 
+  zap trash: "~/.config/mpv-macWrapper"
+
   caveats <<~EOS
     Apple Silicon (arm64) only.  mpv must be installed separately:
       brew install mpv

--- a/Casks/m/mpv-macwrapper.rb
+++ b/Casks/m/mpv-macwrapper.rb
@@ -1,0 +1,24 @@
+cask "mpv-macwrapper" do
+  version "1.0.0"
+
+  on_arm do
+    sha256 "3ccb716615bd5e2f90093835569be85f3ff31dc76abf255c9206cf2734846398"
+  end
+
+  url "https://github.com/IstPlayer/mpv-macWrapper/releases/download/v#{version}/mpv.dmg"
+  name "mpv-macWrapper"
+  desc "Wrap mpv CLI as a native macOS .app bundle"
+  homepage "https://github.com/IstPlayer/mpv-macWrapper"
+
+  depends_on macos: ">= :monterey"
+
+  app "mpv.app"
+
+  caveats <<~EOS
+    Apple Silicon (arm64) only.  mpv must be installed separately:
+      brew install mpv
+
+    If mpv is not found at the default paths, the app will
+    prompt you to locate it on first launch.
+  EOS
+end


### PR DESCRIPTION
## Description

Wraps mpv CLI as a native macOS `.app` bundle with Dock support, file associations, and idle window.  Apple Silicon only.  Tested on macOS Tahoe 26.5.

## Checklist

- [x] Cask follows the Cask Cookbook
- [x] App is not a duplicate
- [x] App is not signed (ad-hoc linker-signed)
- [x] Cask is submitted to homebrew-cask
- [x] Architecture: Apple Silicon (arm64) only (`on_arm` block)