### PR TITLE
Add font-berka-mono-closer cask

### DIFF
--- a/Casks/font/font-b/font-berka-mono-closer.rb
+++ b/Casks/font/font-b/font-berka-mono-closer.rb
@@ -1,0 +1,25 @@
+cask "font-berka-mono-closer" do
+  version "0.1.0"
+  sha256 "0eb20ff4924a712dfeac321b8af4cfe047da6c976945cc6617f3c7692cab0e1b"
+
+  url "https://github.com/vinitkumar/berka-mono-closer/releases/download/v#{version}/BerkaMonoCloser-TTF.zip"
+  name "Berka Mono Closer"
+  desc "Iosevka custom build with a calm, wide, rectangular coding texture"
+  homepage "https://github.com/vinitkumar/berka-mono-closer"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "BerkaMonoCloser-Bold.ttf"
+  font "BerkaMonoCloser-BoldItalic.ttf"
+  font "BerkaMonoCloser-Italic.ttf"
+  font "BerkaMonoCloser-Medium.ttf"
+  font "BerkaMonoCloser-MediumItalic.ttf"
+  font "BerkaMonoCloser-Regular.ttf"
+  font "BerkaMonoCloser-SemiBold.ttf"
+  font "BerkaMonoCloser-SemiBoldItalic.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
Adds a cask for Berka Mono Closer, an OFL-licensed custom build of Iosevka published at https://github.com/vinitkumar/berka-mono-closer.\n\nRelease asset: https://github.com/vinitkumar/berka-mono-closer/releases/tag/v0.1.0\n\nValidation performed:\n- ruby -c Casks/font-berka-mono-closer.rb\n- brew audit --cask vinitkumar/fonts/font-berka-mono-closer passes in the personal tap\n- brew info --cask vinitkumar/fonts/font-berka-mono-closer resolves the font artifacts\n\nNote: brew audit --cask --new reports the GitHub notability threshold for this new font project. I am opening this PR for maintainer review, and I understand if this needs to wait until the project has more adoption.