### PR TITLE
rockxy 0.23.0,36

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.22.0,35"
-  sha256 "dcb5e6f1b0a86d641ee6009855c4dad9b6cf56d96501c9abe91a3e63b2b284fa"
+  version "0.23.0,36"
+  sha256 "1519f0dbae2541c10c700c84929ddcd270f7e24595f00afb6272dfdb610a18ee"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.23.0 build 36.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.23.0/Rockxy-0.23.0-36.dmg
- SHA-256: 1519f0dbae2541c10c700c84929ddcd270f7e24595f00afb6272dfdb610a18ee
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
- `brew livecheck --cask --autobump --json rockxy`