### PR TITLE
Add mirrorkit 1.0.0

### DIFF
--- a/Casks/m/mirrorkit.rb
+++ b/Casks/m/mirrorkit.rb
@@ -1,0 +1,16 @@
+cask "mirrorkit" do
+  version "1.0.0"
+  sha256 "62cc6d175ae84ed19dc5116186e65fba879f5b01aafdabb88b17123fb14e934a"
+
+  url "https://github.com/silica-labs/mirrorkit/releases/download/v#{version}/MirrorKit-#{version}.dmg"
+  name "MirrorKit"
+  desc "Developer tool mirror switcher for macOS"
+  homepage "https://mirrorkit.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "MirrorKit.app"
+end

--- a/Casks/m/mirrorkit.rb
+++ b/Casks/m/mirrorkit.rb
@@ -2,10 +2,12 @@ cask "mirrorkit" do
   version "1.0.0"
   sha256 "62cc6d175ae84ed19dc5116186e65fba879f5b01aafdabb88b17123fb14e934a"
 
-  url "https://github.com/silica-labs/mirrorkit/releases/download/v#{version}/MirrorKit-#{version}.dmg"
+  url "https://github.com/silica-labs/mirrorkit/releases/download/v#{version}/MirrorKit-v#{version}.dmg",verified: "github.com/silica-labs/mirrorkit"
   name "MirrorKit"
-  desc "Developer tool mirror switcher for macOS"
+  desc "Developer tool mirror switcher"
   homepage "https://mirrorkit.app/"
+
+  depends_on macos: ">= :sequoia"
 
   livecheck do
     url :url


### PR DESCRIPTION
MirrorKit is a native macOS app for switching developer tool mirrors (Homebrew, GitHub, Oh My Zsh, Node.js, PyPI, Go) to Chinese domestic mirror sources, solving slow download and timeout issues caused by network restrictions.

- App homepage: https://mirrorkit.app
- Download URL: https://github.com/silica-labs/mirrorkit/releases/download/v1.0.0/MirrorKit-v1.0.0.dmg

Verified with `brew audit --cask mirrorkit --strict --online` and `brew style --cask mirrorkit`.