### PR TITLE
agentsmesh 0.40.0 (new cask)

### DIFF
--- a/Casks/a/agentsmesh.rb
+++ b/Casks/a/agentsmesh.rb
@@ -1,5 +1,5 @@
 cask "agentsmesh" do
-  arch arm: "-arm64", intel: ""
+  arch arm: "-arm64"
 
   version "0.39.0"
   sha256 arm:   "1df93b1dad1167b64b2c996c23f589182ae3bbba44c8e6901b4f3eef27494b36",
@@ -21,11 +21,11 @@ cask "agentsmesh" do
   app "AgentsMesh.app"
 
   zap trash: [
-    "~/Library/Application Support/AgentsMesh",
+    "~/Library/Application Support/agentsmesh",
     "~/Library/Caches/agentsmesh-updater",
     "~/Library/Caches/ai.agentsmesh.desktop",
     "~/Library/HTTPStorages/ai.agentsmesh.desktop",
-    "~/Library/Logs/AgentsMesh",
+    "~/Library/Logs/agentsmesh",
     "~/Library/Preferences/ai.agentsmesh.desktop.plist",
     "~/Library/Saved Application State/ai.agentsmesh.desktop.savedState",
   ]

--- a/Casks/a/agentsmesh.rb
+++ b/Casks/a/agentsmesh.rb
@@ -1,0 +1,32 @@
+cask "agentsmesh" do
+  arch arm: "-arm64", intel: ""
+
+  version "0.39.0"
+  sha256 arm:   "1df93b1dad1167b64b2c996c23f589182ae3bbba44c8e6901b4f3eef27494b36",
+         intel: "c7289f9e0ebb43898c4c101f099a2c11328e03a93f5f9c5720e9de558f6ee600"
+
+  url "https://github.com/AgentsMesh/AgentsMesh/releases/download/v#{version}/AgentsMesh-#{version}#{arch}.dmg",
+      verified: "github.com/AgentsMesh/AgentsMesh/"
+  name "AgentsMesh"
+  desc "AI agent workforce platform"
+  homepage "https://agentsmesh.ai/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :big_sur
+
+  app "AgentsMesh.app"
+
+  zap trash: [
+    "~/Library/Application Support/AgentsMesh",
+    "~/Library/Caches/agentsmesh-updater",
+    "~/Library/Caches/ai.agentsmesh.desktop",
+    "~/Library/HTTPStorages/ai.agentsmesh.desktop",
+    "~/Library/Logs/AgentsMesh",
+    "~/Library/Preferences/ai.agentsmesh.desktop.plist",
+    "~/Library/Saved Application State/ai.agentsmesh.desktop.savedState",
+  ]
+end

--- a/Casks/a/agentsmesh.rb
+++ b/Casks/a/agentsmesh.rb
@@ -1,9 +1,9 @@
 cask "agentsmesh" do
   arch arm: "-arm64"
 
-  version "0.39.0"
-  sha256 arm:   "1df93b1dad1167b64b2c996c23f589182ae3bbba44c8e6901b4f3eef27494b36",
-         intel: "c7289f9e0ebb43898c4c101f099a2c11328e03a93f5f9c5720e9de558f6ee600"
+  version "0.40.0"
+  sha256 arm:   "9c2897eb4589a3e5a4958aeb67ed28c79b702f3c4c5d6127b7e409a63435314a",
+         intel: "eb204fded1e8448dbaef8e2c82c040de113ab190e929fc816d7bee9a1895a725"
 
   url "https://github.com/AgentsMesh/AgentsMesh/releases/download/v#{version}/AgentsMesh-#{version}#{arch}.dmg",
       verified: "github.com/AgentsMesh/AgentsMesh/"


### PR DESCRIPTION
-----

Built and tested locally on macOS 26.5.
Adds AgentsMesh, an AI agent workforce platform.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online agentsmesh` is error-free.
- [x] `brew style --fix agentsmesh` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new agentsmesh` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask agentsmesh` worked successfully.
- [x] `brew uninstall --cask agentsmesh` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to review the cask structure, livecheck behavior, macOS dependency, and validation steps.

I manually verified the release assets, checksums, `brew audit --cask --new agentsmesh`, `brew style --fix agentsmesh`, install/uninstall behavior, livecheck output, and the Info.plist values used for `depends_on` and `zap` paths. The `zap` stanza is based on the app's bundle identifier `ai.agentsmesh.desktop`, product name `AgentsMesh`, and Electron updater/cache conventions.

-----
