### PR TITLE
ping-island 19.0 (new cask)

### DIFF
--- a/Casks/p/ping-island.rb
+++ b/Casks/p/ping-island.rb
@@ -1,0 +1,22 @@
+cask "ping-island" do
+  version "0.19.0"
+  sha256 "0970e94a68482c553aa01902ae314c914bfedbc4310dbca3daa979a0525cc66f"
+
+  url "https://github.com/erha19/ping-island/releases/download/v#{version}/PingIsland-#{version}.dmg",
+      verified: "github.com/erha19/ping-island/"
+  name "Ping Island"
+  desc "Menu bar status for coding agent sessions"
+  homepage "https://erha19.github.io/ping-island/"
+
+  depends_on macos: :sonoma
+
+  app "Ping Island.app"
+
+  zap trash: [
+    "~/Library/Application Support/PingIsland",
+    "~/Library/Caches/com.wudanwu.PingIsland",
+    "~/Library/HTTPStorages/com.wudanwu.PingIsland",
+    "~/Library/Preferences/com.wudanwu.PingIsland.plist",
+    "~/Library/Saved Application State/com.wudanwu.PingIsland.savedState",
+  ]
+end


### PR DESCRIPTION
-----

Built and tested locally on macOS 26.5.
Adds PingIsland, Menu bar status for coding agent sessions.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ping-island` is error-free.
- [x] `brew style --fix ping-island` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new ping-island` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ping-island` worked successfully.
- [x] `brew uninstall --cask ping-island` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to review the cask structure, livecheck behavior, and validation checklist.
I manually verified the release asset URL, checksum, install/uninstall behavior, Gatekeeper signing/notarization, and zap paths for Ping Island's bundle identifier.


-----
