### PR TITLE
ping-island 0.20.0 (new cask)

### DIFF
--- a/Casks/p/ping-island.rb
+++ b/Casks/p/ping-island.rb
@@ -1,0 +1,22 @@
+cask "ping-island" do
+  version "0.20.0"
+  sha256 "549e4a009e5ed468384e59cd668830998ad59284c2bf0ebdb3940562101d1448"
+
+  url "https://github.com/erha19/ping-island/releases/download/v#{version}/PingIsland-#{version}.dmg",
+      verified: "github.com/erha19/ping-island/"
+  name "Ping Island"
+  desc "Menu bar status for coding agent sessions"
+  homepage "https://erha19.github.io/ping-island/"
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Ping Island.app"
+
+  zap trash: [
+    "~/Library/Application Support/PingIsland",
+    "~/Library/Caches/com.wudanwu.PingIsland",
+    "~/Library/HTTPStorages/com.wudanwu.PingIsland",
+    "~/Library/Preferences/com.wudanwu.PingIsland.plist",
+  ]
+end


### PR DESCRIPTION
-----

Adds Ping Island from the current published stable release, v0.19.1.
Ping Island surfaces Dynamic Island-style menu bar status for coding agent sessions.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online ping-island` is error-free.
- [x] `brew style --fix Casks/p/ping-island.rb` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new ping-island` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ping-island` worked successfully.
- [ ] `brew uninstall --cask ping-island` worked successfully.

Local verification performed:

- `ruby -c Casks/p/ping-island.rb`
- `brew style --fix Casks/p/ping-island.rb`
- Downloaded `PingIsland-0.19.1.dmg` and verified SHA-256 `3151b62d8a547562700317669ea73e1cfe06f0de82660e4fc8b644ba0612fd8d`
- Confirmed the app bundle identifier is `com.wudanwu.PingIsland` for zap paths

`brew audit --cask --new --online ping-island` was attempted locally, but this machine needed a first-time `homebrew/core` checkout and the clone failed with an early EOF before audit completed. Leaving the audit/install boxes unchecked so CI can be the source of truth.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI helped draft the cask stanza and validation checklist. I manually verified the current GitHub Release asset URL, the DMG checksum via `curl`/`shasum`, Ruby syntax, Homebrew style, and the zap paths against the `com.wudanwu.PingIsland` bundle identifier.

-----
