### PR TITLE
ccpocket 1.101.1 (new cask)

### DIFF
--- a/Casks/c/cc-pocket.rb
+++ b/Casks/c/cc-pocket.rb
@@ -1,0 +1,38 @@
+cask "cc-pocket" do
+  version "1.101.1,179"
+  sha256 "bfe6d5570382d815e0e9f2aa1a082aa8d55209572bb474ec7839f0f04890f353"
+
+  url "https://github.com/K9i-0/ccpocket/releases/download/macos/v#{version.csv.first}%2B#{version.csv.second}/CC-Pocket-macos-v#{version.csv.first}.dmg",
+      verified: "github.com/K9i-0/ccpocket/"
+  name "CC Pocket"
+  desc "Remote client for Codex and Claude coding agents"
+  homepage "https://k9i-0.github.io/ccpocket/install/"
+
+  livecheck do
+    url :url
+    regex(%r{macos/v?(\d+(?:\.\d+)+)\+(\d+)$}i)
+    strategy :github_releases do |json, regex|
+      json.filter_map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "CC Pocket.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.k9i.ccpocket",
+    "~/Library/Caches/com.k9i.ccpocket",
+    "~/Library/HTTPStorages/com.k9i.ccpocket",
+    "~/Library/Preferences/com.k9i.ccpocket.plist",
+    "~/Library/Saved Application State/com.k9i.ccpocket.savedState",
+  ]
+end


### PR DESCRIPTION
-----

Built and tested locally on macOS 26.5.
Adds CC Pocket, a remote client for Codex and Claude coding agents


<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ccpocket` is error-free.
- [x] `brew style --fix ccpocket` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new ccpocket` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ccpocket` worked successfully.
- [x] `brew uninstall --cask ccpocket` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to draft the cask and run local validation. I manually reviewed the cask, verified the download URL, app bundle, bundle identifier, minimum macOS version, livecheck result, install/uninstall behavior, and `zap` stanza paths.

-----
