### PR TITLE
harvest 3.0.5 (new cask)

### DIFF
--- a/Casks/h/harvest.rb
+++ b/Casks/h/harvest.rb
@@ -1,0 +1,26 @@
+cask "harvest" do
+  version :latest
+  sha256 :no_check
+
+  url "https://downloads.harvestfiles.com/harvest-desktop/darwin/universal/Harvest-latest.zip",
+      verified: "downloads.harvestfiles.com/harvest-desktop/"
+  name "Harvest"
+  desc "Time tracking application"
+  homepage "https://www.getharvest.com/apps/mac"
+
+  depends_on macos: :big_sur
+
+  app "Harvest.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/68MH8658M5.group.com.getharvest.Harvest",
+    "~/Library/Application Support/Harvest",
+    "~/Library/Caches/com.getharvest.harvestxapp",
+    "~/Library/Caches/com.getharvest.harvestxapp.ShipIt",
+    "~/Library/Caches/Harvest",
+    "~/Library/Group Containers/68MH8658M5.group.com.getharvest.Harvest",
+    "~/Library/HTTPStorages/com.getharvest.harvestxapp",
+    "~/Library/Logs/Harvest",
+    "~/Library/Preferences/com.getharvest.harvestxapp.plist",
+  ]
+end

--- a/Casks/h/harvest.rb
+++ b/Casks/h/harvest.rb
@@ -1,13 +1,21 @@
 cask "harvest" do
-  version :latest
-  sha256 :no_check
+  version "3.0.5"
+  sha256 "b4f58c4391b34c67affd9c94ac7ca2d8e0a5ee5ced8a058ecd033c57b09e4998"
 
-  url "https://downloads.harvestfiles.com/harvest-desktop/darwin/universal/Harvest-latest.zip",
+  url "https://downloads.harvestfiles.com/harvest-desktop/darwin/universal/Harvest-darwin-universal-#{version}.zip",
       verified: "downloads.harvestfiles.com/harvest-desktop/"
   name "Harvest"
   desc "Time tracking application"
   homepage "https://www.getharvest.com/apps/mac"
 
+  livecheck do
+    url "https://downloads.harvestfiles.com/harvest-desktop/darwin/universal/RELEASES.json"
+    strategy :json do |json|
+      json["currentRelease"]
+    end
+  end
+
+  auto_updates true
   depends_on macos: :big_sur
 
   app "Harvest.app"


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online harvest` is error-free.
- [x] `brew style --fix harvest` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new harvest` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask harvest` worked successfully.
- [x] `brew uninstall --cask harvest` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI (Claude Code, Opus 4.8) wrote the cask and ran `brew style`, `brew audit --cask --online --new`, `brew livecheck`, `brew install`, and `brew uninstall --zap`. Version `3.0.5` + `sha256` are pinned against the versioned artifact `Harvest-darwin-universal-#{version}.zip`; the version source is the app's `update-electron-app` Squirrel feed (`.../RELEASES.json`, `currentRelease`), which the `:json` livecheck reads. The `zap` paths were verified empirically rather than guessed: I (the human) launched and used the app to generate its user data, the resulting `~/Library` paths were confirmed via `install` + `uninstall --zap`, and I manually removed the TCC-protected Group Container via Finder.

-----

Built and tested locally on macOS Tahoe 26.5 (arm64).

Re-adds Harvest, removed in 2021 (#116470) when it became Mac App Store-only; it is again distributed as a direct download.