### PR TITLE
Add Ncored 2026.2.4

### DIFF
--- a/Casks/n/ncored.rb
+++ b/Casks/n/ncored.rb
@@ -1,0 +1,29 @@
+cask "ncored" do
+  version "2026.2.4"
+  sha256 "9e66746fab353efcdecce75a45a25defb3ea5b062d62389d835b7328862dad71"
+
+  url "https://github.com/NoirArchitects/ncored-app/releases/download/v#{version}/Ncored-#{version}-arm64.dmg",
+      verified: "github.com/NoirArchitects/ncored-app/"
+  name "Ncored"
+  desc "Fast PDF viewer for large construction drawings"
+  homepage "https://ncored.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :big_sur"
+
+  app "Ncored.app"
+
+  zap trash: [
+    "~/Library/Application Support/Ncored",
+    "~/Library/Caches/com.ncored.app",
+    "~/Library/Logs/Ncored",
+    "~/Library/Preferences/com.ncored.app.plist",
+    "~/Library/Saved Application State/com.ncored.app.savedState",
+  ]
+end


### PR DESCRIPTION
## Ncored 2026.2.4

A fast desktop PDF viewer and markup tool built specifically for architects, structural engineers, mechanical and electrical engineers, BIM coordinators, and construction managers who open very large (50 to 220 MB) construction drawing PDFs.

**Vendor:** Noir architects, a working architecture studio in Vilnius, Lithuania.
**Homepage:** https://ncored.com/
**Release:** https://github.com/NoirArchitects/ncored-app/releases/tag/v2026.2.4

The DMG is signed with the publisher's Apple Developer ID and notarized by Apple. Gatekeeper-verified on first launch.

### Checklist
- [x] `desc` is under 80 characters, no leading article, no trailing period
- [x] `homepage` returns 200 OK and matches the vendor's public website
- [x] `url` points to a versioned GitHub release asset on the vendor's release page (stable URL pattern)
- [x] `sha256` computed from the live release asset (Ncored-2026.2.4-arm64.dmg, ~238 MB)
- [x] `livecheck` uses the GitHub latest strategy on the same URL pattern
- [x] `zap` cleans Application Support, Caches, Logs, Preferences, Saved Application State
- [x] `depends_on arch: :arm64` (the publisher currently ships only an arm64 DMG; an x86_64 build is not currently published)
- [x] `depends_on macos: ">= :big_sur"` matches the application's stated minimum
- [x] `auto_updates true` (the application has a built-in updater that delivers signed updates from the publisher's GitHub releases)

Thanks for reviewing.
