### PR TITLE
font-kose-mono 3.126 (new cask)

### DIFF
--- a/Casks/font/font-k/font-kose-mono.rb
+++ b/Casks/font/font-k/font-kose-mono.rb
@@ -1,0 +1,21 @@
+cask "font-kose-mono" do
+  version "3.126"
+  sha256 "802b658db492e02ae5b659f5b56d7d4ef8f77609515bdcc82f462ae912888c33"
+
+  url "https://github.com/lxgw/kose-font/releases/download/v#{version}/XiaolaiMono-Regular.ttf"
+  name "Kose Font Mono"
+  name "Xiaolai Font Mono"
+  name "小赖字体等宽"
+  name "小瀨字體等寬"
+  desc "Monospace Chinese handwriting font derived from SetoFont"
+  homepage "https://github.com/lxgw/kose-font"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "XiaolaiMono-Regular.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font/font-k/font-kose.rb
+++ b/Casks/font/font-k/font-kose.rb
@@ -1,0 +1,21 @@
+cask "font-kose" do
+  version "3.126"
+  sha256 "e2f68daf0e72777a8cf58bc83de1b98634b251e537ddbfca24b0ae50d1802da2"
+
+  url "https://github.com/lxgw/kose-font/releases/download/v#{version}/Xiaolai-Regular.ttf"
+  name "Kose Font"
+  name "Xiaolai Font"
+  name "小赖字体"
+  name "小瀨字體"
+  desc "Chinese handwriting font derived from SetoFont"
+  homepage "https://github.com/lxgw/kose-font"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "Xiaolai-Regular.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew style --fix <cask>` reported no offenses.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Additionally, **if adding a new cask**:

- [x] Named according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.

---

Built and tested locally on macOS 15.

Add **Kose Font Mono** (小赖字体等宽 / Xiaolai Font Mono), the monospace variant of Kose Font, a Chinese handwriting font derived from SetoFont.

A companion to `font-kose` (#267092) for the proportional version.
