### PR TITLE
voicetypr 1.12.3 (new cask)

### DIFF
--- a/Casks/v/voicetypr.rb
+++ b/Casks/v/voicetypr.rb
@@ -1,0 +1,25 @@
+cask "voicetypr" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "1.12.3"
+  sha256 arm:   "b0217e01d030f9febb1ac46b03c0d28c2f443ff636b7bbb1486f4b22b0219bb0",
+         intel: "950aa98aacaa4fdaf060e6a29bcd22aabf4c57aabbbd5609dd6f3c0db7ba50f2"
+
+  url "https://github.com/moinulmoin/voicetypr/releases/download/v#{version}/VoiceTypr_#{version}_#{arch}.dmg",
+      verified: "github.com/moinulmoin/voicetypr/"
+  name "VoiceTypr"
+  desc "Offline AI voice-to-text dictation tool"
+  homepage "https://voicetypr.com/"
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "VoiceTypr.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.ideaplexa.voicetypr",
+    "~/Library/Caches/com.ideaplexa.voicetypr",
+    "~/Library/Logs/com.ideaplexa.voicetypr",
+    "~/Library/WebKit/com.ideaplexa.voicetypr",
+  ]
+end


### PR DESCRIPTION
-----

Built and tested locally on macOS 26.5.
Adds VoiceTypr, an offline AI voice-to-text dictation tool


<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online voicetypr` is error-free.
- [x] `brew style --fix voicetypr` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new voicetypr` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask voicetypr` worked successfully.
- [x] `brew uninstall --cask voicetypr` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used AI to draft the cask and assist with validation. I reviewed the generated cask, installed and launched the app locally, verified the `zap` paths created under `~/Library`, and confirmed audit/style/install/uninstall pass.

-----
