### PR TITLE
vmlx 1.5.49 (new cask)

### DIFF
--- a/Casks/v/vmlx.rb
+++ b/Casks/v/vmlx.rb
@@ -2,8 +2,8 @@ cask "vmlx" do
   version "1.5.49"
   sha256 "96e693f2cb6a8c476eea079ca8537808a80b5bbc5550d3bf574e0550c00fb2c4"
 
-  url "https://github.com/jjang-ai/mlxstudio/releases/download/v#{version}/vMLX-#{version}-sequoia-arm64.dmg",
-      verified: "github.com/jjang-ai/mlxstudio/"
+  url "https://github.com/jjang-ai/vmlx/releases/download/v#{version}/vMLX-#{version}-sequoia-arm64.dmg",
+      verified: "github.com/jjang-ai/vmlx/"
   name "vMLX"
   desc "Run local AI models on Apple Silicon"
   homepage "https://mlx.studio/"

--- a/Casks/v/vmlx.rb
+++ b/Casks/v/vmlx.rb
@@ -1,0 +1,29 @@
+cask "vmlx" do
+  version "1.5.49"
+  sha256 "96e693f2cb6a8c476eea079ca8537808a80b5bbc5550d3bf574e0550c00fb2c4"
+
+  url "https://github.com/jjang-ai/mlxstudio/releases/download/v#{version}/vMLX-#{version}-sequoia-arm64.dmg",
+      verified: "github.com/jjang-ai/mlxstudio/"
+  name "vMLX"
+  desc "Run local AI models on Apple Silicon"
+  homepage "https://mlx.studio/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "vMLX.app"
+
+  uninstall quit: "net.vmlx.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.vmlx.app.sfl*",
+    "~/Library/Application Support/vmlx",
+    "~/Library/Preferences/net.vmlx.app.plist",
+  ]
+end


### PR DESCRIPTION
-----

Built and tested locally on macOS 26.5.
Adds vMLX, run local AI models on Apple Silicon"

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online vmlx` is error-free.
- [x] `brew style --fix vmlx` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new vmlx` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask vmlx` worked successfully.
- [x] `brew uninstall --cask vmlx` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

 AI was used to draft the cask, compare it against Homebrew Cask conventions, and run validation commands. I manually verified the release metadata, installed and uninstalled the cask locally, and checked the `zap` stanza paths with `brew generate-zap vmlx`.

-----
