### PR TITLE
gephi 0.11.2

### DIFF
--- a/Casks/g/gephi.rb
+++ b/Casks/g/gephi.rb
@@ -1,9 +1,9 @@
 cask "gephi" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.10.1"
-  sha256 arm:   "cbb852d2f33cddf793290a64aee564cd46ad80ef6c51766ad05dfeb801ac7227",
-         intel: "abc7ca1ba7f2a91e51af716ad0a1a785a798f7bb7100841dfdb775895919f508"
+  version "0.11.2"
+  sha256 arm:   "c5ab54d387386f568b400c03d6918a7a99232de828e29f6eb36c79d86f435fa8",
+         intel: "20a858631ae85ed1250e7a3afabe3ac09ec17375adf48d50d37157855ca5fcc3"
 
   url "https://github.com/gephi/gephi/releases/download/v#{version}/gephi-#{version}-macos-#{arch}.dmg",
       verified: "github.com/gephi/gephi/"
@@ -11,7 +11,7 @@ cask "gephi" do
   desc "Open-source platform for visualizing and manipulating large graphs"
   homepage "https://gephi.org/"
 
-  depends_on :macos
+  depends_on macos: ">= :big_sur"
 
   app "Gephi.app"
 

--- a/Casks/g/gephi.rb
+++ b/Casks/g/gephi.rb
@@ -11,7 +11,7 @@ cask "gephi" do
   desc "Open-source platform for visualizing and manipulating large graphs"
   homepage "https://gephi.org/"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "Gephi.app"
 

--- a/audit_exceptions/signing_audit_skiplist.json
+++ b/audit_exceptions/signing_audit_skiplist.json
@@ -2,7 +2,6 @@
   "ai-studio": "all",
   "empoche": "intel",
   "freecad": "intel",
-  "gephi": "intel",
   "icon-composer": "intel",
   "musescore": "intel",
   "readdle-spark": "intel",

--- a/audit_exceptions/signing_audit_skiplist.json
+++ b/audit_exceptions/signing_audit_skiplist.json
@@ -2,6 +2,7 @@
   "ai-studio": "all",
   "empoche": "intel",
   "freecad": "intel",
+  "gephi": "intel",
   "icon-composer": "intel",
   "musescore": "intel",
   "readdle-spark": "intel",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Continuation of #263541.

The `macos-15-intel` runner is weirdly failing again. (All other Intel runners and local tests reveal that the signature is valid.) I tried to fix this by adding the cask into the exception list, but then the macOS 26 Intel runner reports `Cask is in the signing audit skiplist, but does not need to be skipped!`...

Maybe the exception list should be further narrowed to disable the check for specific runners?
