### PR TITLE
Add Bzz

### DIFF
--- a/Casks/b/bzz.rb
+++ b/Casks/b/bzz.rb
@@ -1,0 +1,37 @@
+cask "bzz" do
+  version "0.3.0"
+  sha256 "ca9a0192c2ebad98bb8ce087505285a0e720039692ff297f08f2d45f62cd3483"
+
+  url "https://github.com/zlopixatel/bzz/releases/download/v#{version}/Bzz.dmg",
+      verified: "github.com/zlopixatel/bzz/"
+  name "Bzz"
+  desc "Open-source automatic keyboard layout switcher for Russian and English typing"
+  homepage "https://github.com/zlopixatel/bzz"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates false
+  depends_on macos: :monterey
+
+  app "Bzz.app"
+
+  zap trash: [
+    "~/Library/Application Support/Bzz",
+    "~/Library/LaunchAgents/com.zlopixatel.bzz.plist",
+    "~/Library/Logs/Bzz",
+  ]
+
+  caveats <<~EOS
+    Bzz needs Accessibility permission to read keystrokes:
+      System Settings → Privacy & Security → Accessibility → enable Bzz
+
+    The app is signed and notarized by the developer (Roman Kovalev,
+    TeamID 7FJC4XM2S5) so Gatekeeper should not block it on first launch.
+
+    Privacy policy: https://zlopixatel.github.io/bzz/privacy.html
+    No telemetry, no network calls, source code is MIT on GitHub.
+  EOS
+end


### PR DESCRIPTION
Adds [Bzz](https://github.com/zlopixatel/bzz) — open-source automatic keyboard layout switcher for macOS (Russian/English), written in Go.

After reading and reviewing [`CONTRIBUTING.md`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md), I am confident that my pull request adheres to its guidelines.

- [x] `brew style --fix Casks/b/bzz.rb` clean
- [x] DMG is signed and notarized by Developer ID (Roman Kovalev, TeamID 7FJC4XM2S5)
- [x] Stable release v0.3.0 published https://github.com/zlopixatel/bzz/releases/tag/v0.3.0
- [x] No analogue in the cask repo (`Casks/b/bzz*` does not exist)
- [x] Privacy policy published: https://zlopixatel.github.io/bzz/privacy.html
- [x] Caveats note the Accessibility permission requirement

## What is Bzz

Bzz detects when you type a word in the wrong keyboard layout — e.g. \`ghbdtn\` (which you meant as \`привет\`) — and replaces it on the fly, before you hit Enter. It's an open-source MIT-licensed replacement for:

- **Punto Switcher** by Yandex — abandoned for macOS since 2017
- **Caramba Switcher** — subscription-based closed source

Implementation: Go + CGEventTap (active mode for Enter-suppress), 98K Russian dictionary with Snowball stemmer + Levenshtein fuzzy matching, Cmd+Z undo with per-app learning, tray icon, LaunchAgent auto-start. 4.5 MB notarized binary, no telemetry, no network calls.