### PR TITLE
font-xiaolai-mono 3.126 (new cask)

### DIFF
--- a/Casks/font/font-x/font-xiaolai-mono.rb
+++ b/Casks/font/font-x/font-xiaolai-mono.rb
@@ -1,0 +1,20 @@
+cask "font-xiaolai-mono" do
+  version "3.126"
+  sha256 "802b658db492e02ae5b659f5b56d7d4ef8f77609515bdcc82f462ae912888c33"
+
+  url "https://github.com/lxgw/kose-font/releases/download/v#{version}/XiaolaiMono-Regular.ttf"
+  name "Xiaolai Font Mono"
+  name "小赖字体等宽"
+  name "小瀨字體等寬"
+  name "Kose Font Mono"
+  homepage "https://github.com/lxgw/kose-font"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "XiaolaiMono-Regular.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font/font-x/font-xiaolai-mono.rb
+++ b/Casks/font/font-x/font-xiaolai-mono.rb
@@ -9,11 +9,6 @@ cask "font-xiaolai-mono" do
   name "Kose Font Mono"
   homepage "https://github.com/lxgw/kose-font"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   font "XiaolaiMono-Regular.ttf"
 
   # No zap stanza required


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew style --fix <cask>` reported no offenses.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Additionally, **if adding a new cask**:

- [x] Named according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.

---

Built and tested locally on macOS 15.

Add **Xiaolai Font Mono** (小赖字体等宽), the monospace variant of Xiaolai Font, a Chinese handwriting font derived from SetoFont.
