### PR TITLE
Add rcmd 3.2.1

### DIFF
--- a/Casks/r/rcmd.rb
+++ b/Casks/r/rcmd.rb
@@ -1,0 +1,31 @@
+cask "rcmd" do
+  version "3.2.1"
+  sha256 "e42d0944fe6b74b2ef74da598fc78fa0a55cdf0826eba4f6543508399f1605dd"
+
+  url "https://files.lowtechguys.com/releases/rcmd-#{version}.dmg"
+  name "rcmd"
+  desc "App switcher driven by the Right Command key"
+  homepage "https://lowtechguys.com/rcmd/"
+
+  livecheck do
+    url "https://files.lowtechguys.com/rcmd/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "rcmd.app"
+
+  zap trash: [
+    "~/.config/rcmd",
+    "~/.local/bin/rcmd",
+    "~/Library/Application Scripts/com.lowtechguys.rcmd",
+    "~/Library/Application Support/rcmd",
+    "~/Library/Caches/com.lowtechguys.rcmd",
+    "~/Library/HTTPStorages/com.lowtechguys.rcmd",
+    "~/Library/HTTPStorages/com.lowtechguys.rcmd.binarycookies",
+    "~/Library/Preferences/com.lowtechguys.rcmd.plist",
+    "~/Library/WebKit/com.lowtechguys.rcmd",
+  ]
+end


### PR DESCRIPTION
This is for adding my rcmd app (https://lowtechguys.com/rcmd) to the brew cask. 

I don't have a GitHub repo to prove popularity, but it has 5 years of being on the [App Store](https://apps.apple.com/us/app/rcmd-app-switcher/id1596283165) with 53 reviews in the US, and recently I launched it independently outside the App Store to get access to window management APIs. 

The PR adds that new indie version, the App Store version is discontinued. 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
