### PR TITLE
Add aspire 13.4.0

### DIFF
--- a/Casks/a/aspire.rb
+++ b/Casks/a/aspire.rb
@@ -1,0 +1,29 @@
+cask "aspire" do
+  arch arm: "arm64", intel: "x64"
+
+  version "13.4.0"
+  sha256 arm:   "a828fd1f7cf4712535852624347b4b81b23efe36048c262ceae64a762ae0df98",
+         intel: "baac505b0433a157da9dc24cf01f8f8cbc304d7a068d160a1c6b941f4ce2b02c"
+
+  url "https://github.com/microsoft/aspire/releases/download/v#{version}/aspire-cli-osx-#{arch}-#{version}.tar.gz",
+      verified: "github.com/microsoft/aspire/"
+  name "Aspire CLI"
+  desc "CLI for building observable, production-ready distributed applications"
+  homepage "https://aspire.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on :macos
+
+  binary "aspire"
+
+  # Lets the Aspire CLI identify the install source without path heuristics.
+  postflight do
+    File.write("#{staged_path}/.aspire-install.json", %Q({"source":"brew"}\n))
+  end
+
+  # No zap stanza required
+end

--- a/Casks/a/aspire.rb
+++ b/Casks/a/aspire.rb
@@ -25,5 +25,5 @@ cask "aspire" do
     File.write("#{staged_path}/.aspire-install.json", %Q({"source":"brew"}\n))
   end
 
-  # No zap stanza required
+  zap trash: "~/.aspire"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online aspire` is error-free.
- [x] `brew style --fix aspire` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new aspire` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask aspire` worked successfully.
- [x] `brew uninstall --cask aspire` worked successfully.

-----

First-time submission of an `aspire` cask. The CLI is a Microsoft Developer ID–signed, notarized single binary published to [microsoft/aspire releases](https://github.com/microsoft/aspire/releases).

**Why a cask and not a homebrew-core formula.** Aspire CLI is open-source and CLI-only, so [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks#rejected-casks) ordinarily directs to homebrew-core. Submitting as a cask following the precedent of [`codex` (#232353)](https://github.com/Homebrew/homebrew-cask/pull/232353) and [`mitmproxy` (#159283)](https://github.com/Homebrew/homebrew-cask/pull/159283): the published binary is signed with a Microsoft Developer ID and notarized, and the same binary is shipped via every other Aspire distribution channel (GitHub release downloads, the official `get-aspire-cli` install script, the `Aspire.Cli` dotnet tool). A homebrew-core formula bottle would diverge from that vendor binary in code signature and build identity, which we'd like to avoid for triage and trust consistency.

**Prior closed PRs from `aspire-homebrew-bot` are mine.** [#254315](https://github.com/Homebrew/homebrew-cask/pull/254315), [#254329](https://github.com/Homebrew/homebrew-cask/pull/254329), [#254474](https://github.com/Homebrew/homebrew-cask/pull/254474), [#254509](https://github.com/Homebrew/homebrew-cask/pull/254509), [#265213](https://github.com/Homebrew/homebrew-cask/pull/265213), [#265219](https://github.com/Homebrew/homebrew-cask/pull/265219), [#265234](https://github.com/Homebrew/homebrew-cask/pull/265234), [#265237](https://github.com/Homebrew/homebrew-cask/pull/265237), [#265387](https://github.com/Homebrew/homebrew-cask/pull/265387). I was iterating on an automated cask-publish step in the Aspire release pipeline and the bot was opening PRs faster than I was getting the audit, version-channel, and supersede logic right. As @krehel correctly called out on #254509 and #265387, that wasn't an acceptable shape for the maintainer review queue. Apologies for the noise.

What's different now:

- The automated publish path has been deleted from the Aspire release pipeline. No Aspire CI workflow will open a homebrew-cask PR going forward.
- Subsequent stable-release bumps will be handled by Homebrew autobump via `livecheck :github_latest`, same as codex, copilot-cli, ngrok, and similar.
- Preview / RC versions will not be submitted to this `aspire` cask.
- This PR is a single, hand-driven submission for v13.4.0 (current stable). Full local audit gauntlet (`brew audit --cask --online aspire`, `brew audit --cask --new aspire`, `brew audit --cask --online --new --signing --strict aspire`, `brew style --fix aspire`, `brew livecheck --cask aspire`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask aspire`, `brew uninstall --cask aspire`, `brew uninstall --cask --zap --force aspire`) was run on a clean macOS host and re-read by me before opening.

CC @krehel for visibility given the prior context.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (GitHub Copilot CLI) helped draft and review this PR body and re-ran the local verification gauntlet against the cask. The Ruby cask was written by hand against the [Cookbook](https://docs.brew.sh/Cask-Cookbook); SHA-256 values were computed locally from the downloaded tarballs and cross-checked against the upstream `.sha512` sidecars; signing and notarization were verified directly. AI did not author the Ruby source or pick the version, URL pattern, or SHAs.

Local verification completed against a tap pointing at this branch (`HOMEBREW_NO_INSTALL_FROM_API=1` set in the shell so brew resolves to the staged cask file rather than the upstream JSON API, which does not yet contain an `aspire` cask):

- `ruby -c Casks/a/aspire.rb` → `Syntax OK`.
- `brew style aspire` → no offenses.
- `brew audit --cask --online --new --signing --strict aspire` → exit 0, no findings.
- `brew livecheck --cask aspire` → `aspire: 13.4.0 ==> 13.4.0` (matches current `Latest` release on `microsoft/aspire`).
- SHA-256 of `aspire-cli-osx-arm64-13.4.0.tar.gz` = `a828fd1f7cf4712535852624347b4b81b23efe36048c262ceae64a762ae0df98`; SHA-512 of same tarball matches `aspire-cli-osx-arm64-13.4.0.tar.gz.sha512` published at the release.
- SHA-256 of `aspire-cli-osx-x64-13.4.0.tar.gz` = `baac505b0433a157da9dc24cf01f8f8cbc304d7a068d160a1c6b941f4ce2b02c`; SHA-512 matches the corresponding published sidecar.
- `codesign -dv --verbose=4` on the extracted binary → `Authority=Developer ID Application: Microsoft Corporation (UBF8T346G9)`, hardened runtime, timestamped, satisfies its Designated Requirement.
- `spctl -a -vv -t install` → `accepted, source=Notarized Developer ID, origin=Developer ID Application: Microsoft Corporation (UBF8T346G9)`.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask aspire` → clean install, binary symlinked, `.aspire-install.json` sidecar written under `staged_path`.
- `aspire --help` (first run) → the cask writes nothing outside `staged_path`; the embedded bundle stays under `Caskroom/aspire/13.4.0/`. The CLI itself appends to `~/.aspire/logs/`, which is expected user state shared across install channels.
- `brew uninstall --cask aspire` → caskroom and binary symlink removed; `~/.aspire/` untouched.
- `brew uninstall --cask --zap --force aspire` → emits the expected `Warning: No zap stanza present for Cask 'aspire'`; `~/.aspire/` untouched.

`zap` paths: none. `~/.aspire/` is user state populated by the CLI on first use (caches, logs, bin shim for the install script) and is shared across install channels (winget, `dotnet tool`, the `get-aspire-cli` script, Homebrew). The Cookbook says `zap` "should not remove [...] files created by the user directly" — that applies here. Following [Cookbook §`zap` creation](https://docs.brew.sh/Cask-Cookbook#stanza-zap), the cask carries the `# No zap stanza required` comment in place of a stanza.

-----
