### PR TITLE
New cask: bluetooth-disconnect-on-display-sleep

### DIFF
--- a/Casks/b/bluetooth-disconnect-on-display-sleep.rb
+++ b/Casks/b/bluetooth-disconnect-on-display-sleep.rb
@@ -4,7 +4,7 @@ cask "bluetooth-disconnect-on-display-sleep" do
 
   url "https://github.com/six6liu/macos-bluetooth-disconnect-on-display-sleep/releases/download/v#{version}/Display-BT-Toggle-v#{version}.zip"
   name "macos-bluetooth-disconnect-on-display-sleep"
-  desc "Menu bar app: disconnect a Bluetooth device when the display sleeps, reconnect on wake"
+  desc "Disconnect a Bluetooth device when the display sleeps and reconnect on wake"
   homepage "https://github.com/six6liu/macos-bluetooth-disconnect-on-display-sleep"
 
   livecheck do
@@ -12,11 +12,11 @@ cask "bluetooth-disconnect-on-display-sleep" do
     strategy :github_latest_release
   end
 
+  depends_on macos: ">= :big_sur"
+
   depends_on formula: "blueutil"
 
   app "Display BT Toggle.app"
 
-  zap trash: [
-    "~/Library/Preferences/com.apple.scripteditor.id.macos-bluetooth-disconnect-on-display-sleep.plist",
-  ]
+  zap trash: "~/Library/Preferences/com.apple.scripteditor.id.macos-bluetooth-disconnect-on-display-sleep.plist"
 end

--- a/Casks/b/bluetooth-disconnect-on-display-sleep.rb
+++ b/Casks/b/bluetooth-disconnect-on-display-sleep.rb
@@ -1,0 +1,22 @@
+cask "bluetooth-disconnect-on-display-sleep" do
+  version "1.0"
+  sha256 "48b2dba8e2720abd4ca6bb2b7eb36f28cf4309e01fc1bbe42bd6f388c9a236bd"
+
+  url "https://github.com/six6liu/macos-bluetooth-disconnect-on-display-sleep/releases/download/v#{version}/Display-BT-Toggle-v#{version}.zip"
+  name "macos-bluetooth-disconnect-on-display-sleep"
+  desc "Menu bar app: disconnect a Bluetooth device when the display sleeps, reconnect on wake"
+  homepage "https://github.com/six6liu/macos-bluetooth-disconnect-on-display-sleep"
+
+  livecheck do
+    url :url
+    strategy :github_latest_release
+  end
+
+  depends_on formula: "blueutil"
+
+  app "Display BT Toggle.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.apple.scripteditor.id.macos-bluetooth-disconnect-on-display-sleep.plist",
+  ]
+end


### PR DESCRIPTION
This adds a cask for [macos-bluetooth-disconnect-on-display-sleep](https://github.com/six6liu/macos-bluetooth-disconnect-on-display-sleep), a small menu bar app that disconnects a Bluetooth device (e.g. earbuds) when the macOS display sleeps, and reconnects it on wake. Event-driven (no polling), no system modification, single .app.

## The problem it solves

On a Mac that runs 24/7 (server, media box, always-on workstation), the display can sleep while the host stays awake. macOS does not disconnect paired Bluetooth audio devices on display sleep, so earbuds stay bound to the Mac and block other devices from using them. Built-in tools (`pmset`, Bluesnooze, Shortcuts) only watch host sleep, not display sleep.

## How it works

Watches `com.apple.SkyLight:display` log events (`Event: Did Sleep` / `Event: Did Wake`) and runs a user-configured command — default is `blueutil --disconnect` for one specific device, then `--connect` on wake. Configurable in `~/.config/macos-bluetooth-disconnect/config`.

## Checklist

- [x] Cask name has no "Mac", "OS X", or "macOS" prefix (per style guide)
- [x] `desc` ≤ 80 chars
- [x] `livecheck` block with `github_latest_release` strategy
- [x] `depends_on formula: "blueutil"`
- [x] `zap trash:` for cleanup
- [x] Default MAC in bundled `config.example` is the placeholder `aa-bb-cc-dd-ee-ff` — no PII
- [x] Verified: app launches, menu bar icon shows, watcher reacts to display sleep on the test machine

## Notes for reviewers

- The macOS Gatekeeper will warn on first launch since the .app is ad-hoc signed (`codesign --sign -`). Users have to right-click → Open the first time, or run `xattr -dr com.apple.quarantine /Applications/Display\ BT\ Toggle.app` from the .app's own README.
- I can submit a notarized build if homebrew-cask requires it; let me know.
