### PR TITLE
openlogi 0.3.4 (new cask)

### DIFF
--- a/Casks/o/openlogi.rb
+++ b/Casks/o/openlogi.rb
@@ -1,0 +1,30 @@
+cask "openlogi" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "0.3.4"
+  sha256 arm:   "11024c3a19a8b7c9fd478a39e6c9545a634b7e2f751f19b3574fc843d8d33663",
+         intel: "4e40a994d9763822b46f07c2d52f62d612fd2c8afbeae813623b4ce1a690af58"
+
+  url "https://updates.openlogi.org/releases/v#{version}/OpenLogi-v#{version}-macos-#{arch}.dmg"
+  name "OpenLogi"
+  desc "Local-first alternative to Logitech Options+ for HID++ devices"
+  homepage "https://openlogi.org/"
+
+  livecheck do
+    url "https://github.com/AprilNEA/OpenLogi"
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "OpenLogi.app"
+
+  zap trash: [
+    "~/.config/openlogi",
+    "~/.local/share/openlogi",
+    "~/Library/Caches/org.openlogi.openlogi",
+    "~/Library/Preferences/org.openlogi.openlogi.plist",
+    "~/Library/Saved Application State/org.openlogi.openlogi.savedState",
+  ]
+end


### PR DESCRIPTION
OpenLogi — a native, local-first alternative to Logitech Options+ for Logitech HID++ peripherals (button remap, DPI, SmartShift). No account, no telemetry.

The project launched ~3 days ago and took off on X — https://x.com/AprilNEA/status/2060337015267434858 — 3,000+ stars already. As the repo is just under 30 days old, I'm submitting under the "recently released to great fanfare" allowance in Acceptable Casks; glad to have you hold it until it reaches 30 days (2026-06-23) or merge at your discretion.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----