### PR TITLE
rockxy 0.24.0,37

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.23.0,36"
-  sha256 "1519f0dbae2541c10c700c84929ddcd270f7e24595f00afb6272dfdb610a18ee"
+  version "0.24.0,37"
+  sha256 "22a2a9f89d861712dfdb586367faaa405bb1bca6a31fe0198cca152b6f6d9ed6"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.24.0 build 37.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.24.0/Rockxy-0.24.0-37.dmg
- SHA-256: 22a2a9f89d861712dfdb586367faaa405bb1bca6a31fe0198cca152b6f6d9ed6
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
