### PR TITLE
speechify-ai-assistant: fix app artifact name

### DIFF
--- a/Casks/s/speechify-ai-assistant.rb
+++ b/Casks/s/speechify-ai-assistant.rb
@@ -1,0 +1,27 @@
+cask "speechify-ai-assistant" do
+  version "3.3.0"
+  sha256 :no_check
+
+  url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/SpeechifyVoiceAssistant.dmg",
+      verified: "storage.googleapis.com/speechifymobile.appspot.com/"
+  name "Speechify AI Assistant"
+  desc "AI-powered reading and voice assistant"
+  homepage "https://www.speechify.com/"
+
+  livecheck do
+    url "https://storage.googleapis.com/speechifymobile.appspot.com/macAgentSparkle/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Speechify Voice AI.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.cliffweitzman.speechifymacagent",
+    "~/Library/Caches/com.cliffweitzman.speechifymacagent",
+    "~/Library/Caches/com.crashlytics.data/com.cliffweitzman.speechifymacagent",
+    "~/Library/Preferences/com.cliffweitzman.speechifymacagent.plist",
+  ]
+end


### PR DESCRIPTION
The DMG for `speechify-ai-assistant` v3.3.0 (`SpeechifyVoiceAssistant.dmg`) now ships `Speechify Voice AI.app` instead of `Speechify AI Assistant.app`, causing installation to fail:

```
Error: It seems the App source '/opt/homebrew/Caskroom/speechify-ai-assistant/3.3.0/Speechify AI Assistant.app' is not there.
```

Verified by mounting the DMG locally:
- Volume name: `Install Speechify Voice AI`
- App bundle inside: `Speechify Voice AI.app`

```
$ ls "/Volumes/Install Speechify Voice AI/"
.background/
.DS_Store
Applications -> /Applications
Speechify Voice AI.app/
```

The app launches and runs correctly after manual installation to `/Applications`.

This PR updates the `app` artifact from `"Speechify AI Assistant.app"` to `"Speechify Voice AI.app"` to match the actual name inside the DMG.

Co-Authored-By: Oz <oz-agent@warp.dev>