### PR TITLE
Add ailernhub cask v1.0.2

### DIFF
--- a/Casks/a/ailernhub.rb
+++ b/Casks/a/ailernhub.rb
@@ -1,0 +1,15 @@
+cask "ailernhub" do
+  version "1.0.2"
+  sha256 "aa232ca600efcd1b4333c749bf5e68822ed21efa655c91ab9ac2f830993ef6b0"
+
+  url "https://raw.githubusercontent.com/ArronAI007/homebrew-tap/main/releases/AILearnHub-#{version}.zip"
+  name "AILearnHub"
+  desc "LLM course learning platform with in-browser Python execution"
+  homepage "https://github.com/ArronAI007/AILearnHub"
+
+  depends_on macos: :ventura
+
+  app "AILearnHub.app"
+
+  zap trash: "~/Library/Preferences/com.ailernhub.app.plist"
+end


### PR DESCRIPTION
## Description

**AILearnHub** is an LLM course learning platform with in-browser Python code execution (Pyodide/WebAssembly).

- **App size**: ~1.5MB bundle
- **Tech**: Swift + embedded HTTP server + WKWebView
- **No external dependencies**: No Python, Node.js, or Chrome required

## Install

```bash
brew install --cask ailernhub
```

## Notes

- The zip is hosted on the tap repo for reliable downloads via raw.githubusercontent.com
- App is ad-hoc signed (standard for Homebrew cask)
- Minimum macOS: Ventura

## Verification

- [x] Cask follows Homebrew style guidelines
- [x] SHA256 matches uploaded artifact
- [x] `brew fetch --cask ailernhub` succeeds locally