### PR TITLE
Add AgentAwake v1.0.0

### DIFF
--- a/Casks/a/agentawake.rb
+++ b/Casks/a/agentawake.rb
@@ -1,0 +1,27 @@
+cask "agentawake" do
+  version "1.0.0"
+  sha256 "65c19fab15e9970a0d57d95642e269b08179b7511a531b4513b162085d2fcdf6"
+
+  url "https://github.com/wulonglin/AgentAwake/releases/download/v#{version}/AgentAwake-#{version}.dmg"
+  name "AgentAwake"
+  desc "Keep your Mac awake while AI agents are running"
+  homepage "https://github.com/wulonglin/AgentAwake"
+
+  depends_on macos: ">= :ventura"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "AgentAwake.app"
+
+  postflight do
+    system "xattr", "-cr", "#{appdir}/AgentAwake.app"
+  end
+
+  zap trash: [
+    "~/.agentawake",
+    "~/Library/LaunchAgents/com.agentawake.app.plist",
+  ]
+end


### PR DESCRIPTION
## Add AgentAwake v1.0.0

AgentAwake keeps your Mac awake while AI agents are running.

### Features
- Auto-detect AI coding assistants (fuzzy matching)
- Keep Mac awake while agents run
- Dim screen on lid close, restore on open
- Pause/resume monitoring
- Launch at login

### Supported Agents
Claude, Codex, Trae, CodeBuddy, WorkBuddy, Cursor, Copilot, and 15+ more.

### Description
Don't let sleep interrupt your Agent. Automatically detects AI coding assistants like Claude, Codex, Trae and keeps your Mac awake while they run. Supports lid-close operation so your Agent keeps working until the task is done.

Homepage: https://github.com/wulonglin/AgentAwake