### PR TITLE
Add desktop-duck 1.2

### DIFF
--- a/Casks/d/desktop-duck.rb
+++ b/Casks/d/desktop-duck.rb
@@ -1,0 +1,25 @@
+cask "desktop-duck" do
+  version "1.2"
+  sha256 "07e18ae7cbc15deba1472a3a337f17c0540f2bdb87c2a26057c49eba714e87ce"
+
+  url "https://github.com/ShiyangZheng/DesktopDuck/releases/download/v#{version}/DesktopDuck-v#{version}.app.zip"
+  name "DesktopDuck"
+  desc "AI-powered desktop pet with group chat, journal, and character generation"
+  homepage "https://github.com/ShiyangZheng/DesktopDuck"
+
+  depends_on macos: ">= :monterey"
+
+  app "DesktopDuck.app"
+
+  zap trash: [
+    "~/.workbuddy/duck-config.json",
+    "~/.workbuddy/duck-prefs.json",
+    "~/.workbuddy/pet-thoughts.json",
+    "~/.workbuddy/pet-response.json",
+    "~/.workbuddy/pet-inbox.txt",
+    "~/.workbuddy/journal.json",
+    "~/.workbuddy/chat-history.json",
+    "~/.workbuddy/duck-custom",
+    "~/.workbuddy/duck-sprites",
+  ]
+end


### PR DESCRIPTION
## Desktop Duck v1.2

🦆 AI-powered desktop pet for macOS — a floating window with a duck (or capybara!) that chats, runs group discussions, journals, and generates custom character animations.

### Features
- **AI Chat**: Powered by MiniMax API
- **Group Chat** (v1.2): Two pets engage in autonomous multi-turn discussions
- **Journal**: Guided templates (Odyssey Plan, Wheel of Life, Fear Setting, etc.)
- **Character Generator**: AI spritesheet → GIF animation pipeline
- **Customizable**: Full preferences panel for appearance and behavior

### App Info
- Homepage: https://github.com/ShiyangZheng/DesktopDuck
- Requires: macOS 12+ (Monterey)
- License: MIT
- Swift + AppKit, zero external dependencies