### PR TITLE
Add csv-quick-look

### DIFF
--- a/Casks/c/csv-quick-look.rb
+++ b/Casks/c/csv-quick-look.rb
@@ -1,0 +1,17 @@
+cask "csv-quick-look" do
+  version "1.0.2"
+  sha256 "4a2f8b1508a0730f9072c2a74b5555fb2589e0a90b1f72e01982901481b453e6"
+
+  url "https://github.com/adamorad/csv-quick-look/releases/download/v#{version}/CSV.Quick.Look.zip"
+  name "CSV Quick Look"
+  desc "QuickLook extension for CSV and TSV files"
+  homepage "https://github.com/adamorad/csv-quick-look"
+
+  depends_on macos: ">= :monterey"
+
+  app "CSV Quick Look.app"
+
+  uninstall quit: "com.adammorad.csvquicklook"
+
+  zap trash: "~/Library/Preferences/com.adammorad.csvquicklook.plist"
+end


### PR DESCRIPTION
## cask csv-quick-look

- [x] `brew audit --cask --new csv-quick-look` passes

**What is it?**
A macOS QuickLook extension that renders CSV and TSV files as a spreadsheet table — virtual scroll (500k+ rows), column sort, live filter, dark mode.

**Why does this belong here?**
The only prior plugin for this file type (quicklook-csv) broke when macOS Sequoia removed the .qlgenerator format in 2024. No working replacement exists in homebrew-cask. This is built with the modern .appex extension format and supports macOS 12+.

- Homepage: https://github.com/adamorad/csv-quick-look
- Release: https://github.com/adamorad/csv-quick-look/releases/tag/v1.0.2