### PR TITLE
fathom 3.1.3

### DIFF
--- a/Casks/f/fathom.rb
+++ b/Casks/f/fathom.rb
@@ -2,9 +2,9 @@ cask "fathom" do
   arch arm: "arm64", intel: "x64"
   livecheck_arch = on_arch_conditional arm: "_arm64"
 
-  version "3.0.1"
-  sha256 arm:   "f07612b8b245b963d7a4fc1e9b9cb0227e2407eac58e9b32f811b13d63484935",
-         intel: "655c6ff1df507143810532ee72193ea52d00d93f3f34a1c1a561072c77150242"
+  version "3.1.3"
+  sha256 arm:   "7fcca4d266ac473ce0b87257b5684a3cea614174148a6949b3e6b79154a2d84b",
+         intel: "72661c502fc481396b8685209f6d33a19b46f352d80b12ee359ba1bbd160e9d6"
 
   url "https://electron-update.fathom.video/download/file/Fathom-darwin-#{arch}-#{version}.dmg"
   name "Fathom"


### PR DESCRIPTION
Updates fathom from 3.0.1 to 3.1.3 with corrected SHA256 hashes for both arm64 and intel.

Note: The livecheck in this cask appears to be broken and needs investigation. The livecheck endpoint (`https://electron-update.fathom.video/update/darwin_arm64/0.0.0`) returns version 1.42.6 using a Squirrel auto-updater versioning scheme that does not match the standalone DMG versioning (3.x). No alternative endpoints were found that expose the 3.x versioning, and Fathom does not publish public GitHub releases. This PR does not attempt to fix the livecheck — flagging it here for maintainer review. This is also why `brew audit` fails.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

- Used Claude (claude.ai) to identify the broken download URL, verify the correct version and URL structure by probing the Fathom update server, investigate the livecheck discrepancy, and draft the PR description.
Manual verification steps taken:

- Confirmed https://electron-update.fathom.video/download/file/Fathom-darwin-arm64-3.1.3.dmg returns a valid 302 redirect to Cloudflare R2 storage
- Computed SHA256 hashes independently by downloading both arm64 and intel DMGs
- Ran brew audit --cask --online which confirmed the downloads succeed — the only failure is the known livecheck mismatch documented in this PR
- Ran brew style --fix with no offenses reported
- Verified zap stanza paths (~/Library/Application Support/Fathom and ~/Library/Logs/Fathom) exist on a machine with Fathom installed
-----