### PR TITLE
dfu-blaster-pro 4.2,3282 (new cask)

### DIFF
--- a/Casks/d/dfu-blaster-pro.rb
+++ b/Casks/d/dfu-blaster-pro.rb
@@ -1,0 +1,35 @@
+cask "dfu-blaster-pro" do
+  version "4.2,3282"
+  sha256 "69a4eae2a7a6fb23be29c6f7a7c9540fbb8063a0b1993a9ca74365e23a25d07e"
+
+  url "https://twocanoes-software-updates.s3.amazonaws.com/DFU_Blaster_Pro_Build-#{version.csv.second}_Version-#{version.csv.first}.dmg",
+      verified: "twocanoes-software-updates.s3.amazonaws.com/"
+  name "DFU Blaster Pro"
+  desc "Utility to put Apple silicon Macs into DFU mode for restore"
+  homepage "https://twocanoes.com/products/mac/dfu-blaster/"
+
+  livecheck do
+    url "https://twocanoes.com/products/mac/dfu-blaster/history/"
+    regex(%r{/DFU[._-]Blaster[._-]Pro[._-]Build[._-](\d+)[._-]Version[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      "#{match[2]},#{match[1]}"
+    end
+  end
+
+  depends_on macos: :big_sur
+
+  pkg "DFU Blaster Pro.pkg"
+
+  uninstall launchctl: "com.twocanoes.dfublasterhelper",
+            pkgutil:   "com.twocanoes.pkg.DFU-Blaster"
+
+  zap trash: [
+    "~/Library/Application Support/com.twocanoes.DFU-Blaster-Pro",
+    "~/Library/Caches/com.twocanoes.DFU-Blaster-Pro",
+    "~/Library/HTTPStorages/com.twocanoes.DFU-Blaster-Pro",
+    "~/Library/Preferences/com.twocanoes.DFU-Blaster-Pro.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude) helped scaffold this cask; I verified everything manually. The `sha256` was
computed from Twocanoes' actual download, and the `version` (marketing version + build),
pkg name, and pkg receipt id `com.twocanoes.pkg.DFU-Blaster` were read from the DMG/pkg
with `hdiutil` and `pkgutil --expand-full`. The installer also lays down a privileged
helper daemon, so `uninstall` unloads it with `launchctl: "com.twocanoes.dfublasterhelper"`
alongside the `pkgutil:` receipt. The `zap` paths (`Application Support`, `Caches`,
`HTTPStorages`, `Preferences` under `com.twocanoes.DFU-Blaster-Pro`) come from the files
actually left under `~/Library`; I confirmed `brew install` → `uninstall` → `zap` leaves
nothing behind. `brew audit --cask --online --new` and `brew style` pass.

-----
