### PR TITLE
Add mindmanager (new cask)

### DIFF
--- a/Casks/m/mindmanager.rb
+++ b/Casks/m/mindmanager.rb
@@ -1,0 +1,29 @@
+cask "mindmanager" do
+  version "25.2.105"
+  sha256 "99034e012d02e6ffd0f92a08e7b351afbe1940d9f8d6a858cec4d6f7a9568d47"
+
+  url "https://download.mindjet.com/MindManager_Mac_#{version}.dmg",
+      verified: "download.mindjet.com/"
+  name "MindManager"
+  desc "Mind mapping and visual work-management tool"
+  homepage "https://www.mindmanager.com/en/"
+
+  livecheck do
+    url "https://www.mindmanager.com/mm-mac-dmg"
+    regex(/MindManager[._-]Mac[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "MindManager.app"
+
+  uninstall quit: "com.mindjet.mindmanager.25"
+
+  zap trash: [
+    "~/Library/Application Support/Mindjet",
+    "~/Library/Caches/com.mindjet.mindmanager.25",
+    "~/Library/Preferences/com.mindjet.mindmanager.25.plist",
+  ]
+end

--- a/Casks/m/mindmanager.rb
+++ b/Casks/m/mindmanager.rb
@@ -22,7 +22,7 @@ cask "mindmanager" do
 
   zap trash: [
     "~/Library/Application Support/Mindjet",
-    "~/Library/Caches/com.mindjet.mindmanager.25",
-    "~/Library/Preferences/com.mindjet.mindmanager.25.plist",
+    "~/Library/Caches/com.mindjet.mindmanager.*",
+    "~/Library/Preferences/com.mindjet.mindmanager.*.plist",
   ]
 end

--- a/Casks/m/mindmanager.rb
+++ b/Casks/m/mindmanager.rb
@@ -10,7 +10,6 @@ cask "mindmanager" do
 
   livecheck do
     url "https://www.mindmanager.com/mm-mac-dmg"
-    regex(/MindManager[._-]Mac[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :header_match
   end
 

--- a/Casks/m/mindmanager.rb
+++ b/Casks/m/mindmanager.rb
@@ -18,7 +18,7 @@ cask "mindmanager" do
 
   app "MindManager.app"
 
-  uninstall quit: "com.mindjet.mindmanager.25"
+  uninstall quit: "com.mindjet.mindmanager.#{version.major}"
 
   zap trash: [
     "~/Library/Application Support/Mindjet",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude) helped scaffold this cask; I verified everything manually. The `url`
follows MindManager's `mm-mac-dmg` redirect to the versioned DMG on
`download.mindjet.com`; I computed the `sha256` from that file and read the bundle id
`com.mindjet.mindmanager.25` from the app's `Info.plist`. `brew audit --cask --online
--new` and `brew style` pass, and I installed then uninstalled locally. I verified the
`zap` paths (`~/Library/Application Support/Mindjet`,
`~/Library/Caches/com.mindjet.mindmanager.25`,
`~/Library/Preferences/com.mindjet.mindmanager.25.plist`) against `~/Library` after
install and confirmed removal after uninstall + zap. The bundle id carries a major-version
suffix (`.25`), so it changes each major release.


-----
