### PR TITLE
Add clickshare (new cask)

### DIFF
--- a/Casks/c/clickshare.rb
+++ b/Casks/c/clickshare.rb
@@ -1,0 +1,32 @@
+cask "clickshare" do
+  version "4.50.0,15"
+  sha256 "860f0eae27dd084bb837deb15e2ca57b2dd6d421b0269e8eaa46c35cb8fcb77e"
+
+  url "https://assets.cloud.barco.com/clickshare/release/ClickShare-#{version.csv.first}-b#{version.csv.second}_mac.zip"
+  name "ClickShare"
+  desc "Client for wireless screen sharing with Barco conferencing systems"
+  homepage "https://www.barco.com/en/product/clickshare-app"
+
+  livecheck do
+    url "https://assets.cloud.barco.com/clickshare/release/release.mac"
+    strategy :json do |json|
+      json["version"].to_s.sub(/-?b/, ",")
+    end
+  end
+
+  auto_updates true
+  depends_on :macos
+
+  app "ClickShare.app"
+
+  uninstall quit: "com.barco.clickshare.updater"
+
+  zap trash: [
+    "~/Library/Application Support/ClickShare",
+    "~/Library/Preferences/com.barco.clickshare*.plist",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end

--- a/Casks/c/clickshare.rb
+++ b/Casks/c/clickshare.rb
@@ -10,7 +10,7 @@ cask "clickshare" do
   livecheck do
     url "https://assets.cloud.barco.com/clickshare/release/release.mac"
     strategy :json do |json|
-      json["version"].tr("-b", ",")
+      json["version"].to_s.sub(/-?b/, ",")
     end
   end
 

--- a/Casks/c/clickshare.rb
+++ b/Casks/c/clickshare.rb
@@ -10,7 +10,7 @@ cask "clickshare" do
   livecheck do
     url "https://assets.cloud.barco.com/clickshare/release/release.mac"
     strategy :json do |json|
-      json["version"].to_s.sub(/-?b/, ",")
+      json["version"].tr("-b", ",")
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude) helped scaffold this cask; I verified everything manually. The `version`
and download filename come from Barco's release feed
(`assets.cloud.barco.com/clickshare/release/release.mac`); the `livecheck` reads that
feed and normalizes the `-b` build suffix, and the `url` reconstructs the filename
from the version. I computed the `sha256` from the actual zip. The shipped app is
x86_64, so a `requires_rosetta` caveat is included. `brew audit --cask --online --new`
and `brew style` pass, and I installed then uninstalled locally. I verified the `zap`
paths (`~/Library/Application Support/ClickShare`,
`~/Library/Preferences/com.barco.clickshare*.plist`) against `~/Library` after install
and confirmed removal after uninstall + zap.


-----
