### PR TITLE
paseo: fix zap bundle identifier

### DIFF
--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -21,12 +21,23 @@ cask "paseo" do
   app "Paseo.app"
   binary "#{appdir}/Paseo.app/Contents/Resources/bin/paseo"
 
+  uninstall launchctl: "sh.paseo.desktop.ShipIt",
+            quit:      "sh.paseo.desktop",
+            script:    {
+              executable: "#{appdir}/Paseo.app/Contents/Resources/bin/paseo",
+              args:       ["daemon", "stop", "--force"],
+            }
+
   zap trash: [
-    "~/Library/Application Support/dev.paseo.desktop",
-    "~/Library/Caches/dev.paseo.desktop",
-    "~/Library/Logs/dev.paseo.desktop",
-    "~/Library/Preferences/dev.paseo.desktop.plist",
-    "~/Library/Saved Application State/dev.paseo.desktop.savedState",
-    "~/Library/WebKit/dev.paseo.desktop",
+    "~/.paseo",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/sh.paseo.desktop.sfl*",
+    "~/Library/Application Support/Paseo",
+    "~/Library/Caches/@getpaseodesktop-updater",
+    "~/Library/Caches/sh.paseo.desktop",
+    "~/Library/Caches/sh.paseo.desktop.ShipIt",
+    "~/Library/HTTPStorages/sh.paseo.desktop",
+    "~/Library/Logs/Paseo",
+    "~/Library/Preferences/ByHost/sh.paseo.desktop.ShipIt.*.plist",
+    "~/Library/Preferences/sh.paseo.desktop.plist",
   ]
 end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online paseo` is error-free.
- [x] `brew style --fix paseo` reports no offenses.

Additionally, if adding a new cask:

<!-- N/A — this edits the existing `paseo` cask; no version/url/sha change. -->

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new paseo` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask paseo` worked successfully.
- [ ] `brew uninstall --cask paseo` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

**How AI was used:** Drafted with Claude Code. The model diagnosed the bug, wrote the cask change, and opened the PR. The diagnosis came from a real reproduction on macOS (Apple Silicon), not from model knowledge.

**Why this change — the bug:** The `zap` stanza targets the bundle identifier `dev.paseo.desktop`, but the app this cask installs actually uses `sh.paseo.desktop`. Confirmed on disk:

```
$ /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
    /Applications/Paseo.app/Contents/Info.plist
sh.paseo.desktop
```

Because the prefix doesn't match, `brew uninstall --zap --cask paseo` removes none of the app's support files — every path in the existing `zap` list points at a `dev.paseo.desktop.*` location the app never creates. (I'm *inferring* a `paseo.dev` → `paseo.sh` rename; the verified fact is the installed bundle id today is `sh.paseo.desktop`.)

**Manual verification of the `zap` paths:** Each path below was observed on disk on a real install (via `find ~/Library -iname '*paseo*'` and `ls ~/.paseo`) *before* removal — these are the files the current stanza fails to clean:

| Path | Note |
|------|------|
| `~/.paseo` | app data dir incl. `schedules/`, created in `$HOME` |
| `~/Library/Application Support/Paseo` | Electron `userData` (app name, not bundle id) |
| `~/Library/Logs/Paseo` | app name |
| `~/Library/Caches/@getpaseodesktop-updater` | updater cache |
| `~/Library/Caches/sh.paseo.desktop` | |
| `~/Library/Caches/sh.paseo.desktop.ShipIt` | Squirrel updater |
| `~/Library/HTTPStorages/sh.paseo.desktop` | |
| `~/Library/Preferences/sh.paseo.desktop.plist` | |
| `~/Library/Preferences/ByHost/sh.paseo.desktop.ShipIt.*.plist` | |

I dropped the original `Saved Application State` and `WebKit` entries: with the corrected prefix neither existed on the test install (an Electron app doesn't populate `~/Library/WebKit`). Happy to re-add them as `sh.paseo.desktop` if a maintainer confirms otherwise.

**`uninstall` stanza:** Added `launchctl: "sh.paseo.desktop.ShipIt"`, `quit: "sh.paseo.desktop"`, and a bundled CLI stop script that runs `paseo daemon stop --force` before zap. The stop command was verified against Paseo v0.1.89 source: the CLI exposes `daemon stop --force`, and Paseo's packaged desktop smoke test uses the bundled CLI shim for daemon stop. I have not rerun a full uninstall/zap cycle after adding the script.

**On the remaining unticked audit box:** I ran `brew audit --cask --online paseo` against a local tap of this PR branch on 2026-06-08. It failed because livecheck reports upstream `0.1.91` while this cask is still at `0.1.89`, so I am leaving the audit checkbox unticked. `brew style --fix paseo` passed locally with 1 file inspected and no offenses.
