### PR TITLE
qq 6.9.96_260528_01

### DIFF
--- a/Casks/q/qq.rb
+++ b/Casks/q/qq.rb
@@ -1,15 +1,19 @@
 cask "qq" do
-  version "6.9.95_260429_01"
-  sha256 "89ba6d483f00150d66edc2a5d32395e91043241ea7d6c15947d2c745ead0ccc7"
+  version "6.9.96_260528_01,9.9.31,045f4292"
+  sha256 "70c8163177cab4be192c1ae31a144ea4230d007b4521d9d945fca2f57b6c2232"
 
-  url "https://dldir1v6.qq.com/qqfile/qq/QQNT/Mac/QQ_#{version}.dmg"
+  url "https://qqdl.gtimg.cn/qqfile/QQNT/#{version.csv.second}/release/#{version.csv.third}/QQ_#{version.csv.first}.dmg",
+      verified: "qqdl.gtimg.cn/"
   name "QQ"
   desc "Instant messaging tool"
   homepage "https://im.qq.com/macqq/index.shtml"
 
   livecheck do
-    url "https://cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/macOSConfig.js"
-    regex(/QQ[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
+    url "https://im.qq.com/proxy/domain/cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/pcConfig.json"
+    regex(%r{/QQNT/([\d.]+)/release/(\h+)/QQ[._-](\d+(?:[._]\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[2]},#{match[0]},#{match[1]}" }
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Use Claude Code for regular expression matching.

-----

## Changes

- **Fix download URL**: Old domain `dldir1v6.qq.com` returns 404. Updated to new CDN `qqdl.gtimg.cn` with new URL path structure.
- **Update livecheck**: Switched from `macOSConfig.js` (JS wrapper) to `pcConfig.json` (pure JSON).
- **Version format**: Changed to CSV to capture dynamic URL segments (QQNT internal version + build hash).