### PR TITLE
Add easydb 2.9.0

### DIFF
--- a/Casks/e/easydb.rb
+++ b/Casks/e/easydb.rb
@@ -1,0 +1,21 @@
+cask "easydb" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "2.9.0"
+  sha256 arm:   "f1c063670734ab26c6927a6a9b32555a235a5847f9255819ac0b3e6e125fb73e",
+         intel: "c727ef35d3388bdfa3faf3fda6c46ac80f6570feabcfab852139d2bb1ee563ba"
+
+  url "https://github.com/shencangsheng/easydb_app/releases/download/v#{version}/EasyDB_#{version}_#{arch}.dmg"
+  name "EasyDB"
+  desc "Lightweight desktop data query tool that uses SQL to query local files"
+  homepage "https://github.com/shencangsheng/easydb_app"
+
+  app "EasyDB.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.easydb.app",
+    "~/Library/Caches/com.easydb.app",
+    "~/Library/Preferences/com.easydb.app.plist",
+    "~/Library/Saved Application State/com.easydb.app.savedState",
+  ]
+end


### PR DESCRIPTION
**Important**: This is a self-submission by the EasyDB author.

EasyDB is a lightweight desktop data query tool built with Rust and Tauri. It uses SQL to query local files directly with a built-in Apache DataFusion engine.

- **Homepage**: https://github.com/shencangsheng/easydb_app
- **Latest release**: https://github.com/shencangsheng/easydb_app/releases/tag/v2.9.0
- **License**: MIT
- **macOS support**: Apple Silicon and Intel DMG artifacts
- **Notability**: 618+ GitHub stars, active releases, public downloads via GitHub Releases

Local checks run before opening this PR:

- [ ] `brew audit --cask --new easydb`
- [ ] `brew audit --cask --online easydb`
- [ ] `brew style --fix Casks/e/easydb.rb`
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask easydb`
- [ ] `brew uninstall --cask easydb`

After this cask is merged, future releases are bumped automatically from the EasyDB release workflow via `brew bump-cask-pr`.

### Code signing

The current macOS release is **not code-signed or notarized**. This is documented in the project README. Users may see a Gatekeeper warning on first launch and can remove the quarantine attribute if needed: