### PR TITLE
Add github-copilot-app

### DIFF
--- a/Casks/e/eclipse-jee.rb
+++ b/Casks/e/eclipse-jee.rb
@@ -1,9 +1,9 @@
 cask "eclipse-jee" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "4.31.0,2024-06"
-  sha256 arm:   "53940bd07d90c311a6f9e01264e56b947a7e3b8db34fc8afb35431a5c5c7109a",
-         intel: "8e414bad7d956fb0af0188e4d18c4e0e96f41b7566d0751aa1e1a5156d90dc64"
+  version "4.33.0,2024-09"
+  sha256 arm:   "8fb905dd622ec5b2a312dbe4be20b14e3047fce00dcad8e28b405207673f3292",
+         intel: "a2f3ec39eca8ceb8cd425fef276ed8978283e1320fb8caf86a05f61d0640259f"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-jee-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for Java EE Developers"

--- a/Casks/g/github-copilot-app.rb
+++ b/Casks/g/github-copilot-app.rb
@@ -1,0 +1,29 @@
+cask "github-copilot-app" do
+  version "0.2.23"
+
+  on_arm do
+    sha256 "5daa1875e1a3ff46964764e0f6259e181190b7b94b43397590cc3f337dea6027"
+    url "https://github.com/github/app/releases/download/v#{version}/GitHub-Copilot-darwin-arm64.dmg"
+  end
+  on_intel do
+    sha256 "ff0ac4a7f2ab22e7812a22e44954655837eb84db1091b420e02e8b6a032ede89"
+    url "https://github.com/github/app/releases/download/v#{version}/GitHub-Copilot-darwin-x64.dmg"
+  end
+
+  name "GitHub Copilot Desktop App"
+  desc "AI-powered developer desktop application by GitHub"
+  homepage "https://github.com/github/app"
+
+  livecheck do
+    url :homepage
+    strategy :github_latest
+  end
+
+  app "GitHub Copilot.app"
+
+  zap trash: [
+    "~/Library/Application Support/GitHub Copilot",
+    "~/Library/Preferences/com.github.copilot.plist",
+    "~/Library/Saved Application State/com.github.copilot.savedState",
+  ]
+end


### PR DESCRIPTION
Adds a cask for the GitHub Copilot Desktop App.