### PR TITLE
gcloud-cli: update default python version to Python 3.14

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -21,11 +21,11 @@ cask "gcloud-cli" do
   auto_updates true
 
   on_macos do
-    depends_on formula: "python@3.13"
+    depends_on formula: "python@3.14"
   end
   on_linux do
     on_arm do
-      depends_on formula: "python@3.13"
+      depends_on formula: "python@3.14"
     end
   end
 
@@ -69,7 +69,7 @@ cask "gcloud-cli" do
     end
 
     if OS.mac?
-      ENV["CLOUDSDK_PYTHON"] = "#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python"
+      ENV["CLOUDSDK_PYTHON"] = "#{HOMEBREW_PREFIX}/opt/python@3.14/libexec/bin/python"
       # Install required external dependencies via virtualenv
       if File.exist?(File.join(Dir.home, "/.config/gcloud/virtenv"))
         puts "deleting existing virtual env before enabling virtual env with current Python version"
@@ -79,7 +79,7 @@ cask "gcloud-cli" do
       end
       system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                       args:      ["config", "virtualenv", "create", "--python-to-use",
-                                  "#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python"],
+                                  "#{HOMEBREW_PREFIX}/opt/python@3.14/libexec/bin/python"],
                       reset_uid: true
       system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                       args:      ["config", "virtualenv", "enable"],


### PR DESCRIPTION
Upgraded depends_on Python version to v3.14, aligning with gcloud's upcoming default python upgrade for macOS which will be released on Tuesday (06/09).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
