### PR TITLE
Add sast cask

### DIFF
--- a/Casks/s/sast.rb
+++ b/Casks/s/sast.rb
@@ -1,0 +1,24 @@
+cask "sast" do
+  version "1.0.0"
+  sha256 "12e36cbfad8f92db05f02e557b5cf6b8154856a1d8217c49007c407b1a69dcf9"
+
+  url "https://github.com/vulnz/sast/releases/download/engine-#{version}/sast-macos-arm64",
+      verified: "github.com/vulnz/sast/"
+  name "Insomnia SAST"
+  desc "Free, fast static application security testing for CI/CD"
+  homepage "https://insom.ai/"
+
+  depends_on arch: :arm64
+
+  binary "sast-macos-arm64", target: "sast"
+
+  caveats <<~EOS
+    sast is also available cross-platform via pip:
+      pip install sast
+
+    or as a Homebrew tap:
+      brew install vulnz/sast/sast
+
+    Learn more at https://insom.ai
+  EOS
+end


### PR DESCRIPTION
Adds a cask for **sast** (Insomnia SAST) - a free, fast static application security testing CLI for CI/CD.

- Homepage: https://insom.ai
- Binary hosted on GitHub Releases (vulnz/sast), arm64 (Apple Silicon).
- Also distributed cross-platform via `pip install sast` and the tap `brew install vulnz/sast/sast` (noted in caveats).

After making all changes to the cask:

- [x] `brew audit --cask --new sast` worked successfully.
- [x] `brew style --fix sast` reported no offenses.
- [x] The commit message includes the cask name.

Note: the binary is currently unsigned/un-notarized (notarization is planned). macOS arm64 only at this time.