### PR TITLE
dwellclick 2.3.1 (new cask)

### DIFF
--- a/Casks/d/dwellclick.rb
+++ b/Casks/d/dwellclick.rb
@@ -1,0 +1,21 @@
+cask "dwellclick" do
+  version "2.3.1"
+  sha256 "0f8423715bec34ea18d1ebbd20d1c9dbba45dbf04695c7eef62689a782078d4b"
+
+  url "https://pilotmoon.com/downloads/DwellClick-#{version}.zip"
+  name "DwellClick"
+  desc "Assistive app for clicking without physically pressing a mouse button"
+  homepage "https://pilotmoon.com/dwellclick/"
+
+  livecheck do
+    url "https://softwareupdate.pilotmoon.com/update/dwellclick/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "DwellClick.app"
+
+  zap trash: "~/Library/Preferences/com.pilotmoon.DwellClick.plist"
+end


### PR DESCRIPTION
This PR adds [DwellClick](https://pilotmoon.com/dwellclick/). 

I am the developer of DwellClick.
DwellClick is an accessibility tool for users with physical difficulty operating a mouse. 

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
