### PR TITLE
netviews 2.13 - re-enablement after cloudflare fix

### DIFF
--- a/Casks/n/netviews.rb
+++ b/Casks/n/netviews.rb
@@ -7,6 +7,11 @@ cask "netviews" do
   desc "Network and Wi-Fi diagnostic tool"
   homepage "https://www.netviews.app/"
 
+  livecheck do
+    url "https://www.netviews.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
   auto_updates true
   depends_on macos: :sonoma
 

--- a/Casks/n/netviews.rb
+++ b/Casks/n/netviews.rb
@@ -1,13 +1,11 @@
 cask "netviews" do
-  version "2.9"
-  sha256 "d1566e757f62a9fdcf2f60eb8660cfa9cd8a91a92f79e2604d8af298e371da5e"
+  version "2.13"
+  sha256 "1c47ce0e2103b9e87b58bb8763a020f23074a81d31d34bfe468c04b31ede7edd"
 
   url "https://www.netviews.app/installers/NetViews-#{version}.zip"
   name "NetViews"
   desc "Network and Wi-Fi diagnostic tool"
   homepage "https://www.netviews.app/"
-
-  disable! date: "2026-04-06", because: :unreachable
 
   auto_updates true
   depends_on macos: :sonoma


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
Updates NetViews to 2.13 and re-enables the cask.

The cask was previously disabled because the installer URL was unreachable due to Cloudflare protections blocking automated downloads.

Cloudflare has been reconfigured to allow direct access to the installer path used by Homebrew, and the download URL is now reachable again.