### PR TITLE
topoff 2.0 (new cask)

### DIFF
--- a/Casks/t/topoff.rb
+++ b/Casks/t/topoff.rb
@@ -1,0 +1,26 @@
+cask "topoff" do
+  version "2.0"
+  sha256 "387f33fc9f98528543231d9b4bf89910bfee22d92a2185bbae11ba2bbbf01c91"
+
+  url "https://github.com/ihazgithub/TopOff/releases/download/v#{version}/TopOff-v#{version}.dmg"
+  name "TopOff"
+  desc "Menu bar app that keeps Homebrew packages up to date"
+  homepage "https://github.com/ihazgithub/TopOff"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :sonoma
+
+  app "TopOff.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.topoff.TopOff",
+    "~/Library/Caches/com.topoff.TopOff",
+    "~/Library/HTTPStorages/com.topoff.TopOff",
+    "~/Library/Preferences/com.topoff.TopOff.plist",
+    "~/Library/Saved Application State/com.topoff.TopOff.savedState",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version.
- [x] `brew audit --cask --online topoff` is error-free.
- [x] `brew style --fix topoff` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new topoff` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask topoff` worked successfully.
- [x] `brew uninstall --cask topoff` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

-----

**TopOff** is an open-source SwiftUI menu-bar app that keeps macOS users' Homebrew packages up to date — background checks, one-click `brew update && brew upgrade`. Just released v2.0 (signed by `Developer ID Application: Malsah Labs LLC (GN4XAZC5QR)`, notarized, stapled; `spctl` accepts as Notarized Developer ID).

**Notability disclosure:** TopOff is at 75 stars / 0 forks / 1 watcher — it clears the third-party submission threshold but not the self-submission threshold of 225 stars. I'm submitting under self-submission rules with full transparency and would understand if the maintainers prefer to wait for organic growth. The cask file is audit-clean except for the notability flag, and TopOff's audience overlaps almost entirely with Homebrew Cask's audience (the app exists specifically to help Homebrew users). Happy to close and re-submit at 225 stars if that's the preferred path.

Thank you.
