### PR TITLE
Add ibm-notifier (new cask)

### DIFF
--- a/Casks/i/ibm-notifier.rb
+++ b/Casks/i/ibm-notifier.rb
@@ -1,0 +1,26 @@
+cask "ibm-notifier" do
+  version "3.2.3,135"
+  sha256 "2b4d13398d68a2305574567f486c34204998641206cd21ff2c2d816e346ab257"
+
+  url "https://github.com/IBM/mac-ibm-notifications/releases/download/v-#{version.csv.first}-b-#{version.csv.second}/IBM.Notifier.zip"
+  name "IBM Notifier"
+  desc "macOS agent that displays custom notifications and alerts to end users"
+  homepage "https://github.com/IBM/mac-ibm-notifications"
+
+  livecheck do
+    url :url
+    regex(/v-(\d+(?:\.\d+)+)-b-(\d+)/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  depends_on macos: :big_sur
+
+  app "IBM Notifier.app"
+
+  zap trash: "~/Library/Preferences/com.ibm.cio.notifier.plist"
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `ibm-notifier` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ibm-notifier` is error-free.
- [x] `brew style --fix ibm-notifier` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new ibm-notifier` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ibm-notifier` worked successfully.
- [x] `brew uninstall --cask ibm-notifier` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
