### PR TITLE
Add groove-omnidialer (new cask)

### DIFF
--- a/Casks/g/groove-omnidialer.rb
+++ b/Casks/g/groove-omnidialer.rb
@@ -1,0 +1,30 @@
+cask "groove-omnidialer" do
+  version "26.603.1017"
+  sha256 "5f15c447daa74986b0a31140fa5bce7a5c694f596390ad6dcdb209b3b1550c09"
+
+  url "https://groove-dialer.s3-us-west-2.amazonaws.com/electron/Groove%20OmniDialer-#{version}-universal.dmg",
+      verified: "groove-dialer.s3-us-west-2.amazonaws.com/electron/"
+  name "Groove OmniDialer"
+  desc "Outbound sales dialer for making and managing calls"
+  homepage "https://www.groove.co/"
+
+  livecheck do
+    url "https://groove-dialer.s3.us-west-2.amazonaws.com/electron/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: :catalina
+
+  app "Groove OmniDialer.app"
+
+  uninstall quit: "com.electron.dialer"
+
+  zap trash: [
+    "~/Library/Application Support/com.electron.dialer",
+    "~/Library/Caches/com.electron.dialer",
+    "~/Library/HTTPStorages/com.electron.dialer",
+    "~/Library/Preferences/com.electron.dialer.plist",
+    "~/Library/Saved Application State/com.electron.dialer.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `groove-omnidialer` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online groove-omnidialer` is error-free.
- [x] `brew style --fix groove-omnidialer` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new groove-omnidialer` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask groove-omnidialer` worked successfully.
- [x] `brew uninstall --cask groove-omnidialer` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, and minimum macOS, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
