### PR TITLE
Add sast cask

### DIFF
--- a/Casks/s/sast.rb
+++ b/Casks/s/sast.rb
@@ -1,0 +1,29 @@
+cask "sast" do
+  version "1.0.0"
+  sha256 "2e3cc8f0f73ee0b06e0a970295cc0a73dd3c987e6230248717d820c18d537096"
+
+  url "https://github.com/vulnz/sast/releases/download/engine-#{version}/sast-macos-arm64",
+      verified: "github.com/vulnz/sast/"
+  name "Insomnia SAST"
+  desc "Free, fast static application security testing for CI/CD"
+  homepage "https://insom.ai/"
+
+  depends_on arch: :arm64
+
+  binary "sast-macos-arm64", target: "sast"
+
+  zap trash: [
+    "~/Library/Application Support/sast",
+    "~/Library/Caches/sast",
+  ]
+
+  caveats <<~EOS
+    sast is also available cross-platform via pip:
+      pip install sast
+
+    or as a Homebrew tap:
+      brew install vulnz/sast/sast
+
+    Learn more at https://insom.ai
+  EOS
+end


### PR DESCRIPTION
Adds a cask for **sast** (Insomnia SAST) - free static application security testing for CI/CD.

The macOS binary is now **signed with a Developer ID Application certificate and notarized by Apple** (notarytool status: Accepted), and a `zap` stanza has been added.

- Homepage: https://insom.ai
- arm64 (Apple Silicon), hosted on GitHub Releases (vulnz/sast).
- Also distributed via `pip install sast` and tap `brew install vulnz/sast/sast` (noted in caveats).

After making all changes to the cask:

- [x] `brew audit --cask --new sast` worked successfully.
- [x] `brew style --fix sast` reported no offenses.
- [x] The commit message includes the cask name.