### PR TITLE
Add MacParakeet

### DIFF
--- a/Casks/m/macparakeet.rb
+++ b/Casks/m/macparakeet.rb
@@ -1,0 +1,30 @@
+cask "macparakeet" do
+  version "0.6.18"
+  sha256 "0bbc4dfc130c4f250105e0a0144eb623b9c6488294fc8c39b8ddff9b023da6b7"
+
+  url "https://github.com/moona3k/macparakeet/releases/download/v#{version}/MacParakeet-#{version}.dmg",
+      verified: "github.com/moona3k/macparakeet/"
+  name "MacParakeet"
+  desc "Local speech-to-text, transcription, and meeting recording"
+  homepage "https://macparakeet.com/"
+
+  livecheck do
+    url "https://macparakeet.com/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "MacParakeet.app"
+
+  zap trash: [
+    "~/Library/Application Support/MacParakeet",
+    "~/Library/Caches/com.macparakeet.MacParakeet",
+    "~/Library/HTTPStorages/com.macparakeet.MacParakeet",
+    "~/Library/Logs/MacParakeet",
+    "~/Library/Preferences/com.macparakeet.MacParakeet.plist",
+    "~/Library/Saved Application State/com.macparakeet.MacParakeet.savedState",
+  ]
+end


### PR DESCRIPTION
New cask for **MacParakeet** -- local-first speech-to-text, transcription, and meeting recording for macOS.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `macparakeet` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online macparakeet` is error-free.
- [x] `brew style --fix macparakeet` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+macparakeet&type=pullrequests).
- [x] `brew audit --cask --new macparakeet` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask macparakeet` worked successfully.
- [x] `brew uninstall --cask macparakeet` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with drafting the initial cask and first PR description. I manually verified the Homebrew checks, install/uninstall behavior, release metadata, app bundle metadata, and `zap` stanza paths.

Manual verification:

- Ran style, audit, install, and uninstall against the exact PR cask via a temporary local tap; all passed.
- Verified the 0.6.18 release asset SHA-256, Sparkle short version, `CFBundleIdentifier`, `CFBundleShortVersionString`, and `LSMinimumSystemVersion`.
- Verified `--zap` in an isolated temporary home after confirming both Foundation and Homebrew/Ruby resolved `~` inside that temporary home.
- In that sandbox, launching `MacParakeet.app` created `Application Support`, `Caches`, `HTTPStorages`, and `Logs` paths matching the `zap` stanza.
- `brew uninstall --zap` removed the created sandbox paths and left no `MacParakeet`/`macparakeet` files under the sandbox `~/Library` scan.
- `~/Library/Preferences/com.macparakeet.MacParakeet.plist` exists on my normal MacParakeet 0.6.18 installation, but was not created during the short sandbox launch.
- `~/Library/Saved Application State/com.macparakeet.MacParakeet.savedState` was not present during verification; it is derived from the verified bundle identifier and macOS's standard saved-state location.
- I did not run `brew uninstall --zap` against my real user profile because `~/Library/Application Support/MacParakeet` contains real user data.
