### PR TITLE
rode-virtual-channels 1.1.1

### DIFF
--- a/Casks/r/rode-virtual-channels.rb
+++ b/Casks/r/rode-virtual-channels.rb
@@ -13,10 +13,10 @@ cask "rode-virtual-channels" do
   end
 
   depends_on :macos
+
   rename "RODE Virtual Channels-*.pkg", "RODE Virtual Channels.pkg"
 
-  app "Rode Virtual Channels.pkg"
-  pkg "RODE Virtual Channels-#{version}.pkg"
+  pkg "Rode Virtual Channels.pkg"
 
   uninstall quit:    "com.rode.RODEVirtualChannels",
             pkgutil: [

--- a/Casks/r/rode-virtual-channels.rb
+++ b/Casks/r/rode-virtual-channels.rb
@@ -13,7 +13,9 @@ cask "rode-virtual-channels" do
   end
 
   depends_on :macos
+  rename "RODE Virtual Channels-*.pkg", "RODE Virtual Channels.pkg"
 
+  app "Rode Virtual Channels.pkg"
   pkg "RODE Virtual Channels-#{version}.pkg"
 
   uninstall quit:    "com.rode.RODEVirtualChannels",

--- a/Casks/r/rode-virtual-channels.rb
+++ b/Casks/r/rode-virtual-channels.rb
@@ -20,6 +20,7 @@ cask "rode-virtual-channels" do
             pkgutil: [
               "com.rode.pkg.RODEVirtualChannels",
               "com.rode.pkg.RODEVirtualChannelsApp",
+              "com.rode.pkg.RODEVirtualChannelsDriver",
               "com.rode.pkg.RODEVirtualChannelsLaunchAgent",
               "com.rode.RodeVirtualChannels.driver",
             ]

--- a/Casks/r/rode-virtual-channels.rb
+++ b/Casks/r/rode-virtual-channels.rb
@@ -1,15 +1,15 @@
 cask "rode-virtual-channels" do
-  version "1.0.0"
-  sha256 "00c0b5a2f5f24eb80d4bb0d2e8b5ce2e409fc95ef37099ad7e3f629a4bfd72fe"
+  version "1.1.1"
+  sha256 :no_check
 
-  url "https://update.rode.com/virtual_dev_driver/RODECASTERDriver_MACOS_#{version}.zip"
+  url "https://update.rode.com/virtual_dev_driver/RODECasterDriver_MACOS.zip"
   name "RODE Virtual Channels"
   desc "Virtual Device Driver for RODECASTER Pro II"
   homepage "https://rode.com/en/user-guides/rodecaster-pro-ii/virtual-devices"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?RODECASTERDriver[._-]MACOS[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    url :url
+    strategy :extract_plist
   end
 
   depends_on :macos


### PR DESCRIPTION
RODE collapsed their per-version download URLs into a single rolling "latest" URL, which broke both the `#{version}` URL template and the livecheck regex — the old versioned `RODECASTERDriver_MACOS_<version>.zip` links no longer exist (404) and no longer appear on the page, so the cask was stranded at 1.0.0.

This bumps to 1.1.1 and adapts the cask to the new scheme:

- `url` → static `RODECasterDriver_MACOS.zip` (the only file RODE now publishes; it contains `RODE Virtual Channels-1.1.1.pkg`)
- `sha256 :no_check` (required for unversioned URLs)
- `livecheck` → `:extract_plist` (the version is now only available inside the artifact)

Verified locally:
- `brew livecheck --autobump --extract-plist rode-virtual-channels` → `1.1.1 ==> 1.1.1`
- `brew style rode-virtual-channels` → no offenses
- `brew audit --cask --online --strict rode-virtual-channels` → clean

I've also messaged them on discord/email for why there is no changelog and versioned url.