### PR TITLE
font-ibm-plex-mono: update livecheck

### DIFF
--- a/Casks/font/font-i/font-ibm-plex-mono.rb
+++ b/Casks/font/font-i/font-ibm-plex-mono.rb
@@ -6,9 +6,15 @@ cask "font-ibm-plex-mono" do
   name "IBM Plex Mono"
   homepage "https://github.com/IBM/plex"
 
+  # There can be a notable gap between when a version is tagged and a
+  # corresponding release is created, so we check releases instead of the Git
+  # tags. Upstream maintains multiple fonts in this repository and the "latest"
+  # release may be for another font, so we have to check multiple releases to
+  # identify the correct version.
   livecheck do
     url :url
     regex(%r{^@ibm/plex-mono@?(\d+(?:\.\d+)+)$}i)
+    strategy :github_releases
   end
 
   font "ibm-plex-mono/fonts/complete/otf/IBMPlexMono-Bold.otf"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

livecheck checks the Git tags for `font-ibm-plex-mono` and it returns 2.5.0 as newest but there hasn't been a GitHub release for this version after almost two weeks. This updates the `livecheck` block to use the `GithubReleases` strategy. There are many releases for other fonts in this repository, so the latest plex-mono release can theoretically be pushed out of the first page of AI results but this works for now.