### PR TITLE
k8studio 3.1.5

### DIFF
--- a/Casks/k/k8studio.rb
+++ b/Casks/k/k8studio.rb
@@ -1,12 +1,11 @@
 cask "k8studio" do
   arch arm: "-arm64"
 
-  version "3.1.4"
-  sha256 arm:   "45356d4096d7b625137f8ab621aa04de8432464e23d04ce7fa04fb5ff66b86b8",
-         intel: "3db8e7e1b95f27d9c478c65fe79a42a30aa6d0083cc9123191a8f6b419ff09ad"
+  version "3.1.5"
+  sha256 arm:   "b7de17764be599222d7170d818e6967e62167fe116b3d0ee8b5a055091574aaa",
+         intel: "4a7e4f7f370db97e013b4073e44688e1fc5a01c37b855c86ef836cca1fc23a2e"
 
-  url "https://github.com/k8Studio/k8Studio/releases/download/v#{version}/K8Studio-#{version}#{arch}.dmg",
-      verified: "github.com/k8Studio/k8Studio/"
+  url "https://releases.k8studio.io/K8Studio-#{version}#{arch}.dmg"
   name "K8studio"
   desc "Kubernetes GUI"
   homepage "https://k8studio.io/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`k8studio` is autobumped but the workflow failed to update to version 3.1.5 because upstream is serving the assets from releases.k8studio.io and there isn't a corresponding 3.1.5 release (or tag) on GitHub. This updates the version and adjusts the `url` accordingly.