### PR TITLE
oscar 2.0.0

### DIFF
--- a/Casks/o/oscar.rb
+++ b/Casks/o/oscar.rb
@@ -1,15 +1,11 @@
 cask "oscar" do
-  arch arm: "AppleSilicon", intel: "Intel"
+  arch arm: "ARM", intel: "Intel"
 
-  version "1.7.1"
-  sha256 arm:   "f4ff813ccfca6eafe7b3102df84344b4197c84f56e6c81f9f39ea937fea2c5fe",
-         intel: "fa6171ddbef287490469abcdd9793e4303fb116af7c125c487ec571ff787db7d"
+  version "2.0.0"
+  sha256 arm:   "26ce5039ee73a10364a09d92ccfbc24720d75ffb57e40ea829129e5817638813",
+         intel: "0a08b55ca66c272b127d9dd1399fd3a18b61abae5d876554d3ee0632f5614e34"
 
-  on_intel do
-    disable! date: "2026-09-01", because: :fails_gatekeeper_check
-  end
-
-  url "https://www.sleepfiles.com/OSCAR/#{version}/OSCAR-#{version}-#{arch}.dmg"
+  url "https://www.sleepfiles.com/OSCAR/#{version.major_minor}/OSCAR-#{version}-#{arch}.dmg"
   name "OSCAR"
   desc "CPAP Analysis Reporter"
   homepage "https://www.sleepfiles.com/OSCAR/"
@@ -19,9 +15,11 @@ cask "oscar" do
     regex(%r{href=.*?/OSCAR[._-]v?(\d+(?:\.\d+)+)(?:[._-]#{arch})?\.dmg}i)
   end
 
-  depends_on :macos
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  app "OSCAR.app"
+  depends_on macos: :ventura
+
+  app "OSCAR#{version.major_minor.no_dots}.app"
 
   zap trash: [
     "~/Library/Preferences/org.oscar-team.OSCAR.plist",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`oscar` is autobumped but the workflow failed to update to version 2.0.0 because the asset URL path changed and the ARM suffix in the file name is different. This updates the version and adjusts the cask accordingly. It remains to be seen whether the `version.major_minor` parts will remain the same with the next version but we can address that when we come to it.

For what it's worth, the app for both archs now fail the Gatekeeper check, as the Intel app is unsigned and the ARM app isn't notarized.