### PR TITLE
start 0.301.23903

### DIFF
--- a/Casks/s/start.rb
+++ b/Casks/s/start.rb
@@ -1,10 +1,10 @@
 cask "start" do
   livecheck_arch = on_arch_conditional arm: "-arm"
 
-  version "0.301.22466"
-  sha256 "7291a3521720cfade333b4f728f8d6b024e990fe404216c46bba01888a26d519"
+  version "0.301.23903,10000000"
+  sha256 "df97ccd749000955f70288d3f00cce0196db4375c69203c539e1ff0a677b469e"
 
-  url "https://imgcdn.start.qq.com/cdn/mac.client/installer/START-Installer-universal-#{version}.dmg"
+  url "https://imgcdn.start.qq.com/cdn/mac.client/installer/#{version.csv.first}/START-Installer-universal-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}.dmg"
   name "START"
   name "腾讯云游戏"
   desc "Tencent cloud gaming platform"
@@ -17,7 +17,7 @@ cask "start" do
       match = json.dig("configs", "macos-update-info#{livecheck_arch}", "value")&.match(regex)
       next if match.blank?
 
-      match[1]
+      match[1].tr("-", ",")
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`start` is autobumped but the workflow failed to update to version 0.301.23903 because the file name also includes a `-10000000` suffix after the version. This updates the version and adjusts the cask to be able to handle this setup, while also still handling versions without a suffix like this.