### PR TITLE
Add shade 2.3.16

### DIFF
--- a/Casks/s/shade.rb
+++ b/Casks/s/shade.rb
@@ -1,0 +1,37 @@
+cask "shade" do
+  arch arm: "-arm64"
+
+  version "2.3.16"
+  sha256 arm:   "a35c41477a4b4fd52e743201446472e240d672d9c60babad7edc222a1609d2f1",
+         intel: "e9f3a56788304128c31c6176d7f06ada427170d6f9c52b60d20307113dba6379"
+
+  url "https://storage.googleapis.com/v2-public.shade.inc/releases/stable/mac/Shade-#{version}#{arch}.pkg",
+      verified: "storage.googleapis.com/v2-public.shade.inc/"
+  name "Shade"
+  desc "AI-powered media storage and asset management platform"
+  homepage "https://shade.inc/"
+
+  livecheck do
+    url "https://storage.googleapis.com/v2-public.shade.inc/releases/stable/mac/fuse-t-latest-arm64-mac.yml"
+    regex(/version:\s*"?v?(\d+(?:\.\d+)+)"?/i)
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  pkg "Shade-#{version}#{arch}.pkg"
+
+  uninstall launchctl: "inc.shade.xpc",
+            pkgutil:   "com.shade.shade",
+            delete:    [
+              "/Library/Application Support/Shade/ShadeFS XPC Service.xpc",
+              "/Library/LaunchAgents/inc.shade.xpc.plist",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/Shade",
+    "~/Library/Logs/Shade",
+    "~/Library/Preferences/com.shade.shade.plist",
+    "~/Library/Saved Application State/com.shade.shade.savedState",
+  ]
+end


### PR DESCRIPTION
Adds a cask for Shade, an AI-powered media storage and asset management platform.

Validation:
- `brew style --fix Casks/s/shade.rb`
- `brew audit --new --cask shade`
- `brew audit --new --cask --arch=all --except=token_conflicts shade`
- `brew livecheck --cask shade`
- `brew fetch --cask shade --force`

Notes:
- Package artifacts are signed with a Developer ID Installer certificate and notarized.
- A full `--arch=all` audit without exclusions reached the same artifact checks but was stopped while cloning `homebrew/core` for the token-conflict check; local `brew search shade` did not show an existing `shade` token.
