### PR TITLE
server-box: fix download URL

### DIFF
--- a/Casks/s/server-box.rb
+++ b/Casks/s/server-box.rb
@@ -2,7 +2,7 @@ cask "server-box" do
   version "1.0.1426"
   sha256 "f8f997158e0631e72c7dab6b0493d365bf227a7fcedd3c51fd83db588eb691c2"
 
-  url "https://github.com/lollipopkit/flutter_server_box/releases/download/v#{version}/ServerBox-#{version}.dmg"
+  url "https://github.com/lollipopkit/flutter_server_box/releases/download/v#{version}/ServerBox-v#{version}.dmg"
   name "ServerBox"
   desc "App for monitoring server status with SSH terminal, SFTP, Container management"
   homepage "https://github.com/lollipopkit/flutter_server_box"


### PR DESCRIPTION
The cask currently points to:
https://github.com/lollipopkit/flutter_server_box/releases/download/v1.0.1426/ServerBox-1.0.1426.dmg
which returns HTTP 404.
```
brew install --cask server-box
✔︎ JSON API packages.arm64_tahoe.jws.json                                                                          Downloaded   15.1MB/ 15.1MB
==> Fetching downloads for: server-box
✘ Cask server-box (1.0.1426)
Error: Download failed on Cask 'server-box' with message: Download failed: https://github.com/lollipopkit/flutter_server_box/releases/download/v1.0.1426/ServerBox-1.0.1426.dmg
curl: (56) The requested URL returned error: 404
```

The actual release asset is:
https://github.com/lollipopkit/flutter_server_box/releases/download/v1.0.1426/ServerBox-v1.0.1426.dmg

This PR updates the URL template accordingly.

Verification:

- `brew style –fix Casks/s/server-box.rb` passed with no offenses.
- The corrected URL was manually verified and returns a valid GitHub release asset (HTTP 302 redirect).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
