### PR TITLE
qq 6.9.96_260528_01

### DIFF
--- a/Casks/q/qq.rb
+++ b/Casks/q/qq.rb
@@ -1,8 +1,8 @@
 cask "qq" do
-  version "6.9.95_260429_01"
-  sha256 "89ba6d483f00150d66edc2a5d32395e91043241ea7d6c15947d2c745ead0ccc7"
+  version "6.9.96_260528_01"
+  sha256 "70c8163177cab4be192c1ae31a144ea4230d007b4521d9d945fca2f57b6c2232"
 
-  url "https://dldir1v6.qq.com/qqfile/qq/QQNT/Mac/QQ_#{version}.dmg"
+  url "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.31/release/045f4292/QQ_6.9.96_260528_01.dmg"
   name "QQ"
   desc "Instant messaging tool"
   homepage "https://im.qq.com/macqq/index.shtml"


### PR DESCRIPTION
Update QQ from 6.9.95 to 6.9.96.

- Old download URL (dldir1v6.qq.com) returns 404
- New URL from qqdl.gtimg.cn, version verified via livecheck
- SHA256 verified against downloaded DMG