### PR TITLE
kid3 3.10.0 - fix checksums

### DIFF
--- a/Casks/k/kid3.rb
+++ b/Casks/k/kid3.rb
@@ -3,8 +3,8 @@ cask "kid3" do
 
   # NOTE: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
   version "3.10.0"
-  sha256 arm:   "2992dc81b20eb9097f6b73411f74d09d23fb8374774c5f97609c74b5a1610473",
-         intel: "7508aece4fc0553b13ee63e646375d6b9f45a10296463c2772470d183bab101d"
+  sha256 arm:   "d18a73808cff3b3155b5b87f44a6a790a52f1d546741440e9ae7e0cccbec67c5",
+         intel: "b344286e84143e6613e9f433f1e887c24e33c2320a0c597342ec1cbd35eb8e68"
 
   url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin-#{arch}.dmg",
       verified: "downloads.sourceforge.net/kid3/"


### PR DESCRIPTION
kid3 was updated yesterday in #268204, but the checksums were set incorrectly. The checksums for both the Arm and Intel builds as downloaded directly from kid3's SourceForge page are:

```
b344286e84143e6613e9f433f1e887c24e33c2320a0c597342ec1cbd35eb8e68  kid3-3.10.0-Darwin-amd64.dmg
d18a73808cff3b3155b5b87f44a6a790a52f1d546741440e9ae7e0cccbec67c5  kid3-3.10.0-Darwin-arm64.dmg
```

These differ from the values set in the current cask definition file:

```ruby
  sha256 arm:   "2992dc81b20eb9097f6b73411f74d09d23fb8374774c5f97609c74b5a1610473",
         intel: "7508aece4fc0553b13ee63e646375d6b9f45a10296463c2772470d183bab101d"
```

Trying to install kid3 using the current cask definition results in an error:

```
✘ Cask kid3 (3.10.0)                                 Verifying    32.6MB/ 32.6MB
Error: Cask reports different checksum:     2992dc81b20eb9097f6b73411f74d09d23fb8374774c5f97609c74b5a1610473
       SHA-256 checksum of downloaded file: d18a73808cff3b3155b5b87f44a6a790a52f1d546741440e9ae7e0cccbec67c5
```

Installing kid3 with the updated definition succeeds:

```
==> Fetching downloads for: mase3206/cask/kid3
✔︎ Cask kid3 (3.10.0)                                                                                                                        Verified     32.6MB/ 32.6MB
==> Installing Cask kid3
==> Moving App 'kid3.app' to '/Applications/kid3.app'
==> Linking Binary 'kid3-cli' to '/opt/homebrew/bin/kid3-cli'
🍺  kid3 was successfully installed!
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
