### PR TITLE
feat: add mole-widget

### DIFF
--- a/Casks/m/mole-widget.rb
+++ b/Casks/m/mole-widget.rb
@@ -1,0 +1,18 @@
+cask "mole-widget" do
+  version "0.5.3"
+  sha256 "8caffcab508ff2948345a3f610578b8cae2e7c2eac619dc56ac1d63bd8fd9080"
+
+  url "https://github.com/bsnkhua/mole-widget/releases/download/v#{version}/MoleWidget.dmg"
+  name "Mole Widget"
+  desc "Lightweight macOS desktop system monitor widget"
+  homepage "https://github.com/bsnkhua/mole-widget"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Mole Widget.app"
+
+  zap trash: "~/Library/Preferences/com.sbezbabnykh.mole-widget.plist"
+end


### PR DESCRIPTION
## Cask info

| Field | Value |
|-------|-------|
| Name | Mole Widget |
| Homepage | https://github.com/bsnkhua/mole-widget |
| Version | 0.5.3 |
| License | MIT |

## Description

Mole Widget is a lightweight macOS desktop system monitor widget showing live CPU, memory, disk, network, battery and process metrics. It is a native Swift + SwiftUI borderless window that lives at desktop level, above the wallpaper and below application windows.

## Checklist

- [x] The app is signed with a Developer ID certificate
- [x] The app is notarized by Apple
- [x] Stable version tagged on GitHub
- [x] Open-source (MIT license)
- [x] Homepage accessible
- [x] `livecheck` configured for automatic version detection