### PR TITLE
mole-widget 0.5.4 (new cask)

### DIFF
--- a/Casks/m/mole-widget.rb
+++ b/Casks/m/mole-widget.rb
@@ -1,0 +1,20 @@
+cask "mole-widget" do
+  version "0.5.4"
+  sha256 "07062aca8399f7586df2c6f6707cdffdac93bfef9b2319da9659f87bda66f80a"
+
+  url "https://github.com/bsnkhua/mole-widget/releases/download/v#{version}/MoleWidget.dmg"
+  name "Mole Widget"
+  desc "Lightweight macOS desktop system monitor widget"
+  homepage "https://github.com/bsnkhua/mole-widget"
+
+  livecheck do
+    url "https://github.com/bsnkhua/mole-widget"
+    strategy :github_latest
+  end
+
+  depends_on macos: :sonoma
+
+  app "Mole Widget.app"
+
+  zap trash: "~/Library/Preferences/com.sbezbabnykh.mole-widget.plist"
+end


### PR DESCRIPTION
Built and tested locally on macOS 15 (Sequoia).

Signed and notarized DMG via Developer ID Application certificate. The binary embeds `minos 14.0` (from `Package.swift platforms: [.macOS(.v14)]`), matching the `depends_on macos: :sonoma` stanza.

- [x] Submission is for a stable version
- [x] `brew style` reports no offenses
- [x] Named according to token reference
- [x] Not previously refused

AI-assisted PR: cask file was generated with Claude Code; zap stanza path verified against `com.sbezbabnykh.mole-widget` bundle ID in `Info.plist`.