### PR TITLE
vifty 1.0.0 (new cask)

### DIFF
--- a/Casks/v/vifty.rb
+++ b/Casks/v/vifty.rb
@@ -1,0 +1,17 @@
+cask "vifty" do
+  version "1.0.0"
+  sha256 "5b3d6c67acfb7833e71edeb250d238b7c8c362285189e118278fc5bd350cd884"
+
+  url "https://github.com/Reedtrullz/Vifty/releases/download/v#{version}/Vifty-v#{version}.zip"
+  name "Vifty"
+  desc "Menu-bar fan control and power monitor for MacBook Pro"
+  homepage "https://github.com/Reedtrullz/Vifty"
+
+  depends_on macos: :sequoia
+
+  signing_identity identity: "-"
+
+  app "Vifty.app"
+
+  zap trash: "~/Library/Application Support/Vifty"
+end


### PR DESCRIPTION
## Description

New cask for **Vifty**, a native macOS menu-bar utility for MacBook Pro that combines fan control, thermal telemetry, and charger/battery power monitoring with a safety-bounded agent CLI.

- **Homepage**: https://github.com/Reedtrullz/Vifty
- **Version**: 1.0.0
- **License**: MIT
- **Stars**: 56 · **Forks**: 18

## Features
- Three fan modes: Auto, Fixed RPM, Temperature Curve with saveable profiles
- Live power tracking: adapter wattage, USB-C PD profiles, battery health
- `viftyctl` agent CLI with bounded workload cooling leases
- Privileged XPC helper (LaunchDaemon) for fail-closed SMC fan writes
- 127 XCTest cases, CI, and local-only privacy (no analytics, no cloud)

## Fixes from initial CI
- Added `signing_identity identity: "-"` for ad-hoc code signature
- Fixed `desc` to not mention platform (lint rule)
- Fixed `depends_on macos:` to use `:sequoia` (not `>= :sequoia`)
- Fixed `zap trash:` single-element array → string

## Checklist
- [x] Cask follows [CONTRIBUTING.md](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md) conventions
- [x] App is signed with ad-hoc signature
- [x] App is open-source and MIT licensed
- [x] Cask has correct `name`, `desc`, `homepage`, and `zap`