### PR TITLE
officecli 1.0.106 (new cask)

### DIFF
--- a/Casks/o/officecli.rb
+++ b/Casks/o/officecli.rb
@@ -1,0 +1,20 @@
+cask "officecli" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.0.106"
+  sha256 arm:   "2df4e0ee7ebe3e23cafc830f68f6e65d5b51936c04c31c56628cb684e74e94fd",
+         intel: "347904b118dfa05c6f495d16367d4d73ef902975a667e7bd01d945b10b28d5c2"
+
+  url "https://github.com/iOfficeAI/OfficeCLI/releases/download/v#{version}/officecli-mac-#{arch}",
+      verified: "github.com/iOfficeAI/OfficeCLI/"
+  name "OfficeCLI"
+  desc "CLI tool for AI agents to read, edit, and automate Office documents"
+  homepage "https://www.officecli.ai/"
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  binary "officecli-mac-#{arch}", target: "officecli"
+
+  zap trash: "~/.officecli"
+end


### PR DESCRIPTION
New cask for OfficeCLI — a CLI tool for AI agents to read, edit, and automate Office documents (.docx, .xlsx, .pptx).

The macOS binaries are Developer ID signed and notarized by Apple. This is a macOS-only cask (`depends_on macos:`), which resolves the cross-platform `readall` failure on the earlier #268407.

- [x] `brew audit --cask --new Casks/o/officecli.rb` is error-free.
- [x] `brew style --fix Casks/o/officecli.rb` reports no offenses.
- [x] The commit message includes the cask's name and version.