### PR TITLE
officecli 1.0.106 (new cask)

### DIFF
--- a/Casks/o/officecli.rb
+++ b/Casks/o/officecli.rb
@@ -1,0 +1,20 @@
+cask "officecli" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.0.106"
+  sha256 arm:   "2df4e0ee7ebe3e23cafc830f68f6e65d5b51936c04c31c56628cb684e74e94fd",
+         intel: "347904b118dfa05c6f495d16367d4d73ef902975a667e7bd01d945b10b28d5c2"
+
+  url "https://github.com/iOfficeAI/OfficeCLI/releases/download/v#{version}/officecli-mac-#{arch}",
+      verified: "github.com/iOfficeAI/OfficeCLI/"
+  name "OfficeCLI"
+  desc "CLI tool for AI agents to read, edit, and automate Office documents"
+  homepage "https://www.officecli.ai/"
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  binary "officecli-mac-#{arch}", target: "officecli"
+
+  zap trash: "~/.officecli"
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online officecli` is error-free.
- [x] `brew style --fix officecli` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+officecli&type=pullrequests).
- [x] `brew audit --cask --new officecli` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask officecli` worked successfully.
- [x] `brew uninstall --cask officecli` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

An AI assistant helped draft this PR. Each command above was run and its output verified: `brew audit --cask --new`/`--online`, `brew style`, and `brew install`/`uninstall` all succeed. The `zap` path `~/.officecli` was manually confirmed against the app's config directory. The macOS binaries are Developer ID signed and notarized; `depends_on macos:` marks this as a macOS-only cask.