### PR TITLE
ubports-installer: fix macOS download

### DIFF
--- a/Casks/u/ubports-installer.rb
+++ b/Casks/u/ubports-installer.rb
@@ -18,7 +18,7 @@ cask "ubports-installer" do
 
   livecheck do
     url :url
-    regex(/^ubports-installer_(\d+(?:\.\d+)+)_mac_#{arch}\.dmg$/i)
+    regex(/^ubports-installer[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg$/i)
     strategy :github_releases do |json, regex|
       json.map do |release|
         next if release["draft"] || release["prerelease"]

--- a/Casks/u/ubports-installer.rb
+++ b/Casks/u/ubports-installer.rb
@@ -1,21 +1,30 @@
 cask "ubports-installer" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.11.2"
-  sha256 arm:   "21f40396f8f8d1b0da9b3b7b029cd6d15988603c64cdfceb5d9ba1eb4232cd3c",
-         intel: "cd5532fff5c2a35e04f55b6b0ad03918404bfbaa1065e54a87cf9fb69609807b"
+  on_arm do
+    version "0.11.1"
+    sha256 "18f9bdfe73a56f37cd90a43c0978ab98840ae0f2e5f27d8bbaa396d037fc63fe"
+
+    livecheck do
+      skip "No Apple Silicon release available after 0.11.1"
+    end
+  end
+  on_intel do
+    version "0.11.2"
+    sha256 "cd5532fff5c2a35e04f55b6b0ad03918404bfbaa1065e54a87cf9fb69609807b"
+
+    livecheck do
+      url :url
+      regex(/v?(\d+(?:\.\d+)+(?:-beta)?)/i)
+      strategy :github_latest
+    end
+  end
 
   url "https://github.com/ubports/ubports-installer/releases/download/#{version}/ubports-installer_#{version}_mac_#{arch}.dmg",
       verified: "github.com/ubports/ubports-installer/"
   name "ubports installer"
   desc "Application to install ubports on mobile devices"
   homepage "https://ubports.com/"
-
-  livecheck do
-    url :url
-    regex(/v?(\d+(?:\.\d+)+(?:-beta)?)/i)
-    strategy :github_latest
-  end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 

--- a/Casks/u/ubports-installer.rb
+++ b/Casks/u/ubports-installer.rb
@@ -4,20 +4,10 @@ cask "ubports-installer" do
   on_arm do
     version "0.11.1"
     sha256 "18f9bdfe73a56f37cd90a43c0978ab98840ae0f2e5f27d8bbaa396d037fc63fe"
-
-    livecheck do
-      skip "No Apple Silicon release available after 0.11.1"
-    end
   end
   on_intel do
     version "0.11.2"
     sha256 "cd5532fff5c2a35e04f55b6b0ad03918404bfbaa1065e54a87cf9fb69609807b"
-
-    livecheck do
-      url :url
-      regex(/v?(\d+(?:\.\d+)+(?:-beta)?)/i)
-      strategy :github_latest
-    end
   end
 
   url "https://github.com/ubports/ubports-installer/releases/download/#{version}/ubports-installer_#{version}_mac_#{arch}.dmg",
@@ -25,6 +15,23 @@ cask "ubports-installer" do
   name "ubports installer"
   desc "Application to install ubports on mobile devices"
   homepage "https://ubports.com/"
+
+  livecheck do
+    url :url
+    regex(/^ubports-installer_(\d+(?:\.\d+)+)_mac_#{arch}\.dmg$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ubports-installer` is error-free.
- [x] `brew style --fix ubports-installer` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Installing `ubports-installer` currently fails on Apple Silicon because the latest upstream release only provides a macOS x64 DMG. The current arm64 URL returns 404.

This removes the arm64 URL variant and marks the app as requiring Rosetta.