### PR TITLE
codex: use package release asset

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -3,12 +3,12 @@ cask "codex" do
   os macos: "apple-darwin", linux: "unknown-linux-musl"
 
   version "0.139.0"
-  sha256 arm:          "c28344255844d83a728c084c2d9e21e168b5d217f6049d3a9a36827903f16fdb",
-         intel:        "c8b52d7588977f6cd055112faa0f3e6b9ec764473bc1be8efa44f3c8f68d14bf",
-         arm64_linux:  "2b7407643e0e74c525d84347c9eecec4b3d275af0382142ac42216508bb0b2a2",
-         x86_64_linux: "12ebf70df41dc831061862912ab5e7eacdd112bb17e8ce9b2098cb3d92180081"
+  sha256 arm:          "4cda925741331880fd18acfe0a40c63fbb08e7824c0b277c9b986b3fcf0438a2",
+         intel:        "d866899e8967d08dff778d15ec687825410325c1191fed0eaab448b3d807546d",
+         arm64_linux:  "d5fc41a310b1ae36c1f3bb366f7d5170dc2ae04aef4b2d73f0322869e7cdedba",
+         x86_64_linux: "8641a47657ab347db65f1a7533905d3707aeff2882549a35187aea1362f9228c"
 
-  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-#{arch}-#{os}.tar.gz"
+  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-package-#{arch}-#{os}.tar.gz"
   name "Codex"
   desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
@@ -21,9 +21,9 @@ cask "codex" do
 
   depends_on formula: "ripgrep"
 
-  binary "codex-#{arch}-#{os}", target: "codex"
+  binary "bin/codex"
 
-  generate_completions_from_executable "codex-#{arch}-#{os}", "completion", base_name: "codex"
+  generate_completions_from_executable "bin/codex", "completion"
 
   zap rmdir: "~/.codex"
 end


### PR DESCRIPTION
Switch the Codex cask from the bare `codex-#{arch}-#{os}.tar.gz`
release asset to `codex-package-#{arch}-#{os}.tar.gz`.

The bare asset only contains the Codex binary. Codex also publishes a
package asset containing the package layout used by the CLI to discover
bundled resources:

- `bin/codex`
- `codex-package.json`
- `codex-path/rg`
- `codex-resources/zsh/bin/zsh`

Without that layout, enabling Codex's forked-zsh shell backend can fail
at startup because no packaged zsh fork is available for the install.
The package asset keeps those resources private under the Caskroom while
only linking `bin/codex` as the public executable.

I tested the package asset locally through a temporary cask tap and
`codex doctor` recognized the install as a brew package layout with
resources.