### PR TITLE
Add shade 2.3.16

### DIFF
--- a/Casks/s/shade.rb
+++ b/Casks/s/shade.rb
@@ -1,0 +1,39 @@
+cask "shade" do
+  arch arm: "-arm64"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "x64"
+
+  version "2.3.16"
+  sha256 arm:   "a35c41477a4b4fd52e743201446472e240d672d9c60babad7edc222a1609d2f1",
+         intel: "e9f3a56788304128c31c6176d7f06ada427170d6f9c52b60d20307113dba6379"
+
+  url "https://storage.googleapis.com/v2-public.shade.inc/releases/stable/mac/Shade-#{version}#{arch}.pkg",
+      verified: "storage.googleapis.com/v2-public.shade.inc/"
+  name "Shade"
+  desc "AI-powered media storage and asset management platform"
+  homepage "https://shade.inc/"
+
+  livecheck do
+    url "https://storage.googleapis.com/v2-public.shade.inc/releases/stable/mac/fuse-t-latest-#{livecheck_arch}-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  pkg "Shade-#{version}#{arch}.pkg"
+
+  uninstall launchctl: "inc.shade.xpc",
+            pkgutil:   "com.shade.shade",
+            delete:    [
+              "/Library/Application Support/Shade/ShadeFS XPC Service.xpc",
+              "/Library/LaunchAgents/inc.shade.xpc.plist",
+            ]
+
+  zap trash: [
+    "~/.shade",
+    "~/Library/Application Support/Shade",
+    "~/Library/Logs/Shade",
+    "~/Library/Preferences/com.shade.shade.plist",
+    "~/Library/Saved Application State/com.shade.shade.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Local install/uninstall were verified after temporarily moving an existing local development `Shade.app` bundle out of the way so Apple Installer would not relocate the package payload to that development path. The tested commands were `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask shade` and `brew uninstall --cask shade`; install completed successfully and uninstall removed the `inc.shade.xpc` launchctl service, package receipt, XPC bundle, and LaunchAgent plist.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to inspect the upstream release workflow, draft the cask, run verification commands, and prepare this PR text. Manual verification performed before opening/updating this PR:

- Confirmed Shade `v2.3.16` is a stable/non-prerelease GitHub release and that the stable updater manifest reports `version: "2.3.16"`.
- Downloaded both macOS pkg artifacts, computed SHA-256 checksums, and checked they are signed and notarized with `pkgutil --check-signature`.
- Expanded the pkg and verified it installs `/Applications/Shade.app`, uses bundle/receipt id `com.shade.shade`, and requires macOS 12+.
- Inspected the postinstall script and added `launchctl`/`delete` uninstall entries for the installed `inc.shade.xpc` LaunchAgent and XPC bundle.
- Verified `zap` paths are user-scoped Shade support/log/preference/saved-state paths for `com.shade.shade`, plus `~/.shade`; the system-level XPC artifacts are handled in `uninstall`, not `zap`.
- Ran `brew style --fix shade` with no offenses.
- Ran `brew audit --cask --online shade` successfully.
- Ran `brew audit --cask --new shade` successfully.
- Ran `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask shade` successfully.
- Ran `brew uninstall --cask shade` successfully.
- Checked closed/unmerged PRs for `shade`; the only relevant result was the previous Shade PR closed for missing this template, not a substantive refusal.

-----
