### PR TITLE
rockxy 0.25.0,38

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.24.0,37"
-  sha256 "22a2a9f89d861712dfdb586367faaa405bb1bca6a31fe0198cca152b6f6d9ed6"
+  version "0.25.0,38"
+  sha256 "d6133212479fe2278908627e94a71ce443635cad4756172b8d2001d614d194d3"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
Updates Rockxy to 0.25.0 build 38.

This manual PR was opened only after checking that no Homebrew autobump PR already exists.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.25.0/Rockxy-0.25.0-38.dmg
- SHA-256: d6133212479fe2278908627e94a71ce443635cad4756172b8d2001d614d194d3
- Notarized: true

Local checks run:

- `brew style --fix rockxy`
- `brew audit --new --cask rockxy`
- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
