### PR TITLE
quarto: add Linux support

### DIFF
--- a/Casks/q/quarto.rb
+++ b/Casks/q/quarto.rb
@@ -1,9 +1,40 @@
 cask "quarto" do
   version "1.9.38"
-  sha256 "de056ec2407c1b79832bc8fd6181ad6077fde433728285b2a0ae62710d853b84"
 
-  url "https://github.com/quarto-dev/quarto-cli/releases/download/v#{version}/quarto-#{version}-macos.pkg",
-      verified: "github.com/quarto-dev/quarto-cli/"
+  on_macos do
+    sha256 "de056ec2407c1b79832bc8fd6181ad6077fde433728285b2a0ae62710d853b84"
+
+    url "https://github.com/quarto-dev/quarto-cli/releases/download/v#{version}/quarto-#{version}-macos.pkg",
+        verified: "github.com/quarto-dev/quarto-cli/"
+
+    pkg "quarto-#{version}-macos.pkg"
+
+    uninstall pkgutil: "org.rstudio.quarto"
+
+    zap trash: [
+      "~/Library/Application Support/quarto",
+      "~/Library/Application Support/quarto-writer",
+      "~/Library/Caches/quarto",
+    ]
+  end
+
+  on_linux do
+    on_arm do
+      sha256 "75fbc5c1121ffe65e564e9d24711db2ad8f617f9552f5dc7d8a06307d72dde38"
+
+      url "https://github.com/quarto-dev/quarto-cli/releases/download/v#{version}/quarto-#{version}-linux-arm64.tar.gz",
+          verified: "github.com/quarto-dev/quarto-cli/"
+    end
+    on_intel do
+      sha256 "ea8c897368791ad9f200010c087ea3111b2e556b12a960487dd4e216902aa102"
+
+      url "https://github.com/quarto-dev/quarto-cli/releases/download/v#{version}/quarto-#{version}-linux-amd64.tar.gz",
+          verified: "github.com/quarto-dev/quarto-cli/"
+    end
+
+    binary "quarto-#{version}/bin/quarto"
+  end
+
   name "quarto"
   desc "Scientific and technical publishing system built on Pandoc"
   homepage "https://www.quarto.org/"
@@ -12,16 +43,4 @@ cask "quarto" do
     url :url
     strategy :github_latest
   end
-
-  depends_on :macos
-
-  pkg "quarto-#{version}-macos.pkg"
-
-  uninstall pkgutil: "org.rstudio.quarto"
-
-  zap trash: [
-    "~/Library/Application Support/quarto",
-    "~/Library/Application Support/quarto-writer",
-    "~/Library/Caches/quarto",
-  ]
 end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online quarto` is error-free.
- [x] `brew style --fix quarto` reports no offenses.

-----

- [x] AI was used to generate or assist with generating this PR. 

Claude Code drafted the `on_arm`/`on_intel`-inside-`on_linux` structure. I got the SHA256s from the upstream v1.9.38 release assets, ran `brew style --fix quarto` and `brew audit --cask --online quarto` (both clean), confirmed `brew install --cask quarto` and `brew uninstall --cask quarto` on Fedora 44 (x86_64), and confirmed the existing macOS `zap` paths are now scoped inside `on_macos`.

-----