### PR TITLE
screens-connect 5.3

### DIFF
--- a/Casks/s/screens-connect.rb
+++ b/Casks/s/screens-connect.rb
@@ -1,8 +1,8 @@
 cask "screens-connect" do
-  version "5.2.6,22851"
-  sha256 "e8260a42fe0dd5191b5f8b77e2778f49b5f4000e5c95d7fa76c0314e65792760"
+  version "5.3.1,22924"
+  sha256 "a480015c49a04ff25da57a33a9fe0627a15e00121184b850f0df418c141a74e0"
 
-  url "https://updates.edovia.com/com.edovia.screens.connect.mac/ScreensConnect_#{version.csv.first}b#{version.csv.second}.zip"
+  url "https://updates.edovia.com/com.edovia.screens.connect.mac/ScreensConnect_#{version.csv.first.major_minor}b#{version.csv.second}.zip"
   name "Screens Connect"
   desc "Remote desktop software"
   homepage "https://edovia.com/en/screens-connect/"
@@ -23,12 +23,7 @@ cask "screens-connect" do
               "com.edovia.Screens-Connect.launcher",
               "com.edovia.screens.connect",
             ],
-            quit:      "com.edovia.Screens-Connect",
-            script:    {
-              executable:   "#{appdir}/Screens Connect.app/Contents/Resources/sc-uninstaller.tool",
-              must_succeed: false,
-              sudo:         true,
-            }
+            quit:      "com.edovia.Screens-Connect"
 
   zap trash: [
     "~/Library/Preferences/com.edovia.Screens-Connect.plist",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

This fixes the current [audit/CI failures](https://github.com/Homebrew/homebrew-cask/pull/267447).
I verified the current `Screens Connect.app` bundle and could not find that script or another Screens Connect uninstall script.