### PR TITLE
Update Lightworks to 2025.2,56356

### DIFF
--- a/Casks/l/lightworks.rb
+++ b/Casks/l/lightworks.rb
@@ -2,16 +2,17 @@ cask "lightworks" do
   version "2025.2,56356"
   sha256 "8771f90dfc4a1872567e320679729df1a9a06b14ad47f69a4b1200528eef0ef1"
 
-  url "https://cdn.lwks.com/releases/#{version.csv.first}/Lightworks-#{version.csv.first.major_minor}-#{version.csv.second}.dmg"
+  url "https://cdn.lwks.com/releases/#{version.major_minor}/Lightworks-#{version}.dmg"
   name "Lightworks"
   desc "Complete video creation package"
   homepage "https://www.lwks.com/"
 
   livecheck do
     url "https://forum.lwks.com/forums/product-releases.19/index.rss"
-    regex(/v?(\d+(?:\.\d+)+).*?revision\s+(\d+)/i)
+    # v2025-2-56356-now-available
+    regex(/v?(\d+(?:[._-]\d+)+)[._-]now[._-]available/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+      page.scan(regex).map { |match| match.first&.tr("-", ".") }
     end
   end
 

--- a/Casks/l/lightworks.rb
+++ b/Casks/l/lightworks.rb
@@ -2,7 +2,7 @@ cask "lightworks" do
   version "2025.2.56356"
   sha256 "8771f90dfc4a1872567e320679729df1a9a06b14ad47f69a4b1200528eef0ef1"
 
-  url "https://cdn.lwks.com/releases/#{version.major_minor}/Lightworks-#{version}.dmg"
+  url "https://cdn.lwks.com/releases/#{version.major_minor}/Lightworks-#{version.major_minor}-#{version.patch}.dmg"
   name "Lightworks"
   desc "Complete video creation package"
   homepage "https://www.lwks.com/"

--- a/Casks/l/lightworks.rb
+++ b/Casks/l/lightworks.rb
@@ -1,6 +1,6 @@
 cask "lightworks" do
-  version "2025.1,151752"
-  sha256 "11a6438c86cb3df8f325c957a87ad5653806642bd8bf37feadf43c742e08580a"
+  version "2025.2,56356"
+  sha256 "8771f90dfc4a1872567e320679729df1a9a06b14ad47f69a4b1200528eef0ef1"
 
   url "https://cdn.lwks.com/releases/#{version.csv.first}/Lightworks-#{version.csv.first.major_minor}-#{version.csv.second}.dmg"
   name "Lightworks"

--- a/Casks/l/lightworks.rb
+++ b/Casks/l/lightworks.rb
@@ -1,5 +1,5 @@
 cask "lightworks" do
-  version "2025.2,56356"
+  version "2025.2.56356"
   sha256 "8771f90dfc4a1872567e320679729df1a9a06b14ad47f69a4b1200528eef0ef1"
 
   url "https://cdn.lwks.com/releases/#{version.major_minor}/Lightworks-#{version}.dmg"
@@ -9,7 +9,6 @@ cask "lightworks" do
 
   livecheck do
     url "https://forum.lwks.com/forums/product-releases.19/index.rss"
-    # v2025-2-56356-now-available
     regex(/v?(\d+(?:[._-]\d+)+)[._-]now[._-]available/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match.first&.tr("-", ".") }


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The Livecheck stanza no longer works, because the regex is looking for the word "revision", but the last few update announcements don't have the word "revision" in them. I'm not a regex expert myself, so I'm not sure how to fix it.