### PR TITLE
rockxy 0.26.0,39

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.25.0,38"
-  sha256 "d6133212479fe2278908627e94a71ce443635cad4756172b8d2001d614d194d3"
+  version "0.26.0,39"
+  sha256 "0f11e0849e305bdb8d9bbb8bb141a00a59e18aa5128f552abd20e7224b63286e"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online rockxy` is error-free.
- [x] `brew style --fix rockxy` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the token reference.
- [ ] Checked the cask was not already refused.
- [ ] `brew audit --cask --new rockxy` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask rockxy` worked successfully.
- [ ] `brew uninstall --cask rockxy` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. The assistant updated the cask version and SHA, ran the release/Homebrew verification commands, and checked that the existing `zap` paths are unchanged. The cask diff, version, checksum, download URL, livecheck result, fetch, dry-run install, and CI results were manually reviewed before requesting review.

-----

Updates Rockxy to 0.26.0 build 39.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.26.0/Rockxy-0.26.0-39.dmg
- SHA-256: 0f11e0849e305bdb8d9bbb8bb141a00a59e18aa5128f552abd20e7224b63286e
- Notarized: true

Additional local checks run:

- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
- `brew lgtm --online`
