### PR TITLE
cmdr 0.24.0 (new cask)

### DIFF
--- a/Casks/c/cmdr.rb
+++ b/Casks/c/cmdr.rb
@@ -1,0 +1,30 @@
+cask "cmdr" do
+  version "0.24.0"
+  sha256 "2838f14ac160252178e16fae984e00b21d0a20de092d0c6738b2225bab899837"
+
+  url "https://license.getcmdr.com/download/#{version}/universal"
+  name "Cmdr"
+  desc "Keyboard-driven dual-pane file manager"
+  homepage "https://getcmdr.com/"
+
+  livecheck do
+    url "https://getcmdr.com/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Cmdr.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.veszelovszki.cmdr",
+    "~/Library/Caches/com.veszelovszki.cmdr",
+    "~/Library/Logs/com.veszelovszki.cmdr",
+    "~/Library/Preferences/com.veszelovszki.cmdr.plist",
+    "~/Library/Saved Application State/com.veszelovszki.cmdr.savedState",
+    "~/Library/WebKit/com.veszelovszki.cmdr",
+  ]
+end


### PR DESCRIPTION
[Cmdr](https://getcmdr.com) is a two-pane file manager (like Total Commander on Windows) written with Rust/Tauri/Svelte.
I've been building it full-time over the past 5.5 months (proof: GitHub history, see [gitstrata](https://gitstrata.com/github.com/vdavid/cmdr) for easy consumption).

By now, the software got stable enough so that I want to start distributing it (free for personal use, paid commercial license, but source available because I think transparency is nice). For this, having Homebrew as a channel would be really nice.

I've had 591 downloads in the past 30 days and I haven't advertised Cmdr anywhere, this is mostly friends&family plus organic.

Re: the checks:

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Also, because this is a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Claude helped me learn the cask creation process and drafted up the CLI command list to run to verify everything and honestly tick all the boxes above. I ran each CLI command with understanding and care, and manually verified brew audit/style/livecheck outputs, compared the sha256 to the published DMG's, and every zap path against a real install.
