### PR TITLE
Add escrow-buddy (new cask)

### DIFF
--- a/Casks/e/escrow-buddy.rb
+++ b/Casks/e/escrow-buddy.rb
@@ -1,0 +1,20 @@
+cask "escrow-buddy" do
+  version "1.0.0"
+  sha256 "bf1f0dac3a9418eaa71fa7c819b8a788c86fd09a1b14148016088bce2791064d"
+
+  url "https://github.com/macadmins/escrow-buddy/releases/download/v#{version}/Escrow.Buddy-#{version}.pkg"
+  name "Escrow Buddy"
+  desc "Escrows FileVault recovery keys at the login window"
+  homepage "https://github.com/macadmins/escrow-buddy"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+
+  pkg "Escrow.Buddy-1.0.0.pkg"
+
+  uninstall pkgutil: "com.netflix.Escrow-Buddy"
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `escrow-buddy` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online escrow-buddy` is error-free.
- [x] `brew style --fix escrow-buddy` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new escrow-buddy` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask escrow-buddy` worked successfully.
- [x] `brew uninstall --cask escrow-buddy` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
