### PR TITLE
Add managed-app-schema-builder (new cask)

### DIFF
--- a/Casks/m/managed-app-schema-builder.rb
+++ b/Casks/m/managed-app-schema-builder.rb
@@ -1,0 +1,25 @@
+cask "managed-app-schema-builder" do
+  version "1.2.1"
+  sha256 "a86adbded2a773860782c863a2e0e98675dac0f3b45f201e97995af73ceb15ec"
+
+  url "https://github.com/BIG-RAT/Managed-App-Schema-Builder/releases/download/v#{version}/Managed.App.Schema.Builder.zip"
+  name "Managed App Schema Builder"
+  desc "Builds managed app configuration schemas"
+  homepage "https://github.com/BIG-RAT/Managed-App-Schema-Builder"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+
+  app "Managed App Schema Builder.app"
+
+  zap trash: [
+    "~/Library/Caches/com.jamf.pse.ManagedAppSchemaBuilder",
+    "~/Library/HTTPStorages/com.jamf.pse.ManagedAppSchemaBuilder",
+    "~/Library/Preferences/com.jamf.pse.ManagedAppSchemaBuilder.plist",
+    "~/Library/Saved Application State/com.jamf.pse.ManagedAppSchemaBuilder.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `managed-app-schema-builder` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online managed-app-schema-builder` is error-free.
- [x] `brew style --fix managed-app-schema-builder` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new managed-app-schema-builder` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask managed-app-schema-builder` worked successfully.
- [x] `brew uninstall --cask managed-app-schema-builder` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
