### PR TITLE
Add airradar (new cask)

### DIFF
--- a/Casks/a/airradar.rb
+++ b/Casks/a/airradar.rb
@@ -1,0 +1,26 @@
+cask "airradar" do
+  version "8.0"
+  sha256 :no_check
+
+  url "https://www.koingosw.com/products/airradar/download/airradar.dmg"
+  name "AirRadar"
+  desc "Scans for wireless networks and maps signal strength with GPS"
+  homepage "https://www.koingosw.com/products/airradar/"
+
+  livecheck do
+    url "https://www.koingosw.com/products/airradar/"
+    regex(/Version (\d+(?:\.\d+)+)/i)
+    strategy :page_match
+  end
+
+  depends_on macos: :big_sur
+
+  app "AirRadar.app"
+
+  zap trash: [
+    "~/Library/Caches/com.koingosw.AirRadar",
+    "~/Library/HTTPStorages/com.koingosw.AirRadar",
+    "~/Library/Preferences/com.koingosw.AirRadar.plist",
+    "~/Library/Saved Application State/com.koingosw.AirRadar.savedState",
+  ]
+end

--- a/Casks/a/airradar.rb
+++ b/Casks/a/airradar.rb
@@ -10,7 +10,6 @@ cask "airradar" do
   livecheck do
     url "https://www.koingosw.com/products/airradar/"
     regex(/Version (\d+(?:\.\d+)+)/i)
-    strategy :page_match
   end
 
   depends_on macos: :big_sur

--- a/Casks/a/airradar.rb
+++ b/Casks/a/airradar.rb
@@ -9,7 +9,7 @@ cask "airradar" do
 
   livecheck do
     url "https://www.koingosw.com/products/airradar/"
-    regex(/Version (\d+(?:\.\d+)+)/i)
+    regex(/Version\s*(\d+(?:\.\d+)+)/i)
   end
 
   depends_on macos: :big_sur


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `airradar` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online airradar` is error-free.
- [x] `brew style --fix airradar` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new airradar` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask airradar` worked successfully.
- [x] `brew uninstall --cask airradar` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
