### PR TITLE
Add akvis-frames (new cask)

### DIFF
--- a/Casks/a/akvis-frames.rb
+++ b/Casks/a/akvis-frames.rb
@@ -1,0 +1,27 @@
+cask "akvis-frames" do
+  version "8.1"
+  sha256 :no_check
+
+  url "https://akvis-dl.sfo2.cdn.digitaloceanspaces.com/akvis-frames-app.dmg",
+      verified: "akvis-dl.sfo2.cdn.digitaloceanspaces.com/"
+  name "AKVIS Frames"
+  desc "Adds decorative frames and edge effects to photos"
+  homepage "https://akvis.com/en/frames/index.php"
+
+  livecheck do
+    url "https://akvis.com/en/frames/index.php"
+    regex(/Frames (\d+(?:\.\d+)+)/i)
+    strategy :page_match
+  end
+
+  depends_on macos: :catalina
+
+  app "AKVIS Frames.app"
+
+  zap trash: [
+    "~/Library/Caches/com.akvis.Frames",
+    "~/Library/HTTPStorages/com.akvis.Frames",
+    "~/Library/Preferences/com.akvis.Frames.plist",
+    "~/Library/Saved Application State/com.akvis.Frames.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `akvis-frames` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online akvis-frames` is error-free.
- [x] `brew style --fix akvis-frames` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new akvis-frames` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask akvis-frames` worked successfully.
- [x] `brew uninstall --cask akvis-frames` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
