### PR TITLE
Add alarm-clock-pro (new cask)

### DIFF
--- a/Casks/a/alarm-clock-pro.rb
+++ b/Casks/a/alarm-clock-pro.rb
@@ -1,0 +1,26 @@
+cask "alarm-clock-pro" do
+  version "15.9.3"
+  sha256 :no_check
+
+  url "https://www.koingosw.com/products/alarmclockpro/download/alarmclockpro.dmg"
+  name "Alarm Clock Pro"
+  desc "Schedules alarms, reminders, and timed events with audio playback"
+  homepage "https://www.koingosw.com/products/alarmclockpro/"
+
+  livecheck do
+    url "https://www.koingosw.com/products/alarmclockpro/"
+    regex(/Version (\d+(?:\.\d+)+)/i)
+    strategy :page_match
+  end
+
+  depends_on macos: :big_sur
+
+  app "Alarm Clock Pro.app"
+
+  zap trash: [
+    "~/Library/Caches/com.koingosw.alarmclockpro",
+    "~/Library/HTTPStorages/com.koingosw.alarmclockpro",
+    "~/Library/Preferences/com.koingosw.alarmclockpro.plist",
+    "~/Library/Saved Application State/com.koingosw.alarmclockpro.savedState",
+  ]
+end

--- a/Casks/a/alarm-clock-pro.rb
+++ b/Casks/a/alarm-clock-pro.rb
@@ -9,8 +9,7 @@ cask "alarm-clock-pro" do
 
   livecheck do
     url "https://www.koingosw.com/products/alarmclockpro/"
-    regex(/Version (\d+(?:\.\d+)+)/i)
-    strategy :page_match
+    regex(/Version\s*(\d+(?:\.\d+)+)/i)
   end
 
   depends_on macos: :big_sur


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `alarm-clock-pro` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online alarm-clock-pro` is error-free.
- [x] `brew style --fix alarm-clock-pro` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new alarm-clock-pro` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask alarm-clock-pro` worked successfully.
- [x] `brew uninstall --cask alarm-clock-pro` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
