### PR TITLE
Add alivecolors (new cask)

### DIFF
--- a/Casks/a/alivecolors.rb
+++ b/Casks/a/alivecolors.rb
@@ -1,0 +1,26 @@
+cask "alivecolors" do
+  version "11.2.5301"
+  sha256 :no_check
+
+  url "https://alivecolors.sfo2.cdn.digitaloceanspaces.com/alivecolors.dmg",
+      verified: "alivecolors.sfo2.cdn.digitaloceanspaces.com/"
+  name "AliveColors"
+  desc "Image editor with painting, retouching, and AI-based effects"
+  homepage "https://alivecolors.com/en/index.php"
+
+  livecheck do
+    url "https://alivecolors.com/en/download.php"
+    regex(/AliveColors (\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on macos: :catalina
+
+  app "AliveColors.app"
+
+  zap trash: [
+    "~/Library/Caches/com.akvis.AliveColors",
+    "~/Library/HTTPStorages/com.akvis.AliveColors",
+    "~/Library/Preferences/com.akvis.AliveColors.plist",
+    "~/Library/Saved Application State/com.akvis.AliveColors.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `alivecolors` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online alivecolors` is error-free.
- [x] `brew style --fix alivecolors` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new alivecolors` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask alivecolors` worked successfully.
- [x] `brew uninstall --cask alivecolors` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
