### PR TITLE
Add atlassian-companion (new cask)

### DIFF
--- a/Casks/a/atlassian-companion.rb
+++ b/Casks/a/atlassian-companion.rb
@@ -1,0 +1,29 @@
+cask "atlassian-companion" do
+  version "3.2.0"
+  sha256 "d8587ce64c4f6be2e0b95a9e64361dc5a7e6e718bd62af855887e28e8306bbc0"
+
+  url "https://update-nucleus.atlassian.com/Atlassian-Companion/291cb34fe2296e5fb82b83a04704c9b4/darwin/x64/Atlassian%20Companion-darwin-x64-#{version}.zip"
+  name "Atlassian Companion"
+  desc "Edits Confluence and Jira attachments in their native apps"
+  homepage "https://confluence.atlassian.com/display/DOC/Install+Atlassian+Companion"
+
+  livecheck do
+    url "https://update-nucleus.atlassian.com/Atlassian-Companion/291cb34fe2296e5fb82b83a04704c9b4/darwin/x64/RELEASES.json"
+    regex(/currentRelease"\s*:\s*"(\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on macos: :monterey
+
+  app "Atlassian Companion.app"
+
+  zap trash: [
+    "~/Library/Caches/com.electron.companion",
+    "~/Library/HTTPStorages/com.electron.companion",
+    "~/Library/Preferences/com.electron.companion.plist",
+    "~/Library/Saved Application State/com.electron.companion.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `atlassian-companion` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online atlassian-companion` is error-free.
- [x] `brew style --fix atlassian-companion` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new atlassian-companion` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask atlassian-companion` worked successfully.
- [x] `brew uninstall --cask atlassian-companion` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
