### PR TITLE
Add luna-display (new cask)

### DIFF
--- a/Casks/l/luna-display.rb
+++ b/Casks/l/luna-display.rb
@@ -9,7 +9,6 @@ cask "luna-display" do
 
   livecheck do
     url "https://downloads.astropad.com/luna/mac/latest"
-    regex(/LunaDisplay-(\d+(?:\.\d+)+)\.dmg/i)
     strategy :header_match
   end
 

--- a/Casks/l/luna-display.rb
+++ b/Casks/l/luna-display.rb
@@ -1,0 +1,26 @@
+cask "luna-display" do
+  version "5.3.8.4999"
+  sha256 "71a05fdfad47ce6fbd2be5dd4b95f192a4ddff0b80d1e4536ba12ccb91a0604f"
+
+  url "https://downloads.astropad.com/luna/mac/LunaDisplay-#{version}.dmg"
+  name "Luna Display"
+  desc "Turns an iPad or second device into an external display"
+  homepage "https://astropad.com/getting-started/luna-display/"
+
+  livecheck do
+    url "https://downloads.astropad.com/luna/mac/latest"
+    regex(/LunaDisplay-(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :header_match
+  end
+
+  depends_on macos: :catalina
+
+  app "Luna Display.app"
+
+  zap trash: [
+    "~/Library/Caches/com.astro-hq.LunaDisplayMac",
+    "~/Library/HTTPStorages/com.astro-hq.LunaDisplayMac",
+    "~/Library/Preferences/com.astro-hq.LunaDisplayMac.plist",
+    "~/Library/Saved Application State/com.astro-hq.LunaDisplayMac.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `luna-display` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online luna-display` is error-free.
- [x] `brew style --fix luna-display` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new luna-display` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask luna-display` worked successfully.
- [x] `brew uninstall --cask luna-display` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
