### PR TITLE
Add microsoft-skype-for-business (new cask)

### DIFF
--- a/Casks/m/microsoft-skype-for-business.rb
+++ b/Casks/m/microsoft-skype-for-business.rb
@@ -19,7 +19,9 @@ cask "microsoft-skype-for-business" do
 
   pkg "SkypeForBusinessUpdater-#{version}.pkg"
 
-  uninstall pkgutil: "macosx"
+  app "Skype for Business.app"
+
+  uninstall pkgutil: "com.microsoft.SkypeForBusiness"
 
   zap trash: [
     "~/Library/Caches/com.microsoft.skype",

--- a/Casks/m/microsoft-skype-for-business.rb
+++ b/Casks/m/microsoft-skype-for-business.rb
@@ -20,4 +20,15 @@ cask "microsoft-skype-for-business" do
   pkg "SkypeForBusinessUpdater-#{version}.pkg"
 
   uninstall pkgutil: "macosx"
+
+  zap trash: [
+    "~/Library/Caches/com.microsoft.skype",
+    "~/Library/Caches/com.microsoft.skype.slimeu",
+    "~/Library/HTTPStorages/com.microsoft.skype",
+    "~/Library/HTTPStorages/com.microsoft.skype.slimeu",
+    "~/Library/Preferences/com.microsoft.skype.plist",
+    "~/Library/Preferences/com.microsoft.skype.slimeu.plist",
+    "~/Library/Saved Application State/com.microsoft.skype.savedState",
+    "~/Library/Saved Application State/com.microsoft.skype.slimeu.savedState",
+  ]
 end

--- a/Casks/m/microsoft-skype-for-business.rb
+++ b/Casks/m/microsoft-skype-for-business.rb
@@ -1,0 +1,23 @@
+cask "microsoft-skype-for-business" do
+  version "16.30.32"
+  sha256 "81f484842e86a39c9f33abc4d35b4e7dbb87189ca3c424a6396e15d96ea2dbd5"
+
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/SkypeForBusinessUpdater-#{version}.pkg",
+      verified: "res.public.onecdn.static.microsoft/"
+  name "Microsoft Skype for Business"
+  desc "Enterprise instant messaging and online meeting client"
+  homepage "https://learn.microsoft.com/en-us/skypeforbusiness/"
+
+  livecheck do
+    url "https://go.microsoft.com/fwlink/?linkid=832978"
+    regex(/SkypeForBusinessUpdater-(\d+(?:\.\d+)+)\.pkg/i)
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on macos: :catalina
+
+  pkg "SkypeForBusinessUpdater-#{version}.pkg"
+
+  uninstall pkgutil: "macosx"
+end

--- a/Casks/m/microsoft-skype-for-business.rb
+++ b/Casks/m/microsoft-skype-for-business.rb
@@ -17,20 +17,29 @@ cask "microsoft-skype-for-business" do
   auto_updates true
   depends_on macos: :catalina
 
-  pkg "SkypeForBusinessUpdater-#{version}.pkg"
+  pkg "SkypeForBusinessUpdater-#{version}.pkg",
+      choices: [
+        {
+          "choiceIdentifier" => "com.microsoft.autoupdate.fba",
+          "choiceAttribute"  => "selected",
+          "attributeSetting" => 0,
+        },
+      ]
 
-  app "Skype for Business.app"
-
-  uninstall pkgutil: "com.microsoft.SkypeForBusiness"
+  uninstall quit:       "com.microsoft.autoupdate2",
+            login_item: "Skype for Business",
+            pkgutil:    [
+              "com.microsoft.SkypeForBusiness",
+              "com.microsoft.SkypeForBusiness.MeetingJoinPlugin",
+            ],
+            delete:     "/Applications/Skype for Business.app"
 
   zap trash: [
-    "~/Library/Caches/com.microsoft.skype",
-    "~/Library/Caches/com.microsoft.skype.slimeu",
-    "~/Library/HTTPStorages/com.microsoft.skype",
-    "~/Library/HTTPStorages/com.microsoft.skype.slimeu",
-    "~/Library/Preferences/com.microsoft.skype.plist",
-    "~/Library/Preferences/com.microsoft.skype.slimeu.plist",
-    "~/Library/Saved Application State/com.microsoft.skype.savedState",
-    "~/Library/Saved Application State/com.microsoft.skype.slimeu.savedState",
-  ]
+    "/Library/Internet Plug-Ins/MeetingJoinPlugin.plugin",
+    "~/Library/Application Support/com.microsoft.SkypeForBusinessTAP",
+    "~/Library/Application Support/Skype for Business",
+    "~/Library/Preferences/com.microsoft.SkypeForBusinessTAP.debuglogging.plist",
+    "~/Library/Preferences/com.microsoft.SkypeForBusinessTAP.plist",
+  ],
+      rmdir: "/Library/Application Support/Microsoft"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `microsoft-skype-for-business` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online microsoft-skype-for-business` is error-free.
- [x] `brew style --fix microsoft-skype-for-business` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new microsoft-skype-for-business` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask microsoft-skype-for-business` worked successfully.
- [x] `brew uninstall --cask microsoft-skype-for-business` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
