### PR TITLE
Add poll-everywhere (new cask)

### DIFF
--- a/Casks/p/poll-everywhere.rb
+++ b/Casks/p/poll-everywhere.rb
@@ -10,7 +10,7 @@ cask "poll-everywhere" do
 
   livecheck do
     url "https://polleverywhere-app.s3.amazonaws.com/?list-type=2&prefix=mac-stable/"
-    regex(%r{mac-stable/(\d+(?:\.\d+)+)/pollev\.dmg}i)
+    regex(%r{mac[._-]stable/v?(\d+(?:\.\d+)+)/pollev\.dmg}i)
   end
 
   depends_on macos: :sonoma

--- a/Casks/p/poll-everywhere.rb
+++ b/Casks/p/poll-everywhere.rb
@@ -11,7 +11,6 @@ cask "poll-everywhere" do
   livecheck do
     url "https://polleverywhere-app.s3.amazonaws.com/?list-type=2&prefix=mac-stable/"
     regex(%r{mac-stable/(\d+(?:\.\d+)+)/pollev\.dmg}i)
-    strategy :page_match
   end
 
   depends_on macos: :sonoma

--- a/Casks/p/poll-everywhere.rb
+++ b/Casks/p/poll-everywhere.rb
@@ -1,0 +1,27 @@
+cask "poll-everywhere" do
+  version "4.0.1"
+  sha256 "cbe60b569d5f6c05ca71092fd7d6d19c6f99bc09d72ddf428e1441de582fe065"
+
+  url "https://polleverywhere-app.s3.amazonaws.com/mac-stable/#{version}/pollev.dmg",
+      verified: "polleverywhere-app.s3.amazonaws.com/"
+  name "Poll Everywhere"
+  desc "Live audience response and interactive polling client"
+  homepage "https://www.polleverywhere.com/"
+
+  livecheck do
+    url "https://polleverywhere-app.s3.amazonaws.com/?list-type=2&prefix=mac-stable/"
+    regex(%r{mac-stable/(\d+(?:\.\d+)+)/pollev\.dmg}i)
+    strategy :page_match
+  end
+
+  depends_on macos: :sonoma
+
+  app "Poll Everywhere.app"
+
+  zap trash: [
+    "~/Library/Caches/com.polleverywhere.PollEv-Presenter",
+    "~/Library/HTTPStorages/com.polleverywhere.PollEv-Presenter",
+    "~/Library/Preferences/com.polleverywhere.PollEv-Presenter.plist",
+    "~/Library/Saved Application State/com.polleverywhere.PollEv-Presenter.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `poll-everywhere` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online poll-everywhere` is error-free.
- [x] `brew style --fix poll-everywhere` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new poll-everywhere` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask poll-everywhere` worked successfully.
- [x] `brew uninstall --cask poll-everywhere` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
