### PR TITLE
orcaslicer: update urls

### DIFF
--- a/Casks/o/orcaslicer.rb
+++ b/Casks/o/orcaslicer.rb
@@ -2,10 +2,10 @@ cask "orcaslicer" do
   version "2.3.2"
   sha256 "334f7265b1df930e94ac75a318005bbe63f670fe719a9e7778c30f4d7c887cc2"
 
-  url "https://github.com/SoftFever/OrcaSlicer/releases/download/v#{version}/OrcaSlicer_Mac_universal_V#{version}.dmg"
+  url "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/v#{version}/OrcaSlicer_Mac_universal_V#{version}.dmg"
   name "Orca Slicer"
   desc "G-code generator for 3D printers"
-  homepage "https://github.com/SoftFever/OrcaSlicer"
+  homepage "https://github.com/OrcaSlicer/OrcaSlicer"
 
   conflicts_with cask: "orcaslicer@nightly"
   depends_on macos: :big_sur

--- a/Casks/o/orcaslicer@nightly.rb
+++ b/Casks/o/orcaslicer@nightly.rb
@@ -10,7 +10,7 @@ cask "orcaslicer@nightly" do
   homepage "https://github.com/OrcaSlicer/OrcaSlicer"
 
   conflicts_with cask: "orcaslicer"
-  depends_on :macos
+  depends_on macos: :big_sur
 
   app "OrcaSlicer.app"
 

--- a/Casks/o/orcaslicer@nightly.rb
+++ b/Casks/o/orcaslicer@nightly.rb
@@ -4,10 +4,10 @@ cask "orcaslicer@nightly" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/SoftFever/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Mac_universal_nightly.dmg"
+  url "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Mac_universal_nightly.dmg"
   name "Orca Slicer Nightly"
   desc "G-code generator for 3D printers"
-  homepage "https://github.com/SoftFever/OrcaSlicer"
+  homepage "https://github.com/OrcaSlicer/OrcaSlicer"
 
   conflicts_with cask: "orcaslicer"
   depends_on :macos


### PR DESCRIPTION
The upstream repository for OrcaSlicer has been renamed from SoftFever/OrcaSlicer to OrcaSlicer/OrcaSlicer. This PR updates the homepage and download URLs for both the `orcaslicer` and `orcaslicer@nightly` casks to reflect the new repository name. Resolves Homebrew/homebrew-cask#256482.