### PR TITLE
devin-cli: sync improvements from vendor tap

### DIFF
--- a/Casks/d/devin-cli.rb
+++ b/Casks/d/devin-cli.rb
@@ -3,22 +3,15 @@ cask "devin-cli" do
   os macos: "apple-darwin", linux: "unknown-linux"
 
   version "2026.5.26-8"
+  sha256 arm:          "ffcbdddba574cf5ab2b7c10e27667f25d58d1a36fe88df98920689411a011d49",
+         intel:        "b85e8e45b5b00b4860214445a1715087fe683ef7d2e1c81105a0ae8b84b41341",
+         arm64_linux:  "d61a1377a251e379d1fa178ba94ee280ff9d79b2356e159c2251ba046c9a8f72",
+         x86_64_linux: "4ea480041c6282261369f8b4bf11589ecb0b8c76e25d868dc48f29ae4929f021"
 
   url "https://static.devin.ai/cli/#{version}/devin-#{version}-#{arch}-#{os}.tar.gz"
   name "Devin CLI"
-  desc "Coding agent with Devin Cloud integration"
-  homepage "https://cli.devin.ai/docs"
-
-  on_macos do
-    sha256 arm:   "ffcbdddba574cf5ab2b7c10e27667f25d58d1a36fe88df98920689411a011d49",
-           intel: "b85e8e45b5b00b4860214445a1715087fe683ef7d2e1c81105a0ae8b84b41341"
-  end
-
-  on_linux do
-    sha256 "4ea480041c6282261369f8b4bf11589ecb0b8c76e25d868dc48f29ae4929f021"
-
-    depends_on arch: :x86_64
-  end
+  desc "Fast and minimal agent that lives both in your terminal and in the cloud"
+  homepage "https://docs.devin.ai/cli"
 
   livecheck do
     url "https://static.devin.ai/cli/current/manifest.json"
@@ -28,6 +21,18 @@ cask "devin-cli" do
   end
 
   binary "bin/devin"
+  manpage "share/man/man1/devin.1"
 
-  zap trash: "~/.devin"
+  postflight do
+    # Write distribution marker to indicate this is a Homebrew-managed installation
+    # This prevents the CLI from attempting self-update, directing users to
+    # use `brew upgrade devin-cli` instead
+    File.write("#{staged_path}/distribution", "homebrew")
+  end
+
+  zap trash: [
+    "~/.cache/devin/cli",
+    "~/.config/devin/cli",
+    "~/.local/share/devin/cli",
+  ]
 end

--- a/Casks/d/devin-cli.rb
+++ b/Casks/d/devin-cli.rb
@@ -23,13 +23,6 @@ cask "devin-cli" do
   binary "bin/devin"
   manpage "share/man/man1/devin.1"
 
-  postflight do
-    # Write distribution marker to indicate this is a Homebrew-managed installation
-    # This prevents the CLI from attempting self-update, directing users to
-    # use `brew upgrade devin-cli` instead
-    File.write("#{staged_path}/distribution", "homebrew")
-  end
-
   zap trash: [
     "~/.cache/devin/cli",
     "~/.config/devin/cli",


### PR DESCRIPTION
We have been maintaining this cask in our private tap. The cask was added here (which is great!) but not by us, so this syncs the differences:

- add Linux arm64 (checksums are published in [manifest.json](https://static.devin.ai/cli/current/manifest.json))
- install the manpage
- write a `distribution` marker in postflight so the CLI won't try to self-update and directs users to `brew upgrade` instead ([docs](https://docs.devin.ai/cli/essential-commands))
- fix zap: the CLI's dirs are `~/{.config,.local/share,.cache}/devin/cli` — `~/.devin` belongs to a different product
- update homepage (the old URL now redirects to docs.devin.ai/cli) and desc

Built and tested locally on macOS 15.5 (arm64).

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online devin-cli` is error-free.
- [x] `brew style --fix devin-cli` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new devin-cli` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask devin-cli` worked successfully.
- [ ] `brew uninstall --cask devin-cli` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Prepared with the Devin CLI itself. I reviewed the diff and verified everything locally: audit/style pass, `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --cask devin-cli` installs the manpage and writes the marker, and the zap paths match the directories the CLI actually creates.
