### PR TITLE
clarify 1.5.8 (new cask)

### DIFF
--- a/Casks/c/clarify.rb
+++ b/Casks/c/clarify.rb
@@ -5,7 +5,7 @@ cask "clarify" do
   url "https://github.com/clarifyhq/desktop-app-releases/releases/download/v#{version}/Clarify.dmg",
       verified: "github.com/clarifyhq/desktop-app-releases/"
   name "Clarify"
-  desc "AI-native CRM with meeting recording and transcription"
+  desc "Autonomous CRM with agents to source leads, send campaigns, and manage pipeline"
   homepage "https://clarify.ai/"
 
   livecheck do
@@ -20,7 +20,7 @@ cask "clarify" do
   app "Clarify.app"
 
   zap trash: [
-    "~/Library/Application Support/Clarify",
+    "~/Library/Application Support/clarify-desktop",
     "~/Library/Caches/com.clarify.desktop",
     "~/Library/Caches/com.clarify.desktop.ShipIt",
     "~/Library/HTTPStorages/com.clarify.desktop",

--- a/Casks/c/clarify.rb
+++ b/Casks/c/clarify.rb
@@ -1,6 +1,6 @@
 cask "clarify" do
-  version "1.6.0"
-  sha256 "57049bad71a873493ef4fac1b176c47f045608dc5f6a1ba25d3d47f40ba7ed99"
+  version "1.6.1"
+  sha256 "e213cdb3ed33ea41a217759d3297380dd0e6c94a21e2d4c7230e03b8b1249388"
 
   url "https://github.com/clarifyhq/desktop-app-releases/releases/download/v#{version}/Clarify.dmg",
       verified: "github.com/clarifyhq/desktop-app-releases/"

--- a/Casks/c/clarify.rb
+++ b/Casks/c/clarify.rb
@@ -1,17 +1,12 @@
 cask "clarify" do
-  version "1.5.8"
-  sha256 "89b680efce4b33e8504b593d4757fd16526fe040eccb2d3e97c59fb3c8ddc73c"
+  version "1.6.0"
+  sha256 "57049bad71a873493ef4fac1b176c47f045608dc5f6a1ba25d3d47f40ba7ed99"
 
   url "https://github.com/clarifyhq/desktop-app-releases/releases/download/v#{version}/Clarify.dmg",
       verified: "github.com/clarifyhq/desktop-app-releases/"
   name "Clarify"
-  desc "Autonomous CRM with agents to source leads, send campaigns, and manage pipeline"
+  desc "Autonomous CRM"
   homepage "https://clarify.ai/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   auto_updates true
   depends_on arch: :arm64

--- a/Casks/c/clarify.rb
+++ b/Casks/c/clarify.rb
@@ -1,0 +1,30 @@
+cask "clarify" do
+  version "1.5.8"
+  sha256 "89b680efce4b33e8504b593d4757fd16526fe040eccb2d3e97c59fb3c8ddc73c"
+
+  url "https://github.com/clarifyhq/desktop-app-releases/releases/download/v#{version}/Clarify.dmg",
+      verified: "github.com/clarifyhq/desktop-app-releases/"
+  name "Clarify"
+  desc "AI-native CRM with meeting recording and transcription"
+  homepage "https://clarify.ai/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :monterey
+
+  app "Clarify.app"
+
+  zap trash: [
+    "~/Library/Application Support/Clarify",
+    "~/Library/Caches/com.clarify.desktop",
+    "~/Library/Caches/com.clarify.desktop.ShipIt",
+    "~/Library/HTTPStorages/com.clarify.desktop",
+    "~/Library/Preferences/com.clarify.desktop.plist",
+    "~/Library/Saved Application State/com.clarify.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
New cask for **Clarify**, an AI-native CRM desktop app for macOS (Apple Silicon).

-----

<!-- In the following questions `<cask>` is the token of the cask you're editing (clarify). -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

**AI usage + manual verification:** AI assisted with drafting the cask and an initial `zap` stanza. Every `zap` path was then manually verified on a machine with the app installed (bundle id `com.clarify.desktop`): after install and use, each path was confirmed on disk. The one correction from review — `~/Library/Application Support/Clarify` → `~/Library/Application Support/clarify-desktop` — is in commit db7ce5bd9 and matches the real directory the app creates. The `Saved Application State` entry is the standard macOS-generated path.

**Notability:** the only item `brew audit --cask --new clarify` flags is the GitHub release repo (`clarifyhq/desktop-app-releases`, used solely to host the signed build) being below the stars/forks threshold. This is the official vendor application — homepage https://clarify.ai, signed by *Clarify, Inc.* (Developer ID `Y45C5H69NK`) — so per the Acceptable Casks policy the notability heuristic should be waived.

**Signed + notarized:** `spctl -a -vvv` → `accepted`, `source=Notarized Developer ID`; hardened runtime enabled, notarization ticket stapled. Download is a public GitHub release asset (no login/registration wall). arm64-only build (`depends_on arch: :arm64`), minimum macOS Monterey, auto-updates via electron-updater (`auto_updates true`).
