### PR TITLE
rnote 0.14.2

### DIFF
--- a/Casks/r/rnote.rb
+++ b/Casks/r/rnote.rb
@@ -1,18 +1,9 @@
 cask "rnote" do
   arch arm: "arm64", intel: "x86_64"
 
-  on_arm do
-    version "0.14.0+227"
-    sha256 "63f3178f1fba2b0d2d2ac131766e3f581df4550a1d49dfa3d24e8cc909e44803"
-
-    depends_on macos: :ventura
-  end
-  on_intel do
-    version "0.13.1+215"
-    sha256 "c985ea4757b9ac03cd7485ac824d3488a31b52b98fdb221a1d5ee062d58d7af8"
-
-    depends_on macos: :big_sur
-  end
+  version "0.14.2+239"
+  sha256 arm:   "6db9e55b9a2c7ca19f4f02f779f930926da289ead4f6086915dc48e70159410b",
+         intel: "fe321bdaa4c065c2ea3d757210316e6c995fa132ada484ce65ebe12586b4a902"
 
   url "https://gitlab.com/api/v4/projects/44053427/packages/generic/rnote_macos/#{version}/Rnote-#{version}_#{arch}.dmg",
       verified: "gitlab.com/api/v4/projects/44053427/packages/generic/rnote_macos/"
@@ -34,7 +25,7 @@ cask "rnote" do
     end
   end
 
-  depends_on :macos
+  depends_on macos: :ventura
 
   app "Rnote.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Fixes the autobump warning:

> `rnote` needs to be manually updated using one version

References:
- https://github.com/Homebrew/homebrew-cask/actions/runs/27324904663
- https://github.com/Homebrew/homebrew-cask/actions/runs/27317615838
- https://github.com/Homebrew/homebrew-cask/actions/runs/27309484413
- https://github.com/Homebrew/homebrew-cask/actions/runs/27300176280
- https://github.com/Homebrew/homebrew-cask/actions/runs/27290857669