### PR TITLE
dnclient-server 0.9.5,764f2278 (new cask)

### DIFF
--- a/Casks/d/dnclient-server.rb
+++ b/Casks/d/dnclient-server.rb
@@ -1,0 +1,42 @@
+cask "dnclient-server" do
+  version "0.9.5,764f2278"
+  sha256 "fd7df9b98105c83fd1b7fe1c4d5a980b7127fe8f74c972b2b75d7c8dc8597692"
+
+  url "https://dl.defined.net/#{version.csv.second}/v#{version.csv.first}/macos/DNClient-Server.dmg"
+  name "DNClient Server"
+  desc "Peer-to-peer VPN client daemon for managed nebula networks"
+  homepage "https://www.defined.net/"
+
+  livecheck do
+    url "https://api.defined.net/v1/downloads"
+    regex(%r{/(\h+)/v?(\d+(?:\.\d+)+)/macos/DNClient-Server\.dmg}i)
+    strategy :json do |json, regex|
+      json.dig("data", "dnclient")&.map do |_, release|
+        match = release["macos-universal-server-dmg"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
+    end
+  end
+
+  depends_on macos: :ventura
+
+  binary "dnclient"
+
+  zap trash: [
+    "/etc/defined",
+    "/Library/LaunchDaemons/dnclient.plist",
+  ]
+
+  caveats <<~EOS
+    To run dnclient as a system service and enroll this host:
+      sudo dnclient install
+      sudo dnclient start
+      sudo dnclient enroll -code <enrollment-code>
+
+    Before uninstalling this cask, remove the service:
+      sudo dnclient stop
+      sudo dnclient uninstall
+  EOS
+end


### PR DESCRIPTION
Adds `dnclient-server` — the CLI daemon variant of DNClient, the client for Defined Networking's managed [nebula](https://github.com/slackhq/nebula) VPN networks. The existing `dnclient` cask ships the Desktop GUI app; this cask ships the standalone server/headless binary from the vendor's codesigned + notarized `DNClient-Server.dmg`. Closed-source prebuilt binary, so homebrew-core is not an option. I work for Defined Networking (the vendor).

Complements Homebrew/homebrew-cask#269224, which renames `dnclient` → `dnclient-desktop` to keep the pair unambiguous (the two PRs are independent and merge in either order).

`livecheck` follows the same `api.defined.net/v1/downloads` JSON strategy as the existing `dnclient` cask, keyed on the `macos-universal-server-dmg` artifact. Verified locally: `brew livecheck` resolves `0.9.5,764f2278`, and `sudo dnclient install` writes its LaunchDaemon plist pointing at the stable `$(brew --prefix)/bin/dnclient` symlink, so upgrades don't orphan the service.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) of the software
- [x] `brew audit --cask --online {{cask_file}}` is error-free
- [x] `brew style --fix {{cask_file}}` reports no offenses
- [x] `brew install --cask {{cask_file}}` worked successfully, and `brew uninstall --cask {{cask_file}}` afterwards
- [x] The cask is [submittable](https://docs.brew.sh/Acceptable-Casks): closed-source CLI distributed as a prebuilt signed binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)