### PR TITLE
craft-agents 0.13.0

### DIFF
--- a/Casks/c/craft-agents.rb
+++ b/Casks/c/craft-agents.rb
@@ -1,9 +1,21 @@
 cask "craft-agents" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.10.1"
-  sha256 arm:   "ea13fbc5448ff5b6ffb1ee2282fad8dfb49af8e1a2ed70ba15803eb6551796dc",
-         intel: "9ac17ef80625df3957f5b0ecddee5a707038fad4a5c86f508f19dfe9c4405b00"
+  on_arm do
+    version "0.10.3"
+    sha256 "52422901fa51c77042bcccae4dee041ac6476160fa1687b67f1bb431fbfce0b8"
+  end
+  on_intel do
+    version "0.10.1"
+    sha256 "9ac17ef80625df3957f5b0ecddee5a707038fad4a5c86f508f19dfe9c4405b00"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    deprecate! date: "2026-06-02", because: :discontinued
+    disable! date: "2027-06-02", because: :discontinued
+  end
 
   url "https://github.com/lukilabs/craft-agents-oss/releases/download/v#{version}/Craft-Agents-#{version}-mac-#{arch}.dmg",
       verified: "github.com/lukilabs/craft-agents-oss/"

--- a/Casks/c/craft-agents.rb
+++ b/Casks/c/craft-agents.rb
@@ -13,8 +13,7 @@ cask "craft-agents" do
       skip "Legacy version"
     end
 
-    deprecate! date: "2026-06-02", because: :discontinued
-    disable! date: "2027-06-02", because: :discontinued
+    deprecate! date: "2026-06-12", because: :discontinued
   end
 
   url "https://github.com/lukilabs/craft-agents-oss/releases/download/v#{version}/Craft-Agents-#{version}-mac-#{arch}.dmg",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Fixes autobump error

>[autobump](https://github.com/Homebrew/homebrew-cask/actions/runs/27371581974/job/80884958153#step:5:3492)
Download failed on Cask 'craft-agents' with message: Download failed: https://github.com/lukilabs/craft-agents-oss/releases/download/v0.10.3/Craft-Agents-0.10.3-mac-x64.dmg
curl: (56) The requested URL returned error: 404

The upstream has discontinued support for Intel Macs.
https://github.com/craft-ai-agents/craft-agents-oss/releases/tag/v0.10.1

References:
- https://github.com/Homebrew/homebrew-cask/actions/runs/27380444775
- https://github.com/Homebrew/homebrew-cask/actions/runs/27371581974