### PR TITLE
snapview 2.0.0 (new cask)

### DIFF
--- a/Casks/s/snapview.rb
+++ b/Casks/s/snapview.rb
@@ -1,0 +1,28 @@
+cask "snapview" do
+  version "2.0.0"
+  sha256 "280bd1960b20dbf566ca50e4d01c983a1062bce6a4bc6d33253cb37434c3b2d8"
+
+  url "https://github.com/youngchangjo/SnapView/releases/download/v#{version}/SnapView.dmg",
+      verified: "github.com/youngchangjo/SnapView/"
+  name "SnapView"
+  desc "Fast image viewer"
+  homepage "https://snapview.snapworkslab.com/"
+
+  livecheck do
+    url "https://snapview.snapworkslab.com/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sequoia
+
+  app "SnapView.app"
+
+  zap trash: [
+    "~/Library/Application Support/SnapView",
+    "~/Library/Caches/YoungchangJo.SnapView",
+    "~/Library/HTTPStorages/YoungchangJo.SnapView",
+    "~/Library/Preferences/YoungchangJo.SnapView.plist",
+    "~/Library/Saved Application State/YoungchangJo.SnapView.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with drafting the cask. I manually verified the final cask contents and ran:

- `brew audit --cask --online snapview`
- `brew style --fix snapview`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --appdir=/private/tmp/snapview-official-cask-appdir snapview`
- `brew uninstall --cask snapview`

`brew audit --cask --new snapview` currently fails only the GitHub repository notability check. SnapView is distributed through an official website and the Mac App Store, and the GitHub repository is primarily used for release assets. Notability context:

- Mac App Store listing: https://apps.apple.com/us/app/snapview-fast-image-viewer/id6762974261
- Korea Mac App Store chart evidence: #4 in Photo & Video free Mac apps on 2026-06-12 KST.
- App Store Connect Analytics shows 2.13k first downloads, 4.35k product page views, and 15.9k impressions.
- GitHub Releases API shows 2,265 DMG release-asset downloads as of 2026-06-12 KST.
- Combined App Store first downloads plus GitHub Release DMG downloads are 4,395+ as of 2026-06-12 KST.

Installed app verification:

- Version: 2.0.0
- Build: 20000
- Architectures: x86_64 arm64
- `codesign --verify --deep --strict --verbose=4`: valid on disk
- `spctl -a -vv`: accepted, Notarized Developer ID

Zap paths are scoped to the app's direct-download bundle identifier and common macOS support/cache/preference state.

-----
