### PR TITLE
lyricsfinder: add Apple Silicon support

### DIFF
--- a/Casks/l/lyricsfinder.rb
+++ b/Casks/l/lyricsfinder.rb
@@ -2,13 +2,7 @@ cask "lyricsfinder" do
   arch arm: "-arm"
 
   version "1.7"
-
-  on_arm do
-    sha256 "905eea7adb297b2e55716ba096144be52529de6fd7987c36fe36ec8625157722"
-  end
-  on_intel do
-    sha256 "6e6e436de4c5d8ef1505b9afe4bf0aa8bd942caf847141c550878f8fe7276e05"
-  end
+  sha256 :no_check
 
   url "https://www.mediahuman.com/download/LyricsFinder#{arch}.dmg"
   name "Lyrics Finder"
@@ -20,7 +14,7 @@ cask "lyricsfinder" do
     regex(/"softwareVersion">(\d+(?:\.\d+)+)</i)
   end
 
-  depends_on :macos
+  depends_on macos: :monterey
 
   app "LyricsFinder.app"
 

--- a/Casks/l/lyricsfinder.rb
+++ b/Casks/l/lyricsfinder.rb
@@ -1,8 +1,16 @@
 cask "lyricsfinder" do
-  version "1.7"
-  sha256 :no_check
+  arch arm: "-arm"
 
-  url "https://www.mediahuman.com/download/LyricsFinder.dmg"
+  version "1.7"
+
+  on_arm do
+    sha256 "905eea7adb297b2e55716ba096144be52529de6fd7987c36fe36ec8625157722"
+  end
+  on_intel do
+    sha256 "6e6e436de4c5d8ef1505b9afe4bf0aa8bd942caf847141c550878f8fe7276e05"
+  end
+
+  url "https://www.mediahuman.com/download/LyricsFinder#{arch}.dmg"
   name "Lyrics Finder"
   desc "Find and download song lyrics"
   homepage "https://www.mediahuman.com/lyrics-finder/"
@@ -17,8 +25,4 @@ cask "lyricsfinder" do
   app "LyricsFinder.app"
 
   zap trash: "~/Library/Preferences/com.mediahuman.Lyrics Finder.plist"
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
Adds Apple Silicon (arm64) build for Lyrics Finder. The upstream vendor ([mediahuman.com](https://www.mediahuman.com/download3.html)) ships separate Intel and ARM DMGs:

- Intel: `LyricsFinder.dmg`
- ARM: `LyricsFinder-arm.dmg`

This replaces the Intel-only URL with architecture-conditional downloads and removes the `requires_rosetta` caveat.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online lyricsfinder` is error-free.
- [x] `brew style --fix lyricsfinder` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code identified the Intel-only download, fetched the download page to confirm ARM availability, downloaded both DMGs to compute sha256 values, and drafted the updated cask file. I manually reviewed the final cask file.

-----