### PR TITLE
wiiu-downloader 2.93 (new cask)

### DIFF
--- a/Casks/l/lyricsfinder.rb
+++ b/Casks/l/lyricsfinder.rb
@@ -2,13 +2,7 @@ cask "lyricsfinder" do
   arch arm: "-arm"
 
   version "1.7"
-
-  on_arm do
-    sha256 "905eea7adb297b2e55716ba096144be52529de6fd7987c36fe36ec8625157722"
-  end
-  on_intel do
-    sha256 "6e6e436de4c5d8ef1505b9afe4bf0aa8bd942caf847141c550878f8fe7276e05"
-  end
+  sha256 :no_check
 
   url "https://www.mediahuman.com/download/LyricsFinder#{arch}.dmg"
   name "Lyrics Finder"
@@ -20,7 +14,7 @@ cask "lyricsfinder" do
     regex(/"softwareVersion">(\d+(?:\.\d+)+)</i)
   end
 
-  depends_on :macos
+  depends_on macos: :monterey
 
   app "LyricsFinder.app"
 

--- a/Casks/l/lyricsfinder.rb
+++ b/Casks/l/lyricsfinder.rb
@@ -1,8 +1,16 @@
 cask "lyricsfinder" do
-  version "1.7"
-  sha256 :no_check
+  arch arm: "-arm"
 
-  url "https://www.mediahuman.com/download/LyricsFinder.dmg"
+  version "1.7"
+
+  on_arm do
+    sha256 "905eea7adb297b2e55716ba096144be52529de6fd7987c36fe36ec8625157722"
+  end
+  on_intel do
+    sha256 "6e6e436de4c5d8ef1505b9afe4bf0aa8bd942caf847141c550878f8fe7276e05"
+  end
+
+  url "https://www.mediahuman.com/download/LyricsFinder#{arch}.dmg"
   name "Lyrics Finder"
   desc "Find and download song lyrics"
   homepage "https://www.mediahuman.com/lyrics-finder/"
@@ -17,8 +25,4 @@ cask "lyricsfinder" do
   app "LyricsFinder.app"
 
   zap trash: "~/Library/Preferences/com.mediahuman.Lyrics Finder.plist"
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/w/wiiu-downloader.rb
+++ b/Casks/w/wiiu-downloader.rb
@@ -1,0 +1,21 @@
+cask "wiiu-downloader" do
+  version "2.93"
+  sha256 "2d33976ac7fec71530e3757b7b96c389eb301e5eadfbdc007f7a3e67bc194347"
+
+  url "https://github.com/Xpl0itU/WiiUDownloader/releases/download/v#{version}/WiiUDownloader-macOS-Universal.dmg",
+      verified: "github.com/Xpl0itU/WiiUDownloader/"
+  name "WiiUDownloader"
+  desc "Download Wii U games, updates, DLC and demos from Nintendo's servers"
+  homepage "https://github.com/Xpl0itU/WiiUDownloader"
+
+  depends_on macos: :big_sur
+
+  app "WiiUDownloader.app"
+
+  zap trash: [
+    "~/Library/Application Support/WiiUDownloader",
+    "~/Library/Caches/com.Xpl0itU.WiiUDownloader",
+    "~/Library/Preferences/com.Xpl0itU.WiiUDownloader.plist",
+    "~/Library/Saved Application State/com.Xpl0itU.WiiUDownloader.savedState",
+  ]
+end


### PR DESCRIPTION
New cask for WiiUDownloader, a GTK-based tool to browse and download Wii U games, updates, DLC and demos from Nintendo's servers.

brew audit and brew style pass.