### PR TITLE
pycharm-oss 2026.1.2 (new cask)

### DIFF
--- a/Casks/p/pycharm-oss.rb
+++ b/Casks/p/pycharm-oss.rb
@@ -1,9 +1,9 @@
 cask "pycharm-oss" do
   arch arm: "-aarch64"
 
-  version "2026.1.2"
-  sha256 arm:   "de3603370ca944fbe8587ed47258e28bb2f9504bfb2ee670c1f3dbd2f0960f53",
-         intel: "dceb7da17f5fd07f5f4bff02a9a6b98d89f5c7a296cb8af2ce54f4c3d2d15005"
+  version "2026.1.3"
+  sha256 arm:   "81a6d81d8bc2e701f69ea57924a88a662aefb56b6e7344e45137050a64415480",
+         intel: "24659e8962df7979a10e0c7bc91a0a24ef76e7d6a1e1ba4b077c8b9cc3cd8c9a"
 
   url "https://github.com/JetBrains/intellij-community/releases/download/pycharm%2F#{version}/pycharm-#{version}#{arch}.dmg"
   name "PyCharm OSS"

--- a/Casks/p/pycharm-oss.rb
+++ b/Casks/p/pycharm-oss.rb
@@ -1,0 +1,43 @@
+cask "pycharm-oss" do
+  arch arm: "-aarch64"
+
+  version "2026.1.2"
+  sha256 arm:   "de3603370ca944fbe8587ed47258e28bb2f9504bfb2ee670c1f3dbd2f0960f53",
+         intel: "dceb7da17f5fd07f5f4bff02a9a6b98d89f5c7a296cb8af2ce54f4c3d2d15005"
+
+  url "https://github.com/JetBrains/intellij-community/releases/download/pycharm%2F#{version}/pycharm-#{version}#{arch}.dmg"
+  name "PyCharm OSS"
+  desc "Open-source edition of PyCharm"
+  homepage "https://github.com/JetBrains/intellij-community"
+
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
+  livecheck do
+    url :url
+    regex(/^pycharm[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
+  depends_on :macos
+
+  app "PyCharm CE.app"
+
+  zap trash: [
+    "~/Library/Application Support/JetBrains/PyCharmCE#{version.major_minor}",
+    "~/Library/Caches/JetBrains/PyCharmCE#{version.major_minor}",
+    "~/Library/Logs/JetBrains/PyCharmCE#{version.major_minor}",
+    "~/Library/Preferences/com.jetbrains.pycharm.ce.plist",
+    "~/Library/Saved Application State/com.jetbrains.pycharm.ce.savedState",
+  ]
+end

--- a/Casks/p/pycharm-oss.rb
+++ b/Casks/p/pycharm-oss.rb
@@ -34,9 +34,9 @@ cask "pycharm-oss" do
   app "PyCharm CE.app"
 
   zap trash: [
-    "~/Library/Application Support/JetBrains/PyCharmCE#{version.major_minor}",
-    "~/Library/Caches/JetBrains/PyCharmCE#{version.major_minor}",
-    "~/Library/Logs/JetBrains/PyCharmCE#{version.major_minor}",
+    "~/Library/Application Support/JetBrains/PyCharmCE*",
+    "~/Library/Caches/JetBrains/PyCharmCE*",
+    "~/Library/Logs/JetBrains/PyCharmCE*",
     "~/Library/Preferences/com.jetbrains.pycharm.ce.plist",
     "~/Library/Saved Application State/com.jetbrains.pycharm.ce.savedState",
   ]


### PR DESCRIPTION
-----
Built and tested locally on macOS 26.5.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Used Cursor (AI) to write this PR, it assisted in formatting and following guidelines. Cask was created by forking depreciated "pycharm-ce" and updating cask using "intellij-idea-oss" as reference. Cursor was then used to replicate CI updation behaviour where it encountered new version pycharm 2026.1.2 so it was used to update hash and cask version.
 
Manually verified:
- Download URL and version match the latest stable `pycharm/2026.1.2` release on JetBrains/intellij-community
- `brew audit --cask --new pycharm-oss`, `brew audit --cask --online pycharm-oss`, and `brew style --fix` all pass
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask pycharm-oss` and `brew uninstall --cask pycharm-oss` succeed
- `zap` paths match the `pycharm-ce` cask pattern (`PyCharmCE` support/cache/log dirs and `com.jetbrains.pycharm.ce` preference/saved-state paths)
-----
