### PR TITLE
librecad 2.2.1.5

### DIFF
--- a/Casks/l/librecad.rb
+++ b/Casks/l/librecad.rb
@@ -1,9 +1,9 @@
 cask "librecad" do
   arch arm: "-arm64"
 
-  version "2.2.1.4,2.2.1.3-12-gd1ca469c9"
-  sha256 arm:   "32e50dd71461745d2563224eeab9df0a0a26c5cf99e3b8498937c2e41ce2ec56",
-         intel: "74e4f8c000f55eebe4da0fc10b1a7b6c868ce68918acddc8b8b5ab3ee8486f05"
+  version "2.2.1.5"
+  sha256 arm:   "0c6ce2e25a027ff3e921b74101d1c4e167687d2386fe0798f2f4c37d12deb436",
+         intel: "34369e791af12e414d6e08c0954f679990706215a07b569a8eb7b9a6fa115f38"
 
   url "https://github.com/LibreCAD/LibreCAD/releases/download/v#{version.csv.first}/LibreCAD-v#{version.csv.second || version.csv.first}#{arch}.dmg",
       verified: "github.com/LibreCAD/LibreCAD/"
@@ -13,7 +13,7 @@ cask "librecad" do
 
   livecheck do
     url :url
-    regex(/^LibreCAD[._-]v?(\d+(?:[.-]\d+)+(?:-\w+)?)#{arch}\.dmg$/i)
+    regex(/^LibreCAD[._-]v?(\d+(?:[.-]\d+)+(?:-\d+-g\h+)?)#{arch}\.dmg$/i)
     strategy :github_releases do |json, regex|
       json.map do |release|
         next if release["draft"] || release["prerelease"]


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online librecad` is error-free.
- [x] `brew style --fix librecad` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to help investigate the autobump warning and review the livecheck regex change.

-----

Fixes the autobump warning:

`librecad needs to be manually updated using arch-specific versions`

References:
- https://github.com/Homebrew/homebrew-cask/actions/runs/27460613530
- https://github.com/Homebrew/homebrew-cask/actions/runs/27457124291