### PR TITLE
routeconverter 3.4.1

### DIFF
--- a/Casks/r/routeconverter.rb
+++ b/Casks/r/routeconverter.rb
@@ -1,8 +1,11 @@
 cask "routeconverter" do
-  version "3.4"
-  sha256 "33459efd3381b1baddf1c45d6f44ab907c0727345dd32e51511120d601681227"
+  arch arm: "aarch64", intel: "x64"
 
-  url "https://static.routeconverter.com/download/previous-releases/#{version}/RouteConverterMacOpenSource.app.zip"
+  version "3.4.1"
+  sha256 arm:   "968d1900456306fd5ba0d4adea74db6a0e52b01b975180272902603766ded45d",
+         intel: "e0089f0d0c68542b887e3871df1a55db47777866ff29b5305a9777af3b61b61a"
+
+  url "https://static.routeconverter.com/download/previous-releases/#{version}/RouteConverterMacOpenSource-#{arch}.app.zip"
   name "RouteConverter"
   desc "GPS tool to display, edit, enrich and convert routes, tracks and waypoints"
   homepage "https://www.routeconverter.com/"
@@ -21,6 +24,7 @@ cask "routeconverter" do
 
   zap trash: "~/.routeconverter"
 
+  # The aarch64 zip contains the same Intel app as the x64 zip for now.
   caveats do
     requires_rosetta
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`routeconverter` is autobumped but the workflow failed to update to version 3.4.1 because upstream now publishes arch-specific zip files. Unfortunately, the aarch64 zip contains the same Intel app as the x64 zip. I've updated the cask to use an arch-specific setup but retained the Rosetta caveat on ARM for now. This allows us to update the version and we can remove the Rosetta caveat if/when the aarch64 zip file correctly contains an ARM app in the future.