### PR TITLE
Add pikudclaude 0.3.1

### DIFF
--- a/Casks/p/pikudclaude.rb
+++ b/Casks/p/pikudclaude.rb
@@ -1,0 +1,30 @@
+cask "pikudclaude" do
+  version "0.3.1"
+  sha256 "e850ff658dc2515be71bc4523e0df47ccf2a18950a54300cf9cc05edf1ad54a4"
+
+  url "https://github.com/wmgltd/PikudClaude/releases/download/v#{version}/PikudClaude-#{version}-arm64.dmg",
+      verified: "github.com/wmgltd/PikudClaude/"
+  name "PikudClaude"
+  desc "Multi-session terminal hub for Claude Code with Hebrew/RTL support"
+  homepage "https://pikud.io/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+  depends_on arch: :arm64
+  depends_on formula: "tmux"
+
+  app "PikudClaude.app"
+
+  zap trash: [
+    "~/Library/Application Support/pikudclaude",
+    "~/Library/Caches/com.kobi.pikudclaude",
+    "~/Library/Caches/com.kobi.pikudclaude.ShipIt",
+    "~/Library/Logs/pikudclaude",
+    "~/Library/Preferences/com.kobi.pikudclaude.plist",
+    "~/Library/Saved Application State/com.kobi.pikudclaude.savedState",
+  ]
+end


### PR DESCRIPTION
After making changes:

- [x] `brew style <cask>` reports no offenses.
- [x] The commit message includes the cask's name.

[PikudClaude](https://pikud.io/) is a free, open-source desktop app for orchestrating multiple Claude Code sessions side-by-side, with Hebrew/RTL bidirectional text support that's missing from xterm.js-based terminals (VSCode, Cursor, Hyper, Tabby).

- macOS Apple Silicon only (Intel build not published upstream).
- Requires `tmux` (declared as a formula dependency).
- Signed and notarized by **Web Media Group Digital LTD** (Team ID: MFRGMSVZ67).
- MIT licensed; source: <https://github.com/wmgltd/PikudClaude>.

The `livecheck` stanza watches the GitHub Releases feed so future version bumps can be automated by BrewTestBot.