### PR TITLE
baidunetdisk 8.5.2

### DIFF
--- a/Casks/b/baidunetdisk.rb
+++ b/Casks/b/baidunetdisk.rb
@@ -1,9 +1,9 @@
 cask "baidunetdisk" do
-  arch arm: "_arm64"
+  arch arm: "_arm64", intel: "_x64"
 
-  version "8.3.9"
-  sha256 arm:   "362987e7171046615c5a44f1da1335a90a1673c12055176687eef16c346e743f",
-         intel: "2a44ddf6fb38183d8e4f28826b41298169c9db8ae68a571cafdded57218834f1"
+  version "8.5.2"
+  sha256 arm:   "1150f62e80d450ee96bea7a31aa69d4f2c28fe03e842e22e04bd17897950851a",
+         intel: "34751e73af0d77d45e313ae6799c3b71387701f2cee5f45cf50ec2f8c90cecfe"
 
   url "https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/#{version}/BaiduNetdisk_mac_#{version}#{arch}.dmg"
   name "Baidu NetDisk"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online baidunetdisk` is error-free.
- [x] `brew style --fix baidunetdisk` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Fixes the autobump warning:


`baidunetdisk needs to be manually updated using arch-specific versions`

References:
- https://github.com/Homebrew/homebrew-cask/actions/runs/27484789676
- https://github.com/Homebrew/homebrew-cask/actions/runs/27480112694