### PR TITLE
zmk-studio 0.3.1 (new cask)

### DIFF
--- a/Casks/z/zmk-studio.rb
+++ b/Casks/z/zmk-studio.rb
@@ -1,0 +1,24 @@
+cask "zmk-studio" do
+  version "0.3.1"
+  sha256 "cf397f982f5649255005ca77725c1236a11680e4b3566d6ff11e46139a33489e"
+
+  url "https://github.com/zmkfirmware/zmk-studio/releases/download/v#{version}/ZMK.Studio_#{version}_universal.dmg",
+      verified: "github.com/zmkfirmware/zmk-studio/"
+  name "ZMK Studio"
+  desc "Visual editor for ZMK Firmware keymaps"
+  homepage "https://zmk.studio/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on :macos
+
+  app "ZMK Studio.app"
+
+  zap trash: [
+    "~/Library/Caches/dev.zmk.studio",
+    "~/Library/WebKit/dev.zmk.studio",
+  ]
+end


### PR DESCRIPTION
ZMK Studio is the official GUI keymap editor for ZMK Firmware (zmkfirmware/zmk, 4.1k stars), a widely-used wireless keyboard firmware. The app repo itself has 300 stars /114 forks - well past the notability bar - so it's a little surprising this cask was still missing.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online zmk-studio` is error-free.
- [x] `brew style --fix zmk-studio` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new zmk-studio` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask zmk-studio` worked successfully.
- [x] `brew uninstall --cask zmk-studio` worked successfully.
