### PR TITLE
Add Brave Origin (and variants)

### DIFF
--- a/Casks/b/brave-origin.rb
+++ b/Casks/b/brave-origin.rb
@@ -1,0 +1,37 @@
+cask "brave-origin" do
+  arch arm: "arm64", intel: "x64"
+  folder = on_arch_conditional arm: "stable-arm64", intel: "stable"
+
+  version "1.91.172.0"
+  sha256 arm:   "74bb45d302ae9d0032857140755150542fb1c1892a563ccb582873b3e21fec9b",
+         intel: "41c11ae4ba1008386a50830aaf841ea0f4089f70fe43fc971f4106daf070bc29"
+
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-#{arch}.dmg",
+      verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
+  name "Brave Origin"
+  desc "Get the Web your way: Best-in-class privacy, with just the features you want"
+  homepage "https://brave.com/origin"
+
+  livecheck do
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/#{folder}/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Brave Origin.app"
+
+  zap trash: [
+        "~/Library/Application Support/BraveSoftware/Brave-Origin",
+        "~/Library/Caches/BraveSoftware/Brave-Origin",
+        "~/Library/Caches/com.brave.Browser.origin",
+        "~/Library/HTTPStorages/com.brave.Browser.origin",
+        "~/Library/Preferences/com.brave.Browser.origin.plist",
+        "~/Library/Saved Application State/com.brave.Browser.origin.savedState",
+      ],
+      rmdir: [
+        "~/Library/Application Support/BraveSoftware",
+        "~/Library/Caches/BraveSoftware",
+      ]
+end

--- a/Casks/b/brave-origin.rb
+++ b/Casks/b/brave-origin.rb
@@ -1,19 +1,19 @@
 cask "brave-origin" do
   arch arm: "arm64", intel: "x64"
-  folder = on_arch_conditional arm: "stable-arm64", intel: "stable"
+  folder_arch = on_arch_conditional arm: "-arm64"
 
   version "1.91.172.0"
   sha256 arm:   "74bb45d302ae9d0032857140755150542fb1c1892a563ccb582873b3e21fec9b",
          intel: "41c11ae4ba1008386a50830aaf841ea0f4089f70fe43fc971f4106daf070bc29"
 
-  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-#{arch}.dmg",
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
   name "Brave Origin"
-  desc "Get the Web your way: Best-in-class privacy, with just the features you want"
+  desc "Privacy-focused web browser"
   homepage "https://brave.com/origin"
 
   livecheck do
-    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/#{folder}/appcast.xml"
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/b/brave-origin@beta.rb
+++ b/Casks/b/brave-origin@beta.rb
@@ -1,19 +1,19 @@
 cask "brave-origin@beta" do
   arch arm: "arm64", intel: "x64"
-  folder = on_arch_conditional arm: "beta-arm64", intel: "beta"
+  folder_arch = on_arch_conditional arm: "-arm64"
 
   version "1.92.120.0"
   sha256 arm:   "b76fa675f957cb513f4a8ce4cbcc4c0187c4eabcf5cfa739040d14b3c92cb6be",
          intel: "f1ceaaeebdd937914074d6049ba00028941c4799b389e5480924a1ded30d41f5"
 
-  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Beta-#{arch}.dmg",
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Beta-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
   name "Brave Origin Beta"
-  desc "Get the Web your way: Best-in-class privacy, with just the features you want"
+  desc "Privacy-focused web browser"
   homepage "https://brave.com/origin/#beta"
 
   livecheck do
-    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/#{folder}/appcast.xml"
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/b/brave-origin@beta.rb
+++ b/Casks/b/brave-origin@beta.rb
@@ -6,14 +6,14 @@ cask "brave-origin@beta" do
   sha256 arm:   "b76fa675f957cb513f4a8ce4cbcc4c0187c4eabcf5cfa739040d14b3c92cb6be",
          intel: "f1ceaaeebdd937914074d6049ba00028941c4799b389e5480924a1ded30d41f5"
 
-  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Beta-#{arch}.dmg",
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/beta#{folder_arch}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Beta-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
   name "Brave Origin Beta"
   desc "Privacy-focused web browser"
   homepage "https://brave.com/origin/#beta"
 
   livecheck do
-    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/appcast.xml"
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/beta#{folder_arch}/appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/b/brave-origin@beta.rb
+++ b/Casks/b/brave-origin@beta.rb
@@ -1,0 +1,37 @@
+cask "brave-origin@beta" do
+  arch arm: "arm64", intel: "x64"
+  folder = on_arch_conditional arm: "beta-arm64", intel: "beta"
+
+  version "1.92.120.0"
+  sha256 arm:   "b76fa675f957cb513f4a8ce4cbcc4c0187c4eabcf5cfa739040d14b3c92cb6be",
+         intel: "f1ceaaeebdd937914074d6049ba00028941c4799b389e5480924a1ded30d41f5"
+
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Beta-#{arch}.dmg",
+      verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
+  name "Brave Origin Beta"
+  desc "Get the Web your way: Best-in-class privacy, with just the features you want"
+  homepage "https://brave.com/origin/#beta"
+
+  livecheck do
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/#{folder}/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Brave Origin Beta.app"
+
+  zap trash: [
+        "~/Library/Application Support/BraveSoftware/Brave-Origin-Beta",
+        "~/Library/Caches/BraveSoftware/Brave-Origin-Beta",
+        "~/Library/Caches/com.brave.Browser.origin.beta",
+        "~/Library/HTTPStorages/com.brave.Browser.origin.beta",
+        "~/Library/Preferences/com.brave.Browser.origin.beta.plist",
+        "~/Library/Saved Application State/com.brave.Browser.origin.beta.savedState",
+      ],
+      rmdir: [
+        "~/Library/Application Support/BraveSoftware",
+        "~/Library/Caches/BraveSoftware",
+      ]
+end

--- a/Casks/b/brave-origin@nightly.rb
+++ b/Casks/b/brave-origin@nightly.rb
@@ -1,19 +1,19 @@
 cask "brave-origin@nightly" do
   arch arm: "arm64", intel: "x64"
-  folder = on_arch_conditional arm: "nightly-arm64", intel: "nightly"
+  folder_arch = on_arch_conditional arm: "-arm64"
 
   version "1.93.64.0"
   sha256 arm:   "158301149a85f35ba158607d87815dad6c999ef3df7551a6b534c6d4307f2a2d",
          intel: "cf059d6561cc0a792f3e5f69165ae0fc4635425674c450491366646f47f7b257"
 
-  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Nightly-#{arch}.dmg",
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Nightly-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
   name "Brave Origin Nightly"
-  desc "Get the Web your way: Best-in-class privacy, with just the features you want"
+  desc "Privacy-focused web browser"
   homepage "https://brave.com/origin/#nightly"
 
   livecheck do
-    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/#{folder}/appcast.xml"
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/b/brave-origin@nightly.rb
+++ b/Casks/b/brave-origin@nightly.rb
@@ -6,14 +6,14 @@ cask "brave-origin@nightly" do
   sha256 arm:   "158301149a85f35ba158607d87815dad6c999ef3df7551a6b534c6d4307f2a2d",
          intel: "cf059d6561cc0a792f3e5f69165ae0fc4635425674c450491366646f47f7b257"
 
-  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Nightly-#{arch}.dmg",
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/nightly#{folder_arch}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Nightly-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
   name "Brave Origin Nightly"
   desc "Privacy-focused web browser"
   homepage "https://brave.com/origin/#nightly"
 
   livecheck do
-    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/stable#{folder_arch}/appcast.xml"
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/nightly#{folder_arch}/appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/b/brave-origin@nightly.rb
+++ b/Casks/b/brave-origin@nightly.rb
@@ -1,0 +1,37 @@
+cask "brave-origin@nightly" do
+  arch arm: "arm64", intel: "x64"
+  folder = on_arch_conditional arm: "nightly-arm64", intel: "nightly"
+
+  version "1.93.64.0"
+  sha256 arm:   "158301149a85f35ba158607d87815dad6c999ef3df7551a6b534c6d4307f2a2d",
+         intel: "cf059d6561cc0a792f3e5f69165ae0fc4635425674c450491366646f47f7b257"
+
+  url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Origin/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Origin-Nightly-#{arch}.dmg",
+      verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Origin/"
+  name "Brave Origin Nightly"
+  desc "Get the Web your way: Best-in-class privacy, with just the features you want"
+  homepage "https://brave.com/origin/#nightly"
+
+  livecheck do
+    url "https://updates.bravesoftware.com/sparkle/Brave-Origin/#{folder}/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Brave Origin Nightly.app"
+
+  zap trash: [
+        "~/Library/Application Support/BraveSoftware/Brave-Origin-Nightly",
+        "~/Library/Caches/BraveSoftware/Brave-Origin-Nightly",
+        "~/Library/Caches/com.brave.Browser.origin.nightly",
+        "~/Library/HTTPStorages/com.brave.Browser.origin.nightly",
+        "~/Library/Preferences/com.brave.Browser.origin.nightly.plist",
+        "~/Library/Saved Application State/com.brave.Browser.origin.nightly.savedState",
+      ],
+      rmdir: [
+        "~/Library/Application Support/BraveSoftware",
+        "~/Library/Caches/BraveSoftware",
+      ]
+end


### PR DESCRIPTION
Adds the following casks:

- `brave-origin`
- `brave-origin@beta`
- `brave-origin@nightly`

More info on Brave Origin can be found here: https://brave.com/origin/

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online brave-origin brave-origin@beta brave-origin@nightly` is error-free.
- [x] `brew style --fix brave-origin brave-origin@beta brave-origin@nightly` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new brave-origin brave-origin@beta brave-origin@nightly` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask brave-origin brave-origin@beta brave-origin@nightly` worked successfully.
- [x] `brew uninstall --cask brave-origin brave-origin@beta brave-origin@nightly` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
