### PR TITLE
Add seekfast 7.4

### DIFF
--- a/Casks/s/seekfast.rb
+++ b/Casks/s/seekfast.rb
@@ -1,0 +1,23 @@
+cask "seekfast" do
+  version "7.4"
+  sha256 "446cf92a45b830f802b32e20204b42464aa242b213bec4adc9be400c1e8bb17d"
+
+  url "https://seekfast.org/files_933/SeekFast_#{version}.dmg"
+  name "SeekFast"
+  desc "Search text in documents and files"
+  homepage "https://seekfast.org/"
+
+  livecheck do
+    url "https://seekfast.org/files_933/SeekFastMac_pad.xml"
+    regex(%r{<Program_Version>(\d+(?:\.\d+)+)</Program_Version>}i)
+  end
+
+  depends_on macos: :ventura
+
+  app "SeekFast.app"
+
+  zap trash: [
+    "~/Library/Application Support/SeekFast",
+    "~/Library/Caches/velopack/org.seekfast.SeekFast",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online seekfast` is error-free.
- [x] `brew style --fix seekfast` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new seekfast` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask seekfast` worked successfully.
- [x] `brew uninstall --cask seekfast` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI disclosure: OpenAI Codex assisted with preparing the cask, running local validation commands, and identifying the `zap` paths from the SeekFast source code. I manually verified the public DMG URL, SHA256, and version feed; ran `brew audit --new --online --strict --cask seekfast`, `brew audit --cask --online seekfast`, and `brew style --fix --cask seekfast` locally. `gktool` is not installed on my machine, so Homebrew skipped the app signing audit locally. The install/uninstall checks passed in Homebrew CI on macOS Intel and ARM. The `zap` paths were verified from `Constants.GetAppDataFolder()` (`~/Library/Application Support/SeekFast`) and `MacAutoUpdater.GetMacosPackagesDirectory()` (`~/Library/Caches/velopack/org.seekfast.SeekFast/packages`, covered by zapping `~/Library/Caches/velopack/org.seekfast.SeekFast`).

-----
