### PR TITLE
vorssaint 2.11.0 (new cask)

### DIFF
--- a/Casks/v/vorssaint.rb
+++ b/Casks/v/vorssaint.rb
@@ -1,0 +1,28 @@
+cask "vorssaint" do
+  version "2.11.0"
+  sha256 "22efd620b8659670d990188dcce41a66fd376d06fe991ccd845c568bf73925ed"
+
+  url "https://github.com/vorssaint/vorssaint-utils/releases/download/v#{version}/Vorssaint-#{version}.dmg"
+  name "Vorssaint"
+  desc "Menu bar keep-awake, system monitor and window utilities"
+  homepage "https://github.com/vorssaint/vorssaint-utils"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Vorssaint.app"
+
+  uninstall quit: "com.vorssaint.utils"
+
+  zap trash: [
+    "~/Library/Caches/com.vorssaint.utils",
+    "~/Library/HTTPStorages/com.vorssaint.utils",
+    "~/Library/Preferences/com.vorssaint.utils.plist",
+    "~/Library/Saved Application State/com.vorssaint.utils.savedState",
+  ]
+end


### PR DESCRIPTION
A new cask for Vorssaint, a native macOS menu bar utility (keep-awake, system monitor, volume mixer, window switcher and related tools). The app is Developer ID signed and notarized, and ships its own updater, so `auto_updates true` is set.

- [x] Followed the contributing guidelines and commit-style guide
- [x] Checked there are no other open pull requests for this cask
- [x] `brew style --cask vorssaint` reports no offenses
- [x] Cask token and name match the app (`Vorssaint.app`)
- [x] Submission is for a stable release (2.11.0), not a beta or release candidate
- [ ] `brew audit --new --cask vorssaint` passes

Thanks for maintaining homebrew-cask!
