### PR TITLE
chiri: update bundle id

### DIFF
--- a/Casks/c/chiri.rb
+++ b/Casks/c/chiri.rb
@@ -20,10 +20,10 @@ cask "chiri" do
   app "Chiri.app"
 
   zap trash: [
-    "~/Library/Application Support/moe.sapphic.Chiri",
-    "~/Library/Caches/moe.sapphic.chiri",
-    "~/Library/Logs/moe.sapphic.chiri",
-    "~/Library/Preferences/moe.sapphic.Chiri.plist",
-    "~/Library/WebKit/moe.sapphic.Chiri",
+    "~/Library/Application Support/garden.chiri.Chiri",
+    "~/Library/Caches/garden.chiri.Chiri",
+    "~/Library/Logs/garden.chiri.Chiri",
+    "~/Library/Preferences/garden.chiri.Chiri.plist",
+    "~/Library/WebKit/garden.chiri.Chiri",
   ]
 end


### PR DESCRIPTION
Starting in v0.9.0, Chiri changed the bundle ID from `moe.sapphic.Chiri` to `garden.chiri.Chiri`.

Tested on macOS 26.5.1.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
