### PR TITLE
calendr: add auto_updates and uninstall quit

### DIFF
--- a/Casks/c/calendr.rb
+++ b/Casks/c/calendr.rb
@@ -7,9 +7,12 @@ cask "calendr" do
   desc "Menu bar calendar"
   homepage "https://github.com/pakerwreah/Calendr"
 
+  auto_updates true
   depends_on macos: :sonoma
 
   app "Calendr.app"
+
+  uninstall quit: "br.paker.Calendr"
 
   zap trash: [
     "~/Library/Application Scripts/br.paker.Calendr",


### PR DESCRIPTION
Adds two stanzas to the Calendr cask, mirroring how the WhatsApp cask handles the same situation.

**`auto_updates true`** — Calendr has its own built-in updater that does the full download-and-install (not just a "open the releases page" link). Confirmed in the upstream source, `Calendr/Settings/AutoUpdater.swift`: it fetches the latest GitHub release, downloads the `Calendr.zip` asset, trashes the running app, extracts the new version, and relaunches. Per the Cask Cookbook (`auto_updates`: *"Use if `Check for Updates…` or similar is present in an app menu, but not if it only opens a webpage and does not do the download and installation for you"*), this qualifies.

**`uninstall quit: "br.paker.Calendr"`** — without it, `brew upgrade` replaces `Calendr.app` on disk while the app is running, leaving the (menu-bar) app on the old version until the user manually quits and relaunches it. Quitting it on upgrade lets brew reopen it on the new version. Bundle id taken from the cask's existing `zap` paths (`br.paker.Calendr`).

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online calendr` is error-free.
- [x] `brew style --fix calendr` reports no offenses.

-----

- [x] AI was used to generate or assist with generating this PR.

Diagnosed and written with AI assistance (Claude / Claude Code). **How AI was used:** to investigate why an upgraded Calendr kept running the old version, read the upstream `AutoUpdater.swift` to confirm it genuinely self-installs, and draft the two stanzas. **Manual verification:** confirmed the bundle id `br.paker.Calendr` matches the cask's existing `zap` paths and the app's container/scripts identifiers (the `zap` stanza itself is unchanged); ran `brew style --fix calendr` (clean) and `brew audit --cask --online calendr` (error-free) locally.

-----
