### PR TITLE
pokerth 2.0.8

### DIFF
--- a/Casks/p/pokerth.rb
+++ b/Casks/p/pokerth.rb
@@ -1,8 +1,8 @@
 cask "pokerth" do
-  version "2.0.7"
-  sha256 "00075441262752133b85e62ada78798c12fd945e9a7ae9e8b67a30f55f144f67"
+  version "2.0.8"
+  sha256 "c35ba20313883caac2cce5be6910b3c05f3db5f284f509ff12340d7fc0da07c3"
 
-  url "https://downloads.sourceforge.net/pokerth/PokerTH-#{version}.dmg",
+  url "https://downloads.sourceforge.net/pokerth/PokerTH-Widget-#{version}.dmg",
       verified: "downloads.sourceforge.net/pokerth/"
   name "PokerTH"
   desc "Free Texas hold'em poker"
@@ -12,7 +12,7 @@ cask "pokerth" do
 
   depends_on macos: :monterey
 
-  app "pokerth.app"
+  app "PokerTH.app"
 
   zap trash: "~/.pokerth"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`pokerth` is autobumped but the workflow failed to update to version 2.0.8 because the dmg file name now starts with "PokerTH-Widget-". This updates the version and adjusts the `url` accordingly.