### PR TITLE
open-design 0.10.1 (new cask)

### DIFF
--- a/Casks/o/open-design.rb
+++ b/Casks/o/open-design.rb
@@ -1,0 +1,28 @@
+cask "open-design" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.10.1"
+  sha256 arm:   "138936e9b40621985c13783c8e6a16a680c8191ae1617e97bfacc396b42b5d0a",
+         intel: "5c6e2e76b75fae22e5ce017f8207d8890681d06b074a6ab1d65e4b50e9034fdb"
+
+  url "https://github.com/nexu-io/open-design/releases/download/open-design-v#{version}/open-design-#{version}-mac-#{arch}.dmg",
+      verified: "github.com/nexu-io/open-design/"
+  name "Open Design"
+  desc "Local-first, agent-native design tool"
+  homepage "https://open-design.ai/"
+
+  livecheck do
+    url :url
+    regex(/open-design[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Open Design.app"
+
+  zap trash: [
+    "~/Library/Application Support/Open Design",
+    "~/Library/Preferences/io.open-design.desktop.plist",
+  ]
+end


### PR DESCRIPTION
Adds a cask for [Open Design](https://open-design.ai/) — a local-first, open-source, agent-native design app ([nexu-io/open-design](https://github.com/nexu-io/open-design), Apache-2.0, ~65k★ / ~7.3k forks).

The app is distributed as a notarized DMG (arm64 + x64) built with electron-builder, so it ships its own updater (`auto_updates true`).

### Verification
- `brew audit --new --cask --online open-design` → passes (no offenses)
- `brew style open-design` → passes
- Artifact resolves; DMG checksum verified for both architectures
- App is Developer ID signed **and notarized**:
  - `Authority=Developer ID Application: Wei Huang (236R69AWW2)`
  - `spctl -a -t install` → `accepted / source=Notarized Developer ID`

### Notability
- ~65k stars, ~7.3k forks, active releases (latest 0.10.1, Jun 2026)

---
- [x] Have you followed the guidelines for contributing?
- [x] Have you ensured that your commits follow the commit style guide?
- [x] Have you checked that there aren't other open pull requests for the same change?
- [x] Have you built your cask locally prior to submission with `brew install --cask open-design`?
- [x] Have you ran `brew audit --new --cask open-design`?