### PR TITLE
rockxy 0.27.0,41

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.27.0,40"
-  sha256 "26e74dd156b8cf618d9abd7076e86fbb9e8d4071dbddb035ebab81c0a9a3a155"
+  version "0.27.0,41"
+  sha256 "a6476e9f7ff78e7d2efbb7e92e11474b0b568f5b2a17338ebd559a3cb3dca0d8"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online rockxy` is error-free.
- [x] `brew style --fix rockxy` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the token reference.
- [ ] Checked the cask was not already refused.
- [ ] `brew audit --cask --new rockxy` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask rockxy` worked successfully.
- [ ] `brew uninstall --cask rockxy` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. The assistant updated the cask version and SHA, ran the release/Homebrew verification commands, and checked that the existing `zap` paths are unchanged. The cask diff, version, checksum, download URL, livecheck result, fetch, dry-run install, and CI results were manually reviewed before requesting review.

-----

Updates Rockxy to 0.27.0 build 41.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.27.0/Rockxy-0.27.0-41.dmg
- SHA-256: a6476e9f7ff78e7d2efbb7e92e11474b0b568f5b2a17338ebd559a3cb3dca0d8
- Notarized: true

Additional local checks run:

- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
- `brew lgtm --online`
