### PR TITLE
cc-switch: add auto_updates

### DIFF
--- a/Casks/c/cc-switch.rb
+++ b/Casks/c/cc-switch.rb
@@ -7,6 +7,7 @@ cask "cc-switch" do
   desc "Configuration manager for AI coding agents"
   homepage "https://github.com/farion1231/cc-switch"
 
+  auto_updates true
   depends_on macos: :monterey
 
   app "CC Switch.app"


### PR DESCRIPTION
This cask ships an app with an in-app updater, so mark it with `auto_updates true`.

The upstream Tauri updater endpoint (`latest.json`) downloads and installs update artifacts, and upstream release notes describe the in-app update flow. Without the stanza, Homebrew continues to treat the cask receipt version as authoritative after an in-app update, so `brew outdated` can report `cc-switch` as outdated even when the app bundle is already current.

Checks:
- [x] `HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew style --fix homebrew/cask/cc-switch`
- [x] `HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --cask --online homebrew/cask/cc-switch`