### PR TITLE
klayout: use arm64 package on Tahoe

### DIFF
--- a/Casks/k/klayout.rb
+++ b/Casks/k/klayout.rb
@@ -50,7 +50,7 @@ cask "klayout" do
       regex(/href=.*?HW[._-]klayout[._-](\d+(?:\.\d+)+)[._-]macOS[._-]Sonoma.*?\.dmg/i)
     end
   end
-  on_sequoia :or_newer do
+  on_sequoia do
     version "0.30.9"
     sha256 "73fcd98f74b563f232e1eae9866bc52957b0d198f02a4570e77f4c9be05d89c5"
 
@@ -60,6 +60,32 @@ cask "klayout" do
     livecheck do
       url "https://www.klayout.de/build.html"
       regex(/href=.*?HW[._-]klayout[._-](\d+(?:\.\d+)+)[._-]macOS[._-]Sequoia.*?\.dmg/i)
+    end
+  end
+  on_tahoe :or_newer do
+    on_arm do
+      version "0.30.9"
+      sha256 "5b2807b2e522760535a84fb83828de768995c9b68914b75be14c961d1ea0bc49"
+
+      url "https://www.klayout.org/downloads/MacOS/ARM64/arm64ST-klayout-#{version}-macOS-Tahoe-1-qt5MP-RsysPsys.dmg",
+          verified: "klayout.org/downloads/MacOS/ARM64/"
+
+      livecheck do
+        url "https://www.klayout.de/build.html"
+        regex(/href=.*?arm64ST[._-]klayout[._-](\d+(?:\.\d+)+)[._-]macOS[._-]Tahoe.*?\.dmg/i)
+      end
+    end
+    on_intel do
+      version "0.30.9"
+      sha256 "73fcd98f74b563f232e1eae9866bc52957b0d198f02a4570e77f4c9be05d89c5"
+
+      url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Sequoia-1-qt5MP-RsysPhb311.dmg",
+          verified: "klayout.org/downloads/MacOS/"
+
+      livecheck do
+        url "https://www.klayout.de/build.html"
+        regex(/href=.*?HW[._-]klayout[._-](\d+(?:\.\d+)+)[._-]macOS[._-]Sequoia.*?\.dmg/i)
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds the upstream arm64ST package for Apple Silicon macOS Tahoe.

Previously, the cask used the Sequoia HW package under `on_sequoia :or_newer`, so Apple Silicon Tahoe users received the x86_64 Sequoia package.

Upstream provides a dedicated native ARM64 package for macOS Tahoe 26.1+. This PR uses that package only for `on_tahoe :or_newer` on Apple Silicon, while leaving the existing x86_64 Sequoia/Sonoma package choices unchanged.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to help identify the appropriate cask stanza changes, draft the PR description, and interpret local command output.

-----

I manually verified the upstream download URL, checksum, local installation, binary architecture, and Homebrew checks.

Manual verification performed:

```sh
brew style --fix homebrew/cask/klayout
brew audit --cask --online klayout
brew install --cask ./Casks/k/klayout.rb
file /Applications/KLayout/klayout.app/Contents/MacOS/klayout
```

The installed binary was verified as:
```text
/Applications/KLayout/klayout.app/Contents/MacOS/klayout: Mach-O 64-bit executable arm64
```

The upstream MD5 checksum for the downloaded DMG was verified as:
```text
cf824dbb0b333af26db6697e816626f2
```

The SHA-256 checksum used in this cask is:
```text
5b2807b2e522760535a84fb83828de768995c9b68914b75be14c961d1ea0bc49
```

This PR does not change the existing zap stanza:
```ruby
zap trash: "~/.klayout"
```
