### PR TITLE
openemu-silicon 1.2.3 (new cask)

### DIFF
--- a/Casks/o/openemu-silicon.rb
+++ b/Casks/o/openemu-silicon.rb
@@ -1,0 +1,29 @@
+cask "openemu-silicon" do
+  version "1.2.3"
+  sha256 "cbc9169e131a37abcee7dad4558e1f43990678b9b3603ea4f23d54f4467768cc"
+
+  url "https://github.com/nickybmon/OpenEmu-Silicon/releases/download/v#{version}/OpenEmu-Silicon.dmg"
+  name "OpenEmu Silicon"
+  desc "Native Apple Silicon port of the OpenEmu multi-system emulator"
+  homepage "https://github.com/nickybmon/OpenEmu-Silicon"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/nickybmon/OpenEmu-Silicon/main/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "OpenEmu.app"
+
+  zap trash: [
+    "~/Library/Application Support/OpenEmu",
+    "~/Library/Application Support/org.openemu.OEXPCCAgent.Agents",
+    "~/Library/Caches/org.openemu.OpenEmu",
+    "~/Library/HTTPStorages/org.openemu.OpenEmu",
+    "~/Library/HTTPStorages/org.openemu.OpenEmu.binarycookies",
+    "~/Library/Preferences/org.openemu.OpenEmu.plist",
+    "~/Library/Saved Application State/org.openemu.OpenEmu.savedState",
+  ]
+end


### PR DESCRIPTION
## openemu-silicon 1.2.3 (new cask)

Resubmission of #262213, which was closed pending the GitHub notability audit. The repo has since grown past the self-submission stars threshold (225) — currently at 250 stars — and `brew audit --cask --new --online` now passes cleanly.

### What is this?

OpenEmu Silicon is a native Apple Silicon port of [OpenEmu](https://github.com/OpenEmu/OpenEmu), the macOS multi-system emulator. The existing `openemu` cask ships an Intel-only binary that requires Rosetta 2 and is deprecated. This cask provides the ARM64-native replacement.

### Verification

- [x] `brew audit --cask --new --online openemu-silicon` — 0 problems
- [x] `brew style openemu-silicon` — 0 offenses
- [x] `brew livecheck openemu-silicon` — resolves `1.2.3` against the Sparkle appcast
- [x] SHA256 verified against the downloaded DMG
- [x] App bundle name (`OpenEmu.app`) and bundle ID (`org.openemu.OpenEmu`) confirmed from the DMG
- [x] `LSMinimumSystemVersion: 11.0` matches `depends_on macos: :big_sur`
- [x] Gatekeeper: notarized Developer ID
- [x] App launches and runs on macOS 15 (Sequoia) on Apple Silicon

### Notability (vs. prior PR)

| | Then (#262213) | Now |
|---|---:|---:|
| Stars | 121 | 250 |
| Self-submission threshold | 225 | 225 |
| Audit result | fails notability | passes |

### Notes

- `auto_updates true` — the app uses Sparkle for in-app updates
- `livecheck` uses the Sparkle appcast strategy against the project's `appcast.xml`
- `zap` stanza covers all known data paths for bundle ID `org.openemu.OpenEmu`
- Repo: https://github.com/nickybmon/OpenEmu-Silicon