### PR TITLE
greensignal 1.0.0 (new cask)

### DIFF
--- a/Casks/g/greensignal.rb
+++ b/Casks/g/greensignal.rb
@@ -1,0 +1,24 @@
+cask "greensignal" do
+  version "1.0.0"
+  sha256 :no_check
+
+  url "https://releases.greensignal.app/latest/GreenSignal-latest.dmg",
+      verified: "releases.greensignal.app/"
+  name "GreenSignal"
+  desc "Pre-call check for camera, microphone, speaker, and network quality"
+  homepage "https://mutedeck.com/tools/greensignal"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  depends_on macos: :sonoma
+
+  app "GreenSignal.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/app.greensignal.app",
+    "~/Library/Containers/app.greensignal.app",
+  ]
+end

--- a/Casks/g/greensignal.rb
+++ b/Casks/g/greensignal.rb
@@ -1,16 +1,16 @@
 cask "greensignal" do
-  version "1.0.0"
-  sha256 :no_check
+  version "1.0.2"
+  sha256 "630614bcee392247a6ab127a4fc18f2ea2d589f139b6479da48b30cdb45e8d32"
 
-  url "https://releases.greensignal.app/latest/GreenSignal-latest.dmg",
+  url "https://releases.greensignal.app/releases/v#{version}/GreenSignal_#{version}_universal.dmg",
       verified: "releases.greensignal.app/"
   name "GreenSignal"
   desc "Pre-call check for camera, microphone, speaker, and network quality"
   homepage "https://mutedeck.com/tools/greensignal"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url :homepage
+    regex(/href=.*?GreenSignal[._-]v?(\d+(?:\.\d+)+)[._-]universal\.dmg/i)
   end
 
   depends_on macos: :sonoma


### PR DESCRIPTION
Built and tested locally on macOS 26.6.

GreenSignal is a free pre-call check by MuteDeck that verifies camera, microphone, speaker, and network quality before video calls.

---

- [x] Submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions).
- [x] `brew audit --cask --new greensignal` is error-free.
- [x] `brew style --fix greensignal` reports no offenses.
- [x] Named according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew install --cask greensignal` worked successfully.
- [x] `brew uninstall --cask greensignal` worked successfully.

AI-assisted with Claude Code: cask was drafted and all checks (audit, style, install, launch, `uninstall --zap`) were run locally. The `zap` paths were personally verified by launching the app and confirming `~/Library/Containers/app.greensignal.app` and `~/Library/Application Scripts/app.greensignal.app` are the only traces left and are fully removed.
