### PR TITLE
macmediakeyforwarder 4.0.0

### DIFF
--- a/Casks/m/macmediakeyforwarder.rb
+++ b/Casks/m/macmediakeyforwarder.rb
@@ -7,11 +7,6 @@ cask "macmediakeyforwarder" do
   desc "Media key forwarder for Apple Music and Spotify"
   homepage "https://github.com/quentinlesceller/macmediakeyforwarder/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   depends_on macos: :tahoe
 
   app "MacMediaKeyForwarder.app"

--- a/Casks/m/macmediakeyforwarder.rb
+++ b/Casks/m/macmediakeyforwarder.rb
@@ -1,17 +1,23 @@
 cask "macmediakeyforwarder" do
-  version "3.1.2"
-  sha256 "3e2c8ae7fbc9190e9c7528a3c4799ae42e6a33ddaf27f5cf01e141a0b9d6cd04"
+  version "4.0.0"
+  sha256 "2646853c124f2c46f294334144569fff628fad829346f4f1a39ad1b5d3189f23"
 
-  url "https://github.com/quentinlesceller/macmediakeyforwarder/releases/download/v#{version}/MacMediaKeyForwarder.zip"
+  url "https://github.com/quentinlesceller/macmediakeyforwarder/releases/download/v#{version}/MacMediaKeyForwarder.dmg"
   name "Mac Media Key Forwarder"
-  desc "Media key forwarder for iTunes and Spotify"
+  desc "Media key forwarder for Apple Music and Spotify"
   homepage "https://github.com/quentinlesceller/macmediakeyforwarder/"
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
-  depends_on :macos
+  depends_on macos: :tahoe
 
   app "MacMediaKeyForwarder.app"
 
-  zap trash: "~/Library/Preferences/com.milgra.hsmke.plist"
+  zap trash: [
+    "~/Library/Preferences/com.milgra.hsmke.plist",
+    "~/Library/Preferences/com.quentinlesceller.macmediakeyforwarder.plist",
+  ]
 end


### PR DESCRIPTION
Update `macmediakeyforwarder` to 4.0.0 and revive it from its disabled state.

The cask was disabled with `:fails_gatekeeper_check`. Version 4.0.0 is rewritten in Swift, is signed with a Developer ID and **notarized** by Apple, so it now passes Gatekeeper. Verified locally:

```
spctl -a -vvv /Applications/MacMediaKeyForwarder.app
# accepted
# source=Notarized Developer ID
# origin=Developer ID Application: Quentin Le Sceller (9K3SQ64X5H)
```

Changes:
- `version` 3.1.2 -> 4.0.0, updated `sha256`
- artifact is now a `.dmg` instead of a `.zip`
- removed the `disable! :fails_gatekeeper_check` stanza (now notarized)
- `depends_on macos: :tahoe` (4.0.0 requires macOS Tahoe)
- updated `desc` (iTunes -> Apple Music)
- `zap` now trashes both the old and the new preference plist (the bundle id changed)

- [x] `brew audit --cask --online macmediakeyforwarder` passes
- [x] `brew style --cask macmediakeyforwarder` passes
- [x] `brew install --cask macmediakeyforwarder` installs and the app passes Gatekeeper

Release: https://github.com/quentinlesceller/macmediakeyforwarder/releases/tag/v4.0.0