### PR TITLE
codex: use bare release asset

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -3,12 +3,12 @@ cask "codex" do
   os macos: "apple-darwin", linux: "unknown-linux-musl"
 
   version "0.140.0"
-  sha256 arm:          "96882725b0f467c3ef09a93b80aec2a812955a50e27032ce6b7e6c04902719a0",
-         intel:        "45b291141b49ccaecf0f20e90b53d73bdfa67e7454e4a7329a959d5ceb029b17",
-         arm64_linux:  "94249b314da9b75b275bfb929e7d5a8e48750a718745dd5f6def26313899b4d6",
-         x86_64_linux: "9620e798900c6fb289199a9e0a8ed0c3a8cb7e3561048498ebc2dac354a1627b"
+  sha256 arm:          "c81eaf1b4c9aee0e81e2b39dec1742a57b61be6c109f8811e7fcd41f55c2233d",
+         intel:        "2bd0edf75fd1451425736bae41470c3b800fe8eb372c194a668434f9526df9f0",
+         arm64_linux:  "ec6c804d415e42dd28cc6f8c6cb5238b00c9af4bfb58b63be55e26ec4ee576c0",
+         x86_64_linux: "48e591964d4bbaab7c0433daed41c65ea8f152fc0f1dd2334a42e3dd322a4906"
 
-  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-package-#{arch}-#{os}.tar.gz"
+  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-#{arch}-#{os}.tar.gz"
   name "Codex"
   desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
@@ -21,9 +21,9 @@ cask "codex" do
 
   depends_on formula: "ripgrep"
 
-  binary "bin/codex"
+  binary "codex-#{arch}-#{os}", target: "codex"
 
-  generate_completions_from_executable "bin/codex", "completion"
+  generate_completions_from_executable "codex-#{arch}-#{os}", "completion", base_name: "codex"
 
   zap rmdir: "~/.codex"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

### What is included

This PR revert the changes from https://github.com/Homebrew/homebrew-cask/pull/268453/ which point homebrew cask to a different release asset. The updated release assets included additional packaged content but not yet signed by OpenAI which is causing installation issues for end consumers. Reverting the release asset change as we improve on signing all artifacts that we are bundling.

