### PR TITLE
fix: Remove www for urls in makemkv cask

### DIFF
--- a/Casks/m/makemkv.rb
+++ b/Casks/m/makemkv.rb
@@ -2,13 +2,13 @@ cask "makemkv" do
   version "1.18.4"
   sha256 "b77de54fffe4bd8dfdb498bed15a44cf4ca2002c3f86e9184faf8407b2486166"
 
-  url "https://www.makemkv.com/download/makemkv_v#{version}_osx.dmg"
+  url "https://makemkv.com/download/makemkv_v#{version}_osx.dmg"
   name "MakeMKV"
   desc "Video format converter (transcoder)"
-  homepage "https://www.makemkv.com/"
+  homepage "https://makemkv.com/"
 
   livecheck do
-    url "https://www.makemkv.com/download/"
+    url "https://makemkv.com/download/"
     regex(%r{href=.*?/makemkv[._-]v?(\d+(?:\.\d+)+)[._-]osx\.dmg}i)
   end
 


### PR DESCRIPTION
This is not for a new cask, it is fixing the url in an existing one.

fixes #269960

`brew audit` errors out for me as I manage all my homebrew stuff with Nix. 

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
