### PR TITLE
corretto 26.0.1.8.1

### DIFF
--- a/Casks/c/corretto.rb
+++ b/Casks/c/corretto.rb
@@ -1,9 +1,9 @@
 cask "corretto" do
   arch arm: "aarch64", intel: "x64"
 
-  version "25.0.3.9.1"
-  sha256 arm:   "f4fccb2f96f979f848c133091f9624fb0dfdd97ba34318f2ab8cab568591fc58",
-         intel: "4181f9b02d461d1e321ed651f92b9685444aa2ccbf434ea5fe9d15c7e57129ae"
+  version "26.0.1.8.1"
+  sha256 arm:   "4a3e3ad5ebc26f444c802b3becef4ef9af5381cf07ba60fed0989cfd8e37a8c1",
+         intel: "f96af9827487c77c03871ff711fb7726e897fb42c3abd8b53bf830e020615dfe"
 
   url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "AWS Corretto JDK"


### PR DESCRIPTION
Promotes the rolling `corretto` cask to the new general-availability release, **Amazon Corretto 26** (`26.0.1.8.1`, released 2026-04-22).

Corretto 26 is now the latest release line, superseding 25. The previous line is retained by the existing `corretto@25` cask, so users who want to stay on 25 are unaffected.

This is a major-version promotion rather than a routine patch bump: the `livecheck` block is scoped to `version.major`, so BrewTestBot's autobump only tracks the latest *25.x* and will not cross the major boundary on its own (the same was true for the previous 24 → 25 promotion, which was also a manual PR). Bumping `version` to `26.x` also moves `livecheck`, the `pkg` filename, and the `uninstall pkgutil:` id to the 26 line automatically.

- `brew style Casks/c/corretto.rb` — passes
- `brew audit --cask --online corretto` — passes (checksums verified against the live downloads for both arm64 and x64)

- [x] Have you followed the [guidelines for contributing](https://docs.brew.sh/Adding-Software-to-Homebrew)?
- [x] Have you ensured that your commits follow the [commit message conventions](https://docs.brew.sh/Adding-Software-to-Homebrew#commit-messages)?
- [x] Have you checked that there aren't other open pull requests for the same change?
- [x] Have you built your code locally with `brew audit --cask --online` and `brew style`?