### PR TITLE
rockxy 0.27.1,42

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.27.0,41"
-  sha256 "a6476e9f7ff78e7d2efbb7e92e11474b0b568f5b2a17338ebd559a3cb3dca0d8"
+  version "0.27.1,42"
+  sha256 "00fee314b9859093c078d3d6a765eb339940951bf2194e1fd3274e42e86e337e"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online rockxy` is error-free.
- [x] `brew style --fix rockxy` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the token reference.
- [ ] Checked the cask was not already refused.
- [ ] `brew audit --cask --new rockxy` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask rockxy` worked successfully.
- [ ] `brew uninstall --cask rockxy` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. The assistant updated the cask version and SHA, ran the release/Homebrew verification commands, and checked that the existing `zap` paths are unchanged. The cask diff, version, checksum, download URL, livecheck result, fetch, dry-run install, and CI results were manually reviewed before requesting review.

-----

Updates Rockxy to 0.27.1 build 42.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.27.1/Rockxy-0.27.1-42.dmg
- SHA-256: 00fee314b9859093c078d3d6a765eb339940951bf2194e1fd3274e42e86e337e
- Notarized: true

Additional local checks run:

- `brew fetch --cask rockxy --force`
- `brew install --dry-run --cask rockxy`
- `brew lgtm --online`
