### PR TITLE
adrive 6.9.1

### DIFF
--- a/Casks/a/adrive.rb
+++ b/Casks/a/adrive.rb
@@ -1,9 +1,13 @@
 cask "adrive" do
   arch arm: "-arm64"
 
-  version "6.9.0"
-  sha256 arm:   "d34b82b8200fcd291fa3713daf6e98b8f4ac8731f3ca9d7a94dc5b8de9e819af",
-         intel: "b7bf89688504c5a18bc9bf96c03aaa8e48b5cb557647fe780f68e780a1fda60b"
+  version "6.9.1"
+  sha256 arm:   "c01303f9a45e47d49d0dc551745ff22a38aa4b20147f31e5ce50adc91d8f2479",
+         intel: "13159c91858923d06c01697ea4ab4dc7a51bc77a54f61f1374441364f060e974"
+
+  on_intel do
+    disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  end
 
   url "https://cdn.aliyundrive.net/downloads/apps/desktop/aDrive-#{version}#{arch}.dmg",
       verified:   "cdn.aliyundrive.net/",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online adrive` is error-free.
- [x] `brew style --fix adrive` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

In a bump-cask job, I noticed that `adrive` was not up to date.
`==> adrive`
`Current cask version:     6.9.0`
`Latest livecheck version: 6.9.1`
`Duplicate pull requests:  adrive 6.9.1 (https://github.com/Homebrew/homebrew-cask/pull/240055)`

I checked the previous BrewTestBot PR and found that it had been closed after the Gatekeeper check failed on Intel macOS.

This PR disables Gatekeeper verification for adrive so the cask can be bumped to the latest version.

References:
- https://github.com/Homebrew/homebrew-cask/pull/240055
- https://github.com/Homebrew/homebrew-cask/actions/runs/20069678580