### PR TITLE
algoapp 13.1.2

### DIFF
--- a/Casks/a/algoapp.rb
+++ b/Casks/a/algoapp.rb
@@ -1,5 +1,5 @@
 cask "algoapp" do
-  version "13.1.1"
+  version "13.1.2"
   sha256 :no_check
 
   url "https://static.algoapp.ai/AlgoApp-MacOS.zip"

--- a/Casks/a/algoapp.rb
+++ b/Casks/a/algoapp.rb
@@ -1,19 +1,19 @@
 cask "algoapp" do
-  version "11.2.2"
-  sha256 "6500ce0268d010774248cc15dabd3e1ff326e953dc6458bf476a2ad5d894c174"
+  version "13.1.1"
+  sha256 :no_check
 
-  url "https://updates.ankiapp.com/AlgoApp-#{version}-universal.dmg"
+  url "https://static.algoapp.ai/AlgoApp-MacOS.zip"
   name "AlgoApp"
   desc "Spaced Repetition Flashcard App"
-  homepage "https://www.ankiapp.com/"
+  homepage "https://www.algoapp.ai/"
 
   livecheck do
-    url "https://updates.ankiapp.com/latest-mac.yml"
-    strategy :electron_builder
+    # The app checks https://updates.algoapp.ai/latest-mac.yml but it currently returns 404.
+    url :url
+    strategy :extract_plist
   end
 
-  auto_updates true
-  depends_on :macos
+  depends_on macos: :monterey
 
   app "AlgoApp.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online algoapp` is error-free.
- [x] `brew style --fix algoapp` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The previous livecheck URL for algoapp no longer works.

https://updates.ankiapp.com/latest-mac.yml now returns 404, so livecheck cannot retrieve a version:


`==> algoapp`
`Current cask version:     11.2.2`
`Latest livecheck version: unable to get versions`

The upstream site has moved from ankiapp.com to algoapp.ai, and the current macOS download is provided zip url:
 
https://static.algoapp.ai/AlgoApp-MacOS.zip

Since no working update feed or versioned download URL appears to be available, this updates the cask to use strategy :extract_plist and read the version from the app bundle's Info.plist


References:
- https://github.com/Homebrew/homebrew-cask/actions/runs/27659722806/job/81801429600
- https://github.com/Homebrew/homebrew-cask/actions/runs/27667067691/job/81823166897