### PR TITLE
Add syv-ai-dash 0.11.3 (new cask)

### DIFF
--- a/Casks/s/syv-ai-dash.rb
+++ b/Casks/s/syv-ai-dash.rb
@@ -1,0 +1,21 @@
+cask "syv-ai-dash" do
+  version "0.11.3"
+  sha256 "2939042a58173c4f4061a17cb6ee14f9392ecec002f1032da56f8c1d36c59b3b"
+
+  url "https://github.com/syv-ai/dash/releases/download/v#{version}/Dash-#{version}-mac-arm64.dmg"
+  name "Dash"
+  desc "Run Claude Code across multiple projects in isolated git worktrees"
+  homepage "https://github.com/syv-ai/dash"
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :catalina
+
+  app "Dash.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.syv.dash.sfl*",
+    "~/Library/Application Support/Dash",
+    "~/Library/Preferences/com.syv.dash.plist",
+  ]
+end


### PR DESCRIPTION
A new cask for [Dash](https://github.com/syv-ai/dash) by syv.ai, a macOS desktop app that runs Claude Code across multiple projects and tasks, each in its own isolated git worktree and branch.

The token is `syv-ai-dash` (vendor-prefixed) rather than `dash`, because the `dash` token is already in use by Kapeli's Dash (API documentation browser). The vendor-prefixed form follows the naming convention for conflicting names.

### Details
- Upstream: https://github.com/syv-ai/dash (276+ stars)
- Distributed as a signed + notarized `.dmg` via GitHub Releases (`Developer ID Application: syv.ai ApS (2DD8ZKZ975)`; Gatekeeper reports `source=Notarized Developer ID`)
- macOS build is arm64-only (the project ships no Intel Mac artifact), hence `depends_on arch: :arm64`
- Minimum macOS is 10.15 (Catalina) per the app's `LSMinimumSystemVersion`
- The app self-updates via `electron-updater`, hence `auto_updates true`

### Verification
- [x] `brew audit --new --cask syv-ai-dash` passes
- [x] `brew style syv-ai-dash` passes
- [x] `brew install --cask syv-ai-dash` installs and launches; `brew uninstall --cask syv-ai-dash` removes cleanly
- [x] Checked there are no other open PRs for this cask
