### PR TITLE
agentsview: update livecheck and url

### DIFF
--- a/Casks/a/agentsview.rb
+++ b/Casks/a/agentsview.rb
@@ -16,15 +16,29 @@ cask "agentsview" do
 
   url_end = on_system_conditional linux: ".AppImage", macos: ".dmg"
 
-  url "https://github.com/wesm/agentsview/releases/download/v#{version}/AgentsView_#{version}_#{arch}#{url_end}",
-      verified: "github.com/wesm/agentsview/"
+  url "https://github.com/kenn-io/agentsview/releases/download/v#{version}/AgentsView_#{version}_#{arch}#{url_end}",
+      verified: "github.com/kenn-io/agentsview/"
   name "AgentsView"
   desc "Browse, search and analyse your past AI coding sessions"
   homepage "https://www.agentsview.io/"
 
+  # Not every release on GitHub provides assets for the app, so we have to find
+  # the newest one with the files the cask uses.
   livecheck do
     url :url
-    strategy :github_latest
+    regex(%r{/AgentsView[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}#{url_end}}i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next unless match
+
+          match[1]
+        end
+      end.flatten
+    end
   end
 
   on_macos do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

I used a local model to help with the livecheck, but then modified it by hand to clean up.

First, I updated the main application URL since it's been moved to a new repository under the same owner.

Second, the latest release `(0.33.1)` does not contain either an application bundle for macOS or for Linux.  It includes `.tar.gz` files which unpack into a binary.

The changes for the `livecheck` attempt to identify proper releases for both Linux and macOS.  If there's a split in versioning in the future, we may need to make adjustments.