### PR TITLE
kde-connect 26.04.2 (new cask)

### DIFF
--- a/Casks/k/kde-connect.rb
+++ b/Casks/k/kde-connect.rb
@@ -1,0 +1,31 @@
+cask "kde-connect" do
+  version "26.04.2"
+  sha256 "e2be426417eb55ff9a4bcdf959d05c74751a2b83240a2368b5645aef4252d718"
+
+  url "https://download.kde.org/stable/release-service/#{version}/macos/kdeconnect-kde-macos-clang-arm64.dmg"
+  name "KDE Connect"
+  desc "Communicate with your handheld devices"
+  homepage "https://kdeconnect.kde.org/"
+
+  livecheck do
+    url "https://kdeconnect.kde.org/download.html"
+    regex(%r{href=.*?release-service/(\d+(?:\.\d+)+)(?:/macos/kdeconnect-kde-macos-clang-arm64.dmg)}i)
+  end
+
+  depends_on macos: :ventura, arch: :arm64
+
+  app "KDE Connect.app"
+  binary "#{appdir}/KDE Connect.app/Contents/MacOS/kdeconnect-cli",
+         target: "kdeconnect"
+
+  uninstall quit: "org.kde.kdeconnect"
+
+  zap trash: [
+    "~/Library/Application Support/kdeconnect.app",
+    "~/Library/Application Support/kpeoplevcard/kdeconnect*",
+    "~/Library/Caches/kdeconnect*",
+    "~/Library/Preferences/kdeconnect",
+    "~/Library/Preferences/org.kde.kdeconnect.plist",
+    "~/Library/Preferences/State/kdeconnect.appstaterc",
+  ]
+end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field). [1]
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Crafted the livecheck regex with assistance from Gemini.
-----

Previously PRs with the nightlies were rejected. This is the [first stable macOS release](https://invent.kde.org/network/kdeconnect-kde/-/work_items/40#note_1525174).
