### PR TITLE
llama-app: fix quit bundle identifier

### DIFF
--- a/Casks/l/llama-app.rb
+++ b/Casks/l/llama-app.rb
@@ -13,7 +13,7 @@ cask "llama-app" do
 
   app "Llama.app"
 
-  uninstall quit: "app.llamabarn.LlamaBarn"
+  uninstall quit: "app.llama.Llama"
 
   zap trash: [
     "~/.llama-app",


### PR DESCRIPTION
The cask installs `Llama.app` (bundle id `app.llama.Llama`), but the `uninstall quit:` stanza still referenced the pre-rename id `app.llamabarn.LlamaBarn`. As a result the running app isn't quit on `brew upgrade`/`reinstall`/`uninstall`. Corrected to `app.llama.Llama`.