### PR TITLE
burp-suite 2026.4.3

### DIFF
--- a/Casks/b/burp-suite.rb
+++ b/Casks/b/burp-suite.rb
@@ -1,11 +1,11 @@
 cask "burp-suite" do
   arch arm: "MacOsArm64", intel: "MacOsx"
 
-  version "2026.3.3"
-  sha256 arm:   "d9f0bc695e9b13554c013631c05e3a82c6bda6b7e573b0d606eea22342ef8bd0",
-         intel: "380723f86be65bed4c8645adae9badcb817aca7061be652014483f437879cf8c"
+  version "2026.4.3"
+  sha256 arm:   "86e8eda2e6ebfd2d7c5ff34bb82bf4872f814cd27beb90535460a37c892c80c2",
+         intel: "8919a177167f0230eb25b0226ffbd6b3de49549a4a33d2ce2c38e2df84d937b9"
 
-  url "https://portswigger-cdn.net/burp/releases/download?product=community&version=#{version}&type=#{arch}",
+  url "https://portswigger-cdn.net/burp/releases/download?product=desktop&version=#{version}&type=#{arch}",
       verified: "portswigger-cdn.net/burp/releases/"
   name "Burp Suite Community Edition"
   desc "Web security testing toolkit"
@@ -20,9 +20,9 @@ cask "burp-suite" do
       all_versions.filter_map do |item|
         item["version"] if
               item["releaseChannels"]&.include?("Stable") &&
-              item["categories"]&.include?("Community") &&
+              item["categories"]&.include?("Desktop") &&
               item["builds"]&.any? do |build|
-                build["BuildCategoryId"] == "community" &&
+                build["BuildCategoryId"] == "desktop" &&
                 build["BuildCategoryPlatform"] == arch.to_s
               end
       end
@@ -32,7 +32,7 @@ cask "burp-suite" do
   conflicts_with cask: "burp-suite@early-adopter"
   depends_on :macos
 
-  app "Burp Suite Community Edition.app"
+  app "Burp Suite.app"
 
   zap trash: "~/.BurpSuite"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online burp-suite` is error-free.
- [x] `brew style --fix burp-suite` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

livecheck/url/app stanza investigation assisted by AI; verified audit/style locally.

-----

Related https://github.com/Homebrew/homebrew-cask/issues/270304