### PR TITLE
burp-suite@early-adopter 2026.6

### DIFF
--- a/Casks/b/burp-suite@early-adopter.rb
+++ b/Casks/b/burp-suite@early-adopter.rb
@@ -1,11 +1,11 @@
 cask "burp-suite@early-adopter" do
   arch arm: "MacOsArm64", intel: "MacOsx"
 
-  version "2026.3.1"
-  sha256 arm:   "c0797b36873456bc6e28b2865e7d9f9c7cea091f0638e85ebbced71287966427",
-         intel: "63d2382254e278d431eb85f38f0872803838479ae72c46274785999d5cc0cc3a"
+  version "2026.6"
+  sha256 arm:   "709a014d0398da2b840a200418e0dfe51fcfb1fb70d44ebf1465973c84e17f8b",
+         intel: "3b71b4ba81de250c5589381a8f8708d5985414d49e25c0ffd4cb1e315d4ae545"
 
-  url "https://portswigger-cdn.net/burp/releases/download?product=community&version=#{version}&type=#{arch}",
+  url "https://portswigger-cdn.net/burp/releases/download?product=desktop&version=#{version}&type=#{arch}",
       verified: "portswigger-cdn.net/burp/releases/"
   name "Burp Suite Community Edition"
   desc "Web security testing toolkit"
@@ -20,9 +20,9 @@ cask "burp-suite@early-adopter" do
       all_versions.filter_map do |item|
         item["version"] if
               item["releaseChannels"]&.include?("Early Adopter") &&
-              item["categories"]&.include?("Community") &&
+              item["categories"]&.include?("Desktop") &&
               item["builds"]&.any? do |build|
-                build["BuildCategoryId"] == "community" &&
+                build["BuildCategoryId"] == "desktop" &&
                 build["BuildCategoryPlatform"] == arch.to_s
               end
       end
@@ -32,7 +32,7 @@ cask "burp-suite@early-adopter" do
   conflicts_with cask: "burp-suite"
   depends_on :macos
 
-  app "Burp Suite Community Edition.app"
+  app "Burp Suite.app"
 
   zap trash: "~/.BurpSuite"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online burp-suite@early-adopter` is error-free.
- [x] `brew style --fix burp-suite@early-adopter` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

livecheck/url/app stanza investigation assisted by AI; verified audit/style locally.

-----

Related https://github.com/Homebrew/homebrew-cask/issues/270304