### PR TITLE
Add ml-job-swarm 0.2.1

### DIFF
--- a/Casks/m/ml-job-swarm.rb
+++ b/Casks/m/ml-job-swarm.rb
@@ -1,0 +1,29 @@
+cask "ml-job-swarm" do
+  version "0.2.1"
+  sha256 "561daabe5f8baa0cd8596e28bd986bfcd377882353c964486eb98c15dc371d4a"
+
+  url "https://github.com/davidlifschitz/job-swarm/releases/download/v#{version}/MLJobSwarm-#{version}-macos-arm64.tar.gz",
+      verified: "github.com/davidlifschitz/job-swarm/"
+  name "ML Job Swarm"
+  desc "Local-first job catalog and resume matching for curated technical roles"
+  homepage "https://github.com/davidlifschitz/job-swarm"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "MLJobSwarm.app"
+
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/MLJobSwarm.app"]
+    system_command "/usr/bin/codesign", args: ["--force", "--deep", "--sign", "-", "#{appdir}/MLJobSwarm.app"]
+  end
+
+  zap trash: [
+    "~/Library/Application Support/MLJobSwarm",
+  ]
+end


### PR DESCRIPTION
Adds [ML Job Swarm](https://github.com/davidlifschitz/job-swarm), a local-first macOS app for curated technical job cataloging and resume matching.

- **Homepage:** https://github.com/davidlifschitz/job-swarm
- **Download:** GitHub Releases tar.gz (arm64, macOS 14+)
- **Artifact:** `MLJobSwarm-0.2.1-macos-arm64.tar.gz`

### Notes

- Apple Silicon only (`depends_on arch: :arm64`).
- Release builds are ad-hoc signed (not notarized). `postflight` clears quarantine and re-signs so Gatekeeper allows launch on Apple Silicon — same approach as the maintainer tap at `davidlifschitz/job-swarm`.
- Also distributed via `brew tap davidlifschitz/job-swarm`.

### Checklist

- [x] `verified:` URL matches homepage host
- [x] `livecheck` uses `:github_latest`
- [x] `sha256` matches release asset

After making all changes, the following passed locally:

- [ ] `brew audit --new --cask ml-job-swarm` *(rubygems unreachable in CI agent environment; relying on PR checks)*
- [ ] `brew install --cask ml-job-swarm`
- [ ] `brew uninstall --cask ml-job-swarm`