### PR TITLE
Update CDN url across all Microsoft casks

### DIFF
--- a/Casks/i/intune-company-portal.rb
+++ b/Casks/i/intune-company-portal.rb
@@ -2,7 +2,8 @@ cask "intune-company-portal" do
   version "5.2604.2"
   sha256 "7f990faf3ce5f9f5641f796a25c1f43d7f69aaefd5b569503c772d159f75a91e"
 
-  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Upgrade.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Upgrade.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Company Portal"
   desc "App to manage access to corporate apps, data, and resources"
   homepage "https://docs.microsoft.com/en-us/mem/intune/user-help/enroll-your-device-in-intune-macos-cp"

--- a/Casks/m/microsoft-365-copilot.rb
+++ b/Casks/m/microsoft-365-copilot.rb
@@ -2,8 +2,8 @@ cask "microsoft-365-copilot" do
   version "1.2606.0801"
   sha256 "334b47a40de9e2adddc225399a0335464a00a4f2059c2578e6e0ff2fb424733d"
 
-  url "https://res.cdn.office.net/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_Copilot_universal_#{version}_Installer.pkg",
-      verified: "res.cdn.office.net/"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_Copilot_universal_#{version}_Installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft 365 Copilot"
   desc "AI-first productivity assistant for Microsoft 365"
   homepage "https://www.microsoft.com/en-us/microsoft-365-copilot/download-copilot-app"

--- a/Casks/m/microsoft-auto-update.rb
+++ b/Casks/m/microsoft-auto-update.rb
@@ -2,7 +2,8 @@ cask "microsoft-auto-update" do
   version "4.83.26040910"
   sha256 "a307dc89adfd60c0f9d60ad869efd19e22798ec7fd11015a351378e0249325cd"
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_AutoUpdate_#{version}_Updater.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_AutoUpdate_#{version}_Updater.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft Auto Update"
   desc "Provides updates to various Microsoft products"
   homepage "https://docs.microsoft.com/officeupdates/release-history-microsoft-autoupdate"

--- a/Casks/m/microsoft-excel.rb
+++ b/Casks/m/microsoft-excel.rb
@@ -22,8 +22,8 @@ cask "microsoft-excel" do
     end
   end
   on_sonoma :or_newer do
-    version "16.109.26053122"
-    sha256 "fce501614e212cb672590c91d5d15711f902e9c21cdbdd80f1da5e18b5581d3f"
+    version "16.110.26061317"
+    sha256 "d9ced6c1a95f60649739394597d7dc89281b587ae6951e055b6a52197e351c0a"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525135"

--- a/Casks/m/microsoft-excel.rb
+++ b/Casks/m/microsoft-excel.rb
@@ -31,7 +31,8 @@ cask "microsoft-excel" do
     end
   end
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Excel_#{version}_Installer.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Excel_#{version}_Installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft Excel"
   desc "Spreadsheet software"
   homepage "https://www.microsoft.com/en-US/microsoft-365/excel"

--- a/Casks/m/microsoft-office-businesspro.rb
+++ b/Casks/m/microsoft-office-businesspro.rb
@@ -2,7 +2,8 @@ cask "microsoft-office-businesspro" do
   version "16.109.26053122"
   sha256 "3429a6f2b567436a27fd103a173f137e6e64679209e1c7f2323de1696efc1beb"
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_BusinessPro_Installer.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_BusinessPro_Installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft Office BusinessPro"
   desc "Office suite"
   homepage "https://www.microsoft.com/en-us/microsoft-365/mac/microsoft-365-for-mac/"

--- a/Casks/m/microsoft-office-businesspro.rb
+++ b/Casks/m/microsoft-office-businesspro.rb
@@ -1,6 +1,6 @@
 cask "microsoft-office-businesspro" do
-  version "16.109.26053122"
-  sha256 "3429a6f2b567436a27fd103a173f137e6e64679209e1c7f2323de1696efc1beb"
+  version "16.110.26061317"
+  sha256 "a7eb1e290c39e0f159d7f5a4221e65e5e3565c874aaf85ede0f0480d577c5929"
 
   url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_BusinessPro_Installer.pkg",
       verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"

--- a/Casks/m/microsoft-office.rb
+++ b/Casks/m/microsoft-office.rb
@@ -2,7 +2,8 @@ cask "microsoft-office" do
   version "16.109.26053122"
   sha256 "f069d50b2e7a846de6e21be229a1aeba49c5a035e9852e40da9c7bf3108f1ed1"
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_Installer.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_Installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft Office"
   desc "Office suite"
   homepage "https://www.microsoft.com/en-us/microsoft-365/mac/microsoft-365-for-mac/"

--- a/Casks/m/microsoft-office.rb
+++ b/Casks/m/microsoft-office.rb
@@ -1,6 +1,6 @@
 cask "microsoft-office" do
-  version "16.109.26053122"
-  sha256 "f069d50b2e7a846de6e21be229a1aeba49c5a035e9852e40da9c7bf3108f1ed1"
+  version "16.110.26061317"
+  sha256 "986eadffad678ab1ef62543ba135acd082da1aee64ae9ce27e1d1f64d07996a3"
 
   url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_Installer.pkg",
       verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"

--- a/Casks/m/microsoft-onenote.rb
+++ b/Casks/m/microsoft-onenote.rb
@@ -1,6 +1,6 @@
 cask "microsoft-onenote" do
-  version "16.109.26053122"
-  sha256 "aade4b2b3bad2286388e2f0d9f88667b1bdc7717d8a69606b29198caa6acdc62"
+  version "16.110.26061317"
+  sha256 "bdd7dbba11276a129f91f33a7a7a0d4a7984ed9ecbcfa113f56660546a872461"
 
   url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_#{version}_Updater.pkg",
       verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"

--- a/Casks/m/microsoft-onenote.rb
+++ b/Casks/m/microsoft-onenote.rb
@@ -2,7 +2,8 @@ cask "microsoft-onenote" do
   version "16.109.26053122"
   sha256 "aade4b2b3bad2286388e2f0d9f88667b1bdc7717d8a69606b29198caa6acdc62"
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_#{version}_Updater.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_#{version}_Updater.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft OneNote"
   desc "Digital note taking app"
   homepage "https://www.microsoft.com/en-us/microsoft-365/onenote/digital-note-taking-app"

--- a/Casks/m/microsoft-outlook.rb
+++ b/Casks/m/microsoft-outlook.rb
@@ -33,7 +33,8 @@ cask "microsoft-outlook" do
     end
   end
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft Outlook"
   desc "Email client"
   homepage "https://www.microsoft.com/en-us/microsoft-365/outlook/outlook-for-business"

--- a/Casks/m/microsoft-powerpoint.rb
+++ b/Casks/m/microsoft-powerpoint.rb
@@ -22,8 +22,8 @@ cask "microsoft-powerpoint" do
     end
   end
   on_sonoma :or_newer do
-    version "16.109.26053122"
-    sha256 "ac41c012423ff7c5613600e486b9ff70590c936a19018a3a471241c0be808f6a"
+    version "16.110.26061317"
+    sha256 "87dc53981ff801a64b238e0bf788ac220527e3730ce10a62ae1c75d93c3f21bf"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525136"

--- a/Casks/m/microsoft-powerpoint.rb
+++ b/Casks/m/microsoft-powerpoint.rb
@@ -31,7 +31,8 @@ cask "microsoft-powerpoint" do
     end
   end
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_PowerPoint_#{version}_Installer.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_PowerPoint_#{version}_Installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft PowerPoint"
   desc "Presentation software"
   homepage "https://www.microsoft.com/en-US/microsoft-365/powerpoint"

--- a/Casks/m/microsoft-remote-help.rb
+++ b/Casks/m/microsoft-remote-help.rb
@@ -1,9 +1,9 @@
 cask "microsoft-remote-help" do
   version "1.0.2601221"
-  sha256 "9a4d981dfa906c5f10227f906098917307da976700bdd5314b5eed2b6c275ee0"
+  sha256 "2523e95459808b48bd7e3cd3289613966d0ef3b0014aec53321d8ee762cdfdcf"
 
-  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/1ac37578-5a24-40fb-892e-b89d85b6dfaa/MacAutoupdate/Microsoft_Remote_Help_#{version}_installer.pkg",
-      verified: "res.public.onecdn.static.microsoft/"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Remote_Help_#{version}_installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft Remote Help"
   desc "Screen sharing and assistance tool for enterprise IT support"
   homepage "https://learn.microsoft.com/mem/intune/fundamentals/remote-help"

--- a/Casks/m/microsoft-remote-help.rb
+++ b/Casks/m/microsoft-remote-help.rb
@@ -1,6 +1,6 @@
 cask "microsoft-remote-help" do
-  version "1.0.2601221"
-  sha256 "2523e95459808b48bd7e3cd3289613966d0ef3b0014aec53321d8ee762cdfdcf"
+  version "1.0.2606021"
+  sha256 "9199369e1351d9c2796d7b86946aa76d9aef2e832128121537a96357b9a0ee8a"
 
   url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Remote_Help_#{version}_installer.pkg",
       verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"

--- a/Casks/m/microsoft-word.rb
+++ b/Casks/m/microsoft-word.rb
@@ -22,8 +22,8 @@ cask "microsoft-word" do
     end
   end
   on_sonoma :or_newer do
-    version "16.109.26053122"
-    sha256 "b31a44750ea2fafa99385c80878ca5221f1858febf6aeddd44d7b953a4bd8b07"
+    version "16.110.26061317"
+    sha256 "4189eafe4c660bad05107aabae6667a344cf0221719498096b169c719fa4e311"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525134"

--- a/Casks/m/microsoft-word.rb
+++ b/Casks/m/microsoft-word.rb
@@ -31,7 +31,8 @@ cask "microsoft-word" do
     end
   end
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Word_#{version}_Installer.pkg"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Word_#{version}_Installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Microsoft Word"
   desc "Word processor"
   homepage "https://www.microsoft.com/en-US/microsoft-365/word"

--- a/Casks/w/windows-app.rb
+++ b/Casks/w/windows-app.rb
@@ -1,6 +1,6 @@
 cask "windows-app" do
-  version "11.3.5"
-  sha256 "f725f2a4e48203c6e943d11507f0467938433aeafd220e950456f63638ac05fb"
+  version "11.3.6"
+  sha256 "e3a0e38b29de21868b3dd2c2d22f838a2e49df2908a26cbf61f34b52c42c4032"
 
   url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_#{version}_installer.pkg",
       verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"

--- a/Casks/w/windows-app.rb
+++ b/Casks/w/windows-app.rb
@@ -2,8 +2,8 @@ cask "windows-app" do
   version "11.3.5"
   sha256 "f725f2a4e48203c6e943d11507f0467938433aeafd220e950456f63638ac05fb"
 
-  url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_#{version}_installer.pkg",
-      verified: "officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/"
+  url "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_#{version}_installer.pkg",
+      verified: "res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/"
   name "Windows App"
   desc "Connect to Windows"
   homepage "https://aka.ms/WindowsApp"


### PR DESCRIPTION
Microsoft is [standardizing](https://learn.microsoft.com/en-us/microsoft-365/enterprise/cloud-microsoft-domain?view=o365-worldwide) on the `.microsoft` top level domain, and has changed their CDN download URLs, causing download failures in the [autobump](https://github.com/Homebrew/homebrew-cask/actions/runs/27821649698/job/82335964188) jobs for several Microsoft products.

This standardizes the URL across all Microsoft Casks using a `MacAutoupdate` URL, except for `microsoft-remote-desktop`, which is discontinued and hasn't migrated to the new base URL.

Notes:

- The SHA for `microsoft-remote-help` changed - I'm guessing that's because the original download URL for this cask didn't have the same base URL as for other MS casks.
- The changes pass `brew lgtm --online` except for the livecheck audit, which is expected. Once this is merged, autobump will update outdated casks. 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
