### PR TITLE
sogouinput 624d (new cask)

### DIFF
--- a/Casks/s/sogouinput.rb
+++ b/Casks/s/sogouinput.rb
@@ -1,0 +1,43 @@
+cask "sogouinput" do
+  version "623a"
+  sha256 "a31532d5734a581fe8fdef9171fc2a0920e5531a5ea83c9da6ad0dd9f48989ab"
+
+  url "https://ime.gtimg.com/pc/sogou_mac_#{version}.zip",
+      verified: "ime.gtimg.com/pc/"
+  name "Sogou Input Method"
+  name "搜狗输入法"
+  desc "Input method supporting full and double spelling"
+  homepage "https://pinyin.sogou.com/mac/"
+
+  livecheck do
+    url :homepage
+    regex(%r{https?://ime\.gtimg\.com/pc/sogou_mac_(\h+)\.zip}i)
+  end
+
+  auto_updates true
+  depends_on :macos
+
+  installer manual: "sogou_mac_#{version}.app"
+
+  uninstall launchctl: "com.sogou.SogouServices",
+            delete:    [
+              "/Library/Input Methods/SogouInput.app",
+              "/Library/QuickLook/SogouSkinFileQuickLook.qlgenerator",
+            ]
+
+  zap trash: [
+        "~/.sogouinput",
+        "~/Library/Application Support/Sogou/EmojiPanel",
+        "~/Library/Application Support/Sogou/InputMethod",
+        "~/Library/Caches/com.sogou.inputmethod.sogou",
+        "~/Library/Caches/com.sogou.SGAssistPanel",
+        "~/Library/Caches/com.sogou.SogouPreference",
+        "~/Library/Caches/SogouServices",
+        "~/Library/Cookies/com.sogou.inputmethod.sogou.binarycookies",
+        "~/Library/Cookies/com.sogou.SogouPreference.binarycookies",
+        "~/Library/Cookies/SogouServices.binarycookies",
+        "~/Library/Preferences/com.sogou.SogouPreference.plist",
+        "~/Library/Saved Application State/com.sogou.SogouInstaller.savedState",
+      ],
+      rmdir: "~/Library/Application Support/Sogou"
+end

--- a/Casks/s/sogouinput.rb
+++ b/Casks/s/sogouinput.rb
@@ -1,6 +1,6 @@
 cask "sogouinput" do
-  version "624b"
-  sha256 "53c47dd53381b5f6b65e27fb5a48739a0b7b0eb83010c2f7aabe881c2dc65978"
+  version "624d"
+  sha256 "a561e6a20e4b9e350ea79a8894408c038427f93b9ba457d424f7bd46a4ef060e"
 
   url "https://ime.gtimg.com/pc/sogou_mac_#{version}.zip",
       verified: "ime.gtimg.com/pc/"

--- a/Casks/s/sogouinput.rb
+++ b/Casks/s/sogouinput.rb
@@ -1,6 +1,6 @@
 cask "sogouinput" do
-  version "623a"
-  sha256 "a31532d5734a581fe8fdef9171fc2a0920e5531a5ea83c9da6ad0dd9f48989ab"
+  version "624b"
+  sha256 "53c47dd53381b5f6b65e27fb5a48739a0b7b0eb83010c2f7aabe881c2dc65978"
 
   url "https://ime.gtimg.com/pc/sogou_mac_#{version}.zip",
       verified: "ime.gtimg.com/pc/"


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Built and tested locally on macOS 26.5.

Restores sogouinput using the direct official ime.gtimg.com download URL now exposed on the homepage.

Verified that [ime-sec.gtimg.com/202606201745/db84164f7c7f8e77f638639dfb4f903b/pc/sogou_mac_623a.zip](https://ime-sec.gtimg.com/202606201745/db84164f7c7f8e77f638639dfb4f903b/pc/sogou_mac_623a.zip) and [ime.gtimg.com/pc/sogou_mac_623a.zip](https://ime.gtimg.com/pc/sogou_mac_623a.zip) is the same file.

AI-assisted: drafted cask from homebrew-x tap and prior Homebrew cask; manually verified official URL, checksum, audit/style/livecheck, install staging, and uninstall cleanup.