### PR TITLE
Add typewhisper 1.4.0

### DIFF
--- a/Casks/t/typewhisper.rb
+++ b/Casks/t/typewhisper.rb
@@ -1,0 +1,27 @@
+cask "typewhisper" do
+  version "1.4.0"
+  sha256 "7158c9169f366affcfc235eeac58f14564063f6cf3d1dc602ab5cf09ea8995db"
+
+  url "https://github.com/TypeWhisper/typewhisper-mac/releases/download/v#{version}/TypeWhisper-v#{version}.dmg",
+      verified: "github.com/TypeWhisper/typewhisper-mac/"
+  name "TypeWhisper"
+  desc "Speech-to-text and AI text processing"
+  homepage "https://www.typewhisper.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "TypeWhisper.app"
+
+  zap trash: [
+    "~/Library/Application Support/TypeWhisper",
+    "~/Library/Caches/com.typewhisper.mac",
+    "~/Library/HTTPStorages/com.typewhisper.mac",
+    "~/Library/Preferences/com.typewhisper.mac.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance: Codex helped draft the cask from TypeWhisper's official Homebrew tap and nearby Homebrew Cask examples. I verified the cask manually with:

- `brew audit --cask --online seofood/cask/typewhisper`
- `brew style --fix seofood/cask/typewhisper`
- `brew audit --cask --new seofood/cask/typewhisper`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --appdir=/tmp/typewhisper-homebrew-cask-test.SsKxbr seofood/cask/typewhisper`
- `brew uninstall --cask seofood/cask/typewhisper`

The `zap` stanza paths were copied from the official TypeWhisper tap and reviewed against TypeWhisper's documented application support, cache, HTTP storage, and preferences paths.

-----
