### PR TITLE
flameshot 14.0.0

### DIFF
--- a/Casks/f/flameshot.rb
+++ b/Casks/f/flameshot.rb
@@ -1,9 +1,9 @@
 cask "flameshot" do
   arch arm: "arm64", intel: "intel"
 
-  version "13.3.0"
-  sha256 arm:   "ecf0d815b5b4c0a55f896d67c4cf74c49816ccb20acf9df715a3cd893e0184e7",
-         intel: "c549e5687ae32d3f6a48badbd1fedac6bbba659ec16f44a0f1bf56a8dec20fd2"
+  version "14.0.0,14.0"
+  sha256 arm:   "bb0cccb2223ce0f4bfea00d90658e85fb5dc17aa7773bf2b22c70ffdb23d7221",
+         intel: "871653260d9298db2e2a85e121c514f753dfdca94dccabbd74c142a2438f3d78"
 
   on_arm do
     depends_on macos: :sonoma
@@ -12,7 +12,7 @@ cask "flameshot" do
     depends_on macos: :ventura
   end
 
-  url "https://github.com/flameshot-org/flameshot/releases/download/v#{version}/Flameshot-#{version}-artifact-macos-#{arch}.dmg",
+  url "https://github.com/flameshot-org/flameshot/releases/download/v#{version.csv.first}/Flameshot-#{version.csv.second || version.csv.first}-macos-#{arch}.dmg",
       verified: "github.com/flameshot-org/flameshot/"
   name "Flameshot"
   desc "Screenshot software with built-in annotation tools"
@@ -20,12 +20,20 @@ cask "flameshot" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(%r{/v?(\d+(?:\.\d+)+)/Flameshot[._-]v?(\d+(?:\.\d+)+)(?:[._-]artifact)?(?:[._-]macos)?[._-]#{arch}\.dmg}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
+    end
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on :macos
+  depends_on macos: :sequoia
 
   app "flameshot.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`flameshot` is autobumped but the workflow failed to update to version 14.0.0 because the dmg assets only use "14.0" as the file name version and do not include the "-artifact" suffix. Upstream will presumably return to a three-part version for version 14.0.1, so I've set up the asset` url` and `livecheck` block to only use/include a second version part when the tag version and file name version differ. This updates the version and adjusts the cask accordingly.