### PR TITLE
kotlin-lsp 262.8190.0

### DIFF
--- a/Casks/k/kotlin-lsp.rb
+++ b/Casks/k/kotlin-lsp.rb
@@ -2,14 +2,14 @@ cask "kotlin-lsp" do
   arch arm: "-aarch64"
   os macos: "sit", linux: "tar.gz"
 
-  version "262.7569.0"
-  sha256 arm:          "e3076b6500db8f1d40e087a80223ecbb3a14cf4fd2221e031c424a94c6094620",
-         intel:        "0fdc0f0d345a759e6ac1522217679d8c175f8182eab51705bb267ca926ae24e5",
-         arm64_linux:  "f974434597dcd41a0e7e9c3973b1ed999fc52150fb05e72582aacde3d1e79f7f",
-         x86_64_linux: "333cb21215e2ce04817257bbd5c693cbbd4a99121ac100814601edc1f92d2570"
+  version "262.8190.0"
+  sha256 arm:          "e20183262784bb7e665ce1aea4855872a8b16f211ebb478d452773553732d9fb",
+         intel:        "f3845ae9ee38c22ef5e436390d86a3d908f77073e9667fa643a5ae0957c19728",
+         arm64_linux:  "c3edd59ef34a7faa4d04f3517afb7a932b19c3f9cf17d1a14e9da17b0b5440ad",
+         x86_64_linux: "8b4c70e95065420e7867c99aaf9f18e0b4e76311ec453e4c1a39e3f6ae774cbf"
 
-  url "https://download-cdn.jetbrains.com/kotlin-lsp/#{version}/kotlin-server-#{version}#{arch}.#{os}",
-      verified: "download-cdn.jetbrains.com/kotlin-lsp/"
+  url "https://download-cdn.jetbrains.com/language-server/kotlin-server/#{version}/kotlin-server-#{version}#{arch}.#{os}",
+      verified: "download-cdn.jetbrains.com/language-server/kotlin-server/"
   name "Kotlin LSP"
   desc "Official Kotlin Language Server"
   homepage "https://github.com/Kotlin/kotlin-lsp"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`kotlin-lsp` is autobumped but the workflow failed to update to version 262.8190.0 because the path in the download URL changed in this version. This updates the version and adjusts the asset `url` to align with the links in the latest GitHub release description.