### PR TITLE
mactools 1.0.21

### DIFF
--- a/Casks/m/mactools.rb
+++ b/Casks/m/mactools.rb
@@ -1,11 +1,18 @@
 cask "mactools" do
-  version "1.0.20"
-  sha256 "55a7dcfc664b4118c6d76514acd52d74281ffd561dc6030447b0965acb233602"
+  version "1.0.21"
+  sha256 "27fc44361b66d06d671cba6c13be9d8ef2c59e024b238b77481e15b05c4d29b5"
 
   url "https://github.com/ggbond268/MacTools/releases/download/v#{version}/MacTools.dmg"
   name "MacTools"
   desc "Menu bar toolbox"
   homepage "https://github.com/ggbond268/MacTools"
+
+  # The upstream repository also contains tags like `plugins-1.2.3`, so we
+  # only match the main version tags that correspond to app releases.
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   auto_updates true
   depends_on macos: :sonoma


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`mactools` is autobumped but the workflow failed to update to version 1.0.21. livecheck is returning 1.0.22 as newest but this comes from a `plugins-1.0.22` tag and there isn't a `v1.0.22` tag yet for the app. This updates the version and adds a `livecheck` block with a regex that restricts matching to the main tags like `v1.0.21` that correspond to app releases.