### PR TITLE
openmw 0.51.0

### DIFF
--- a/Casks/o/openmw.rb
+++ b/Casks/o/openmw.rb
@@ -1,11 +1,18 @@
 cask "openmw" do
-  arch arm: "arm64", intel: "amd64"
+  arch arm: "arm64", intel: "x86_64"
 
-  version "0.50.0"
-  sha256 arm:   "f1787384b54ae6b76444ca0899c553c491800d28185e7ee8bf052a30656160ed",
-         intel: "8ba6c83933d999f5f1f6f9d1bb35b948c1d01972fc35e6bfe2c302735ca2db8e"
+  version "0.51.0"
+  sha256 arm:   "76bc0436413ed500dcd846a2cc3889711af948645bdd4eafd36ad16bc0c5615c",
+         intel: "cce014e1827cf2b1a23017894015648298c90e3324097fac157dd9e40b341602"
 
-  url "https://github.com/OpenMW/openmw/releases/download/openmw-#{version}/OpenMW-#{version}-macos-#{arch}.dmg",
+  on_arm do
+    depends_on macos: :sonoma
+  end
+  on_intel do
+    depends_on macos: :ventura
+  end
+
+  url "https://github.com/OpenMW/openmw/releases/download/openmw-#{version}/OpenMW-#{version}-macOS-#{arch}.dmg",
       verified: "github.com/OpenMW/openmw/"
   name "OpenMW"
   desc "Open-source open-world RPG game engine that supports playing Morrowind"
@@ -19,7 +26,7 @@ cask "openmw" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: :ventura
+  depends_on :macos
 
   app "OpenMW.app"
   app "OpenMW-CS.app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`openmw` is autobumped but the workflow failed to update to version 0.51.0 because the Intel arch suffix is now "x86_64" instead of "amd64". This updates the version and adjusts the cask accordingly.