### PR TITLE
zo 1.5.6

### DIFF
--- a/Casks/z/zo.rb
+++ b/Casks/z/zo.rb
@@ -1,8 +1,8 @@
 cask "zo" do
-  version "1.5.5"
-  sha256 "be8cc8f26b9b75d54930c18469c2c6e6cd710fa6781a92588f07e59a87eba1d0"
+  version "1.5.6"
+  sha256 "69f3a6055a4911d802b0a89f40d69f3a863937a46665b08b65ca73ae2cda77c1"
 
-  url "https://github.com/zocomputer/Zo/releases/download/desktop-v#{version}/Zo-#{version}-universal-mac.zip",
+  url "https://github.com/zocomputer/Zo/releases/download/v#{version}/Zo-#{version}-universal-mac.zip",
       verified: "github.com/zocomputer/Zo/"
   name "Zo"
   desc "Friendly personal server"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`zo` is autobumped but the workflow failed to update to version 1.5.6 because it uses a typical `v1.5.6` tag instead of the one-off `desktop-v1.5.5` tag format from the previous version. This updates the version and `url` accordingly.