### PR TITLE
x-air-edit: various updates

### DIFF
--- a/Casks/x/x-air-edit.rb
+++ b/Casks/x/x-air-edit.rb
@@ -1,29 +1,18 @@
 cask "x-air-edit" do
-  version "1.8.1,pasxX2fZM0ia-1m2Ag3Yjg,Ur4E_DBb10WZIMoa_W9OVQ"
+  version "1.8.1,f592010e1fca4b82b1c5f410004c2cb8"
   sha256 "30cf6ada86da5b90fb3115b39b4c8983829e9695a16258aeca5c2656bdc1d2d3"
 
-  url "https://cdn.mediavalet.com/aunsw/musictribe/#{version.csv.second}/#{version.csv.third}/Original/X-AIR-Edit_MAC_#{version.csv.first}.zip",
-      verified: "mediavalet.com/aunsw/musictribe/"
+  url "https://cdn-media.empowertribe.com/#{version.csv.second}/X-AIR-Edit_MAC_#{version.csv.first}.zip",
+      verified: "cdn-media.empowertribe.com/"
   name "X AIR Edit"
   desc "Remote control for the Behringer X AIR series mixers"
-  homepage "https://www.behringer.com/series.html?category=R-BEHRINGER-XAIRSERIES"
+  homepage "https://www.behringer.com/en/products/0605-AAD"
 
   livecheck do
-    url "https://www.behringer.com/.rest/musictribe/v1/products/media-library?brandName=behringer&modelCode=0605-AAD"
-    regex(%r{([^/]+)/([^/]+)/Original/X[._-]AIR[._-]Edit[._-]MAC[._-]v?(\d+(?:\.\d+)+)\.zip}i)
-    strategy :json do |json, regex|
-      json.filter_map do |category|
-        next if category["title"] != "Software"
-
-        category["list"]&.map do |item|
-          next unless item["title"]&.match?(/X-AIR EDIT Mac/i)
-
-          match = item["url"]&.match(regex)
-          next if match.blank?
-
-          "#{match[3]},#{match[1]},#{match[2]}"
-        end
-      end.flatten
+    url :homepage
+    regex(%r{/(\h+)/X[._-]AIR[._-]Edit[._-]MAC[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The upstream website has undergone some structural changes, leaving this cask without a working download URL and `livecheck`. This PR updates the cask's `url` to the new location and sets the `homepage` to an X Air series product page since the dedicated page no longer exists.