### PR TITLE
fontstand 3.0.11: fix stale livecheck, bump, update zap

### DIFF
--- a/Casks/f/fontstand.rb
+++ b/Casks/f/fontstand.rb
@@ -1,37 +1,39 @@
 cask "fontstand" do
-  version "2.4.0"
-  sha256 :no_check
+  version "3.0.11,16"
+  sha256 "c8f688de49cc7d06779d65087f9f684369d4d0c9beb84bebac95cab29a53feed"
 
-  url "https://fontstand.com/apps/download/69"
+  url "https://api.fontstand.com/assets/Uploads/Website/App/Fontstand-v#{version.csv.second}.zip"
   name "Fontstand"
   desc "Font discovery and rental platform"
   homepage "https://fontstand.com/"
 
   livecheck do
-    url :url
-    regex(/Fontstand[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
-    strategy :header_match do |headers, regex|
-      match = headers["content-disposition"]&.match(regex)
+    url "https://api.fontstand.com/api/v3/app/sparkle/149?os=macos-26"
+    regex(%r{/Fontstand[._-]v?(\d+(?:\.\d+)*)\.zip}i)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
       next if match.blank?
 
-      match[1].tr("-", ".")
+      "#{item.short_version},#{match[1]}"
     end
   end
 
-  depends_on :macos
+  auto_updates true
+  depends_on macos: :ventura
 
   app "Fontstand.app"
 
   zap trash: [
-    "~/Library/Application Support/com.fontstand-bv.mac.Fontstand",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.fontstand-bv.mac.fontstand.sfl*",
+    "~/Library/Application Support/com.fontstand-bv.mac.Fontstand-Agent",
     "~/Library/Application Support/Fontstand Agent",
     "~/Library/Application Support/Fontstand",
     "~/Library/Caches/com.fontstand-bv.mac.Fontstand",
+    "~/Library/HTTPStorages/com.fontstand-bv.mac.Fontstand",
+    "~/Library/HTTPStorages/com.fontstand-bv.mac.Fontstand-Agent",
     "~/Library/LaunchAgents/com.fontstand-bv.mac.Fontstand-Agent.plist",
+    "~/Library/Preferences/com.fontstand-bv.mac.Fontstand-Agent.plist",
     "~/Library/Preferences/com.fontstand-bv.mac.Fontstand.plist",
+    "~/Library/WebKit/com.fontstand-bv.mac.Fontstand",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Prompted for precedence in other casks with download URL versioning scheme unrelated to Sparkle version, confirmation app no longer uses Rosetta 2

-----
