### PR TITLE
bettercmdtab 26.5.1 (new cask)

### DIFF
--- a/Casks/b/bettercmdtab.rb
+++ b/Casks/b/bettercmdtab.rb
@@ -1,0 +1,28 @@
+cask "bettercmdtab" do
+  version "26.5.1"
+  sha256 "2de73f3189029150a87d45e36926c371b2e1550ad4741b98a4ad4c2204d9b323"
+
+  url "https://github.com/rokartur/BetterCmdTab/releases/download/v#{version}/BetterCmdTab-#{version}-20260613051735.dmg",
+      verified: "github.com/rokartur/BetterCmdTab/"
+  name "BetterCmdTab"
+  desc "Replacement for the built-in Cmd+Tab app switcher"
+  homepage "https://bettercmdtab.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest do |json|
+      json["tag_name"].delete_prefix("v")
+    end
+  end
+
+  auto_updates false
+  depends_on macos: :ventura
+
+  app "BetterCmdTab.app"
+
+  zap trash: [
+    "~/Library/Application Support/pro.bettercmdtab.BetterCmdTab",
+    "~/Library/Caches/pro.bettercmdtab.BetterCmdTab",
+    "~/Library/Preferences/pro.bettercmdtab.BetterCmdTab.plist",
+  ]
+end

--- a/Casks/b/bettercmdtab.rb
+++ b/Casks/b/bettercmdtab.rb
@@ -1,8 +1,8 @@
 cask "bettercmdtab" do
-  version "26.5.1"
+  version "26.5.1,20260613051735"
   sha256 "2de73f3189029150a87d45e36926c371b2e1550ad4741b98a4ad4c2204d9b323"
 
-  url "https://github.com/rokartur/BetterCmdTab/releases/download/v#{version}/BetterCmdTab-#{version}-20260613051735.dmg",
+  url "https://github.com/rokartur/BetterCmdTab/releases/download/v#{version.csv.first}/BetterCmdTab-#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "github.com/rokartur/BetterCmdTab/"
   name "BetterCmdTab"
   desc "Replacement for the built-in Cmd+Tab app switcher"
@@ -10,12 +10,17 @@ cask "bettercmdtab" do
 
   livecheck do
     url :url
-    strategy :github_latest do |json|
-      json["tag_name"].delete_prefix("v")
+    regex(/BetterCmdTab-(\d+(?:\.\d+)+)-(\d+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 
-  auto_updates false
   depends_on macos: :ventura
 
   app "BetterCmdTab.app"

--- a/Casks/b/bettercmdtab.rb
+++ b/Casks/b/bettercmdtab.rb
@@ -10,7 +10,7 @@ cask "bettercmdtab" do
 
   livecheck do
     url :url
-    regex(/BetterCmdTab-(\d+(?:\.\d+)+)-(\d+)\.dmg$/i)
+    regex(/BetterCmdTab[._-]v?(\d+(?:\.\d+)+)-(\d+)\.dmg$/i)
     strategy :github_latest do |json, regex|
       json["assets"]&.map do |asset|
         match = asset["browser_download_url"]&.match(regex)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online bettercmdtab` is error-free.
- [x] `brew style --fix bettercmdtab` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+bettercmdtab&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new bettercmdtab` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask bettercmdtab` worked successfully.
- [x] `brew uninstall --cask bettercmdtab` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used VS Code Copilot plugin with `DeepSeek V4 Pro` while preparing this cask from my existing private tap formula. All changes were checked by me before committing.

This AI mainly helped with drafting and some small formatting changes, such as adding the required `verified:` parameter and removing tap-specific metadata.

Both AI and I verified sha-256 checksum, release version, installation, and zap behavior on macOS 15.5.1. We also checked and made sure the results from `brew style` and `brew audit` are clean.

> [rokartur/BetterCmdTab](https://github.com/rokartur/BetterCmdTab) has 132 stars but relatively few forks. It is an Alt-Tab replacement tool for macOS and is licensed under GPL v3. It also has its own website at [bettercmdtab.app](https://bettercmdtab.app).

-----
