### PR TITLE
8bitdo-firmware-updater 2.5.2 (new cask)

### DIFF
--- a/Casks/8/8bitdo-firmware-updater.rb
+++ b/Casks/8/8bitdo-firmware-updater.rb
@@ -1,0 +1,25 @@
+cask "8bitdo-firmware-updater" do
+  version "2.5.2"
+  sha256 "4f197854e6eca261a77b0a0fc03db60d9f0b860fcb511dadb8484f5d9edea887"
+
+  url "https://support.8bitdo.com/upfiles/Firmware-Updater/8BitDo_Firmware_Updater_macOS_v#{version}.zip"
+  name "8BitDo Firmware Updater"
+  desc "Firmware updater for 8BitDo controllers"
+  homepage "https://support.8bitdo.com/firmware-updater.html"
+
+  livecheck do
+    url "http://dl.8bitdo.cn/Firmware-Updater/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on :macos
+
+  app "8BitDo Firmware Updater.app"
+
+  zap trash: [
+    "~/Library/Caches/com.8bitdo.firmwareupdater",
+    "~/Library/HTTPStorages/com.8bitdo.firmwareupdater",
+    "~/Library/Preferences/com.8bitdo.firmwareupdater.plist",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI-assisted: drafted from the app's Sparkle appcast, modelled on the existing `8bitdo-ultimate-software` cask. Reviewed it and tested locally — `audit --new`, `style`, `install`/`uninstall` and `livecheck` all pass.

zap paths checked against `~/Library` after running the app: Caches, HTTPStorages and the Preferences plist, all under `com.8bitdo.firmwareupdater`.

The old closed PRs (#61050, #100215) just predate `cask-drivers` being merged back into `homebrew/cask` — `8bitdo-ultimate-software` already lives here.
