### PR TITLE
kiro: revert from 1.0.0 to 0.12.333

### DIFF
--- a/Casks/k/kiro.rb
+++ b/Casks/k/kiro.rb
@@ -1,9 +1,9 @@
 cask "kiro" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.0.0"
-  sha256  arm:   "14f53eacc6c6f38b1955d910fab20bdb3eb3d7666d11212b1e0594d32ae3950c",
-          intel: "f2f10ef6a5b3df8f4a0e2e1a29e60de6e7a7b2aabab12657b5a82c192dc561f0"
+  version "0.12.333"
+  sha256  arm:   "5aee5da57ced87f4d3972de4d35f659ff707977660b52f0f7a7193cf04796fa6",
+          intel: "e683cae891ab63ed3e8bf567bd195233fe5740992ade93ec501d486a8aee273c"
 
   url "https://prod.download.desktop.kiro.dev/releases/stable/darwin-#{arch}/signed/#{version}/kiro-ide-#{version}-stable-darwin-#{arch}.dmg"
   name "kiro"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online kiro` is error-free.
- [x] `brew style --fix kiro` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The current cask version is `1.0.0`, but the official Kiro website and the JSON endpoint used by livecheck both report `0.12.333` as the latest version.

`==> kiro`
`Current cask version:     1.0.0 (newer than upstream)`
`Latest livecheck version: 0.12.333`

I wonder if Amazon accidentally published `1.0.0`.

References:
- https://kiro.dev/changelog/ide/
- https://prod.download.desktop.kiro.dev/stable/metadata-dmg-darwin-x64-stable.json
- https://github.com/Homebrew/homebrew-cask/actions/runs/27901643541/job/82562891629
- https://github.com/Homebrew/homebrew-cask/actions/runs/27905321247/job/82572844375