### PR TITLE
claude-usage-bar 1.2.1 (new cask)

### DIFF
--- a/Casks/c/claude-usage-bar.rb
+++ b/Casks/c/claude-usage-bar.rb
@@ -1,0 +1,25 @@
+cask "claude-usage-bar" do
+  version "1.2.1"
+  sha256 "fedfb51ed592805b98f7ca02954d11f7361be97972b4fff1eb601201351a07b3"
+
+  url "https://github.com/Artzainnn/ClaudeUsageBar/releases/download/v#{version}/ClaudeUsageBar-Installer.dmg"
+  name "ClaudeUsageBar"
+  desc "Menu bar tracker for Claude.ai usage"
+  homepage "https://github.com/Artzainnn/ClaudeUsageBar"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+
+  app "ClaudeUsageBar.app"
+
+  zap trash: [
+    "~/Library/Caches/com.claude.usagebar",
+    "~/Library/HTTPStorages/com.claude.usagebar",
+    "~/Library/HTTPStorages/com.claude.usagebar.binarycookies",
+    "~/Library/Preferences/com.claude.usagebar.plist",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI-assisted: drafted from the project's GitHub releases (the release DMG holds the signed + notarized .app), version and sha256 from the v1.2.1 release. Reviewed it and tested locally — `audit --new`, `style`, `install`/`uninstall` and `livecheck` (`github_latest`) all pass.

zap paths checked against `~/Library` after running the app: Caches, HTTPStorages (incl. the binarycookies file) and the Preferences plist, all under `com.claude.usagebar`.
