### PR TITLE
Add Proliferate

### DIFF
--- a/Casks/p/proliferate.rb
+++ b/Casks/p/proliferate.rb
@@ -1,0 +1,31 @@
+cask "proliferate" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.2.19"
+  sha256 arm:   "7303e75d90059b080ab4cef99742e6ed0601257b057698637a07208f08dbfde7",
+         intel: "83161fa9c3aa8b0fdbd3076fd0260189d232af2d666e608c1bda599673184ee5"
+
+  url "https://downloads.proliferate.com/desktop/stable/Proliferate_#{version}_#{arch}.dmg"
+  name "Proliferate"
+  desc "Open-source AI IDE for running coding agents in parallel"
+  homepage "https://proliferate.com/"
+
+  livecheck do
+    url "https://downloads.proliferate.com/desktop/stable/installers.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Proliferate.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.proliferate.app",
+    "~/Library/Caches/com.proliferate.app",
+    "~/Library/Preferences/com.proliferate.app.plist",
+    "~/Library/Saved Application State/com.proliferate.app.savedState",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online proliferate` is error-free.
- [x] `brew style --fix proliferate` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new proliferate` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask proliferate` worked successfully.
- [x] `brew uninstall --cask proliferate` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

**AI usage disclosure:** This cask and PR were prepared with Claude Code (the cask file is emitted by a generator script in the project's release pipeline). Manual verification performed by the maintainer:

- Real `brew install --cask` and `brew uninstall --cask` on macOS arm64 (Proliferate 0.2.19) — app installs to `/Applications` and launches with no Gatekeeper prompt (the app is Developer ID signed and notarized).
- `brew style` run locally — no offenses. `brew audit --cask --online` confirmed error-free via Homebrew CI across all six runners (the local online run was skipped only due to local tap-trust; `brew audit --new --cask` ran clean locally with the DMG downloaded and sha256 verified).
- Mounted the published DMG and confirmed it contains `Proliferate.app`.
- `sha256` values computed directly from the official release artifacts at `https://downloads.proliferate.com/desktop/stable/`.
- `zap` trash paths verified against the app's bundle identifier `com.proliferate.app`.

App: open-source AI IDE (Tauri). Homepage https://proliferate.com/ · Repo https://github.com/proliferate-ai/proliferate (AGPL-3.0). Ships a Tauri in-app updater, hence `auto_updates true` with `livecheck` against the published `installers.json`.