### PR TITLE
Add Proliferate

### DIFF
--- a/Casks/p/proliferate.rb
+++ b/Casks/p/proliferate.rb
@@ -1,0 +1,31 @@
+cask "proliferate" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.2.19"
+  sha256 arm:   "7303e75d90059b080ab4cef99742e6ed0601257b057698637a07208f08dbfde7",
+         intel: "83161fa9c3aa8b0fdbd3076fd0260189d232af2d666e608c1bda599673184ee5"
+
+  url "https://downloads.proliferate.com/desktop/stable/Proliferate_#{version}_#{arch}.dmg"
+  name "Proliferate"
+  desc "Open-source AI IDE for running coding agents in parallel"
+  homepage "https://proliferate.com/"
+
+  livecheck do
+    url "https://downloads.proliferate.com/desktop/stable/installers.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Proliferate.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.proliferate.app",
+    "~/Library/Caches/com.proliferate.app",
+    "~/Library/Preferences/com.proliferate.app.plist",
+    "~/Library/Saved Application State/com.proliferate.app.savedState",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI-assisted: the cask is emitted by the project's release pipeline (Claude Code). Verified locally — `brew audit --new --cask`, `brew style`, and real `install`/`uninstall` on macOS arm64 (Proliferate 0.2.19) all pass; `test proliferate` CI was green on all six runners on the prior submission before a template-format auto-close. The app is Developer ID signed and notarized (launches with no Gatekeeper prompt). `sha256` computed from the official artifacts at https://downloads.proliferate.com/desktop/stable/ . `zap` paths checked under `~/Library` for bundle id `com.proliferate.app` (Application Support, Caches, Preferences plist, Saved Application State). `auto_updates true` because the app ships a Tauri in-app updater; `livecheck` tracks the published `installers.json`.
