### PR TITLE
Add Meta Quest Remote Desktop cask

### DIFF
--- a/Casks/m/meta-quest-remote-desktop.rb
+++ b/Casks/m/meta-quest-remote-desktop.rb
@@ -10,17 +10,17 @@ cask "meta-quest-remote-desktop" do
 
   livecheck do
     url "https://www.oculus.com/download_app/?id=7248432555245552"
-    regex(%r{/binaries/download/\?id=(\d+)}i)
+    regex(%r{/binaries/download/.*?[?&]id=(\d+)}i)
     strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
-      next if match.blank?
+      binary_id = headers["location"]&.[](regex, 1)
+      next unless binary_id
 
-      binary_id = match[1]
       cask = CaskLoader.load(__FILE__)
-      download_url = "https://securecdn.oculus.com/binaries/download/?id=#{binary_id}"
-      app_version = Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(cask: cask,
-                                                                              url:  download_url)[:matches].values.max
-      next if app_version.blank?
+      app_version = Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(
+        cask: cask,
+        url:  "https://securecdn.oculus.com/binaries/download/?id=#{binary_id}",
+      )[:matches].values.max
+      next unless app_version
 
       "#{app_version},#{binary_id}"
     end

--- a/Casks/m/meta-quest-remote-desktop.rb
+++ b/Casks/m/meta-quest-remote-desktop.rb
@@ -1,0 +1,52 @@
+cask "meta-quest-remote-desktop" do
+  version "94.0.0.1.110,27307607982234713"
+  sha256 "9f02ff1278b3f8a279d43e8480fd8f35b9add8a10068086266a95994a21f9690"
+
+  url "https://securecdn.oculus.com/binaries/download/?id=#{version.csv.second}",
+      verified: "securecdn.oculus.com/"
+  name "Meta Quest Remote Desktop"
+  desc "Remote desktop companion app for Meta Quest headsets"
+  homepage "https://www.meta.com/quest/"
+
+  livecheck do
+    url "https://www.oculus.com/download_app/?id=7248432555245552"
+    regex(%r{/binaries/download/\?id=(\d+)}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      binary_id = match[1]
+      cask = CaskLoader.load(__FILE__)
+      download_url = "https://securecdn.oculus.com/binaries/download/?id=#{binary_id}"
+      app_version = Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(cask: cask,
+                                                                              url:  download_url)[:matches].values.max
+      next if app_version.blank?
+
+      "#{app_version},#{binary_id}"
+    end
+  end
+
+  depends_on macos: :ventura
+  container type: :naked
+
+  rename "download", "Meta Quest Remote Desktop.pkg"
+
+  pkg "Meta Quest Remote Desktop.pkg"
+
+  uninstall quit:    "com.meta.virtualdesktop",
+            pkgutil: "com.meta.virtualdesktop"
+
+  zap trash: [
+    "~/Library/Application Support/Meta Quest Remote Desktop",
+    "~/Library/Application Support/Oculus Remote Desktop",
+    "~/Library/Caches/com.meta.virtualdesktop",
+    "~/Library/Caches/com.oculus.xr2dsd",
+    "~/Library/HTTPStorages/com.meta.virtualdesktop",
+    "~/Library/Preferences/com.meta.virtualdesktop.plist",
+    "~/Library/Preferences/com.oculus.remotedesktop.plist",
+    "~/Library/Preferences/com.oculus.xr2ds.remotedesktop.plist",
+    "~/Library/Preferences/com.oculus.xr2dsd.plist",
+    "~/Library/Preferences/com.oculus.xr2dsd.telemetry",
+    "~/Library/Saved Application State/com.meta.virtualdesktop.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance was used to draft the cask and inspect the package metadata. Manual verification performed:

- Confirmed Homebrew did not already contain `meta-quest-remote-desktop`.
- Confirmed the installer from Meta's Horizon desktop page resolves to the Oculus CDN package used in the cask.
- Verified the remote package SHA-256 matches the cask checksum: `9f02ff1278b3f8a279d43e8480fd8f35b9add8a10068086266a95994a21f9690`.
- Expanded the local installer package and verified package id `com.meta.virtualdesktop`, installed app path `/Applications/Meta Quest Remote Desktop.app`, app bundle id `com.meta.virtualdesktop`, and app version `94.0.0.1.110`.
- Checked the installer scripts and package payload to choose the `pkgutil`, `quit`, and `zap` entries. The `zap` paths cover the app's current `com.meta.virtualdesktop` support/cache/preferences data and legacy Oculus Remote Desktop preference/support paths referenced by the bundled uninstall script.
- Ran `ruby -c Casks/m/meta-quest-remote-desktop.rb` successfully.

I could not complete `brew audit`, `brew style`, install, or uninstall in my local sandbox because Homebrew attempted to write to its internal vendor directory under `/opt/homebrew`, which was not writable in that environment.

-----
