### PR TITLE
valentine 1.2 (new cask)

### DIFF
--- a/Casks/v/valentine.rb
+++ b/Casks/v/valentine.rb
@@ -1,0 +1,19 @@
+cask "valentine" do
+  version "1.2"
+  sha256 "1c960177eaf9fba9e8039c9e94166996c04287e29a4f5738ba05b81cd2f81f39"
+
+  url "https://github.com/JesusChapman/valentine/releases/download/v#{version}/Valentine_v#{version}_Universal.dmg"
+  name "Valentine"
+  desc "Elegant native music player with support for synchronized lyrics"
+  homepage "https://github.com/JesusChapman/valentine"
+
+  depends_on macos: :tahoe
+
+  app "Valentine.app"
+
+  zap trash: [
+    "~/Library/Application Support/dev.jesuschapman.Valentine",
+    "~/Library/Preferences/dev.jesuschapman.Valentine.plist",
+    "~/Library/Saved Application State/dev.jesuschapman.Valentine.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Valentine is a local music player developed by me.

I used Linux for years and now that I switched to Mac I came across that the local music players available on it are not so aesthetic and some lacked features that I appreciate.

Currently the music player is fully functional, tested in different ways, and available in several languages.

It lacks popularity because it is something recent, I hope I can get it with the days, if that is an important requirement.

The app is not signed because I don't pay for the Apple developer program membership, maybe at the end of July I will, but the app is open source.

<img width="767" height="704" alt="image" src="https://github.com/user-attachments/assets/09bcac23-7d3e-4fd2-9fd6-bbb794678636" />
