### PR TITLE
supaterm: use hosted downloads

### DIFF
--- a/Casks/s/supaterm.rb
+++ b/Casks/s/supaterm.rb
@@ -2,15 +2,20 @@ cask "supaterm" do
   version "26.0.0"
   sha256 "b12c1a0dc87c560b3502b47aeb91b462952ddfb660c0aeec9bc971bcf06e2628"
 
-  url "https://github.com/supabitapp/supaterm/releases/download/v#{version}/supaterm.dmg",
-      verified: "github.com/supabitapp/supaterm/"
+  url "https://supaterm.com/download/v#{version}/supaterm.dmg"
   name "Supaterm"
   desc "Terminal emulator with built-in agent automation"
   homepage "https://supaterm.com/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://supaterm.com/download/latest/appcast.xml"
+    strategy :sparkle do |items|
+      items.map do |item|
+        next unless item.channel.nil?
+
+        item.short_version
+      end
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
Updates `supaterm` to use Supaterm-hosted release downloads for CDN and the Sparkle appcast for livecheck.

I'm the author of the app, I submitted the original PR for this cask back in https://github.com/Homebrew/homebrew-cask/pull/265032

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Codex updated the cask and ran local verification. Verified the changed cask URL, stable Sparkle livecheck result, product-domain DMG endpoint, checksum metadata, `brew audit --cask --online supaterm`, `brew style --fix Casks/s/supaterm.rb`, and `HOMEBREW_NO_INSTALL_FROM_API=1 brew fetch --cask --force --verbose supaterm`. No `zap` stanza changes.

-----
