### PR TITLE
xpntl 0.1.0 (new cask)

### DIFF
--- a/Casks/x/xpntl.rb
+++ b/Casks/x/xpntl.rb
@@ -1,0 +1,26 @@
+cask "xpntl" do
+  version "0.1.0"
+  sha256 "3c80aa5d519cfd5cc885cda33e85c7ee53d248bfeba48def77a3992f6964d4ac"
+
+  url "https://dl.xpntl.dev/clients/macos/xpntl-#{version}.dmg"
+  name "xpntl"
+  desc "Coordination layer for human and AI engineering teams"
+  homepage "https://xpntl.dev/"
+
+  livecheck do
+    url "https://dl.xpntl.dev/clients/version.json"
+    strategy :json do |json|
+      json.dig("macos", "version")
+    end
+  end
+
+  depends_on macos: :sonoma
+
+  app "xpntl.app"
+
+  zap trash: [
+    "~/Library/Caches/dev.xpntl.macos",
+    "~/Library/Preferences/dev.xpntl.macos.plist",
+    "~/Library/Saved Application State/dev.xpntl.macos.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

**How AI was used:** Claude (Anthropic) authored the cask file and this PR.

**Manual verification performed:**
- `brew audit --new --cask --online xpntl` → no problems; `brew style xpntl` → no offenses.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask xpntl` installed `xpntl.app` to `/Applications`; removed cleanly with uninstall (app + Caskroom entry gone).
- DMG is Developer ID–signed and **notarized**: `spctl -a -t open` → `accepted, Notarized Developer ID`; `xcrun stapler validate` → valid.
- `livecheck` resolves the vendor `version.json` and detects `0.1.0`.
- `zap` paths verified against the installed app's `CFBundleIdentifier` (`dev.xpntl.macos`): `~/Library/Caches/dev.xpntl.macos`, `~/Library/Preferences/dev.xpntl.macos.plist`, `~/Library/Saved Application State/dev.xpntl.macos.savedState`.

xpntl is a native macOS client for [xpntl.dev](https://xpntl.dev/), distributed as a notarized DMG from the vendor's domain.
