### PR TITLE
browseros: update checksums for re-uploaded 0.46.0 assets

### DIFF
--- a/Casks/b/browseros.rb
+++ b/Casks/b/browseros.rb
@@ -2,8 +2,8 @@ cask "browseros" do
   arch arm: "arm64", intel: "x64"
 
   version "0.46.0"
-  sha256 arm:   "7a1edb87cbf31544531aea793be608c3277f1ed3132d4a38fec0cc0ac4373b85",
-         intel: "7193514b1d9f4bd0a078652a0aa445111b43c0fe7ad3381931807919a2dbb202"
+  sha256 arm:   "5832b6faf78c63b5804a4cbd0787bb88787ecf9930ffb3adef6b1765b7e509c7",
+         intel: "30ee4a08cf3a91d6f9ebb29fbb7865d0c6e57a558e4e4b16948e80aadc6ece50"
 
   url "https://github.com/browseros-ai/BrowserOS/releases/download/v#{version.csv.second || version.csv.first}/BrowserOS_v#{version.csv.first}_#{arch}.dmg",
       verified: "github.com/browseros-ai/BrowserOS/"


### PR DESCRIPTION
The `browseros` 0.46.0 release assets were re-uploaded in place on the
upstream GitHub release **after** #270427 was merged, so the cask's pinned
checksums no longer match the files served at the (unchanged) download URLs.
This makes `brew upgrade --cask browseros` fail for everyone with:

```
Cask reports different checksum:  7a1edb87cbf31544531aea793be608c3277f1ed3132d4a38fec0cc0ac4373b85
SHA-256 checksum of downloaded file: 5832b6faf78c63b5804a4cbd0787bb88787ecf9930ffb3adef6b1765b7e509c7
```

Timeline:
- `v0.46.0` release published: **2026-06-17**
- #270427 (`browseros 0.46.0`) merged: **2026-06-18**
- Both `arm64` and `x64` dmg assets re-uploaded (`created_at`/`updated_at`): **2026-06-20**

The version is unchanged because upstream reused the same `v0.46.0` tag and
filenames; only the asset bytes changed. New checksums verified by downloading
both assets directly from the release:

| arch  | old (stale) | new (verified) |
|-------|-------------|----------------|
| arm64 | `7a1edb87…` | `5832b6faf78c63b5804a4cbd0787bb88787ecf9930ffb3adef6b1765b7e509c7` |
| x64   | `7193514b…` | `30ee4a08cf3a91d6f9ebb29fbb7865d0c6e57a558e4e4b16948e80aadc6ece50` |

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

  AI (Claude) assisted with diagnosis and drafting. Manual verification I performed:
  - Independently downloaded both `arm64` and `x64` v0.46.0 dmgs from the release URLs and computed their SHA-256 with `shasum -a 256`; both match the values in this PR.
  - Confirmed via the GitHub API that both assets' `created_at`/`updated_at` (2026-06-20) postdate the merge of #270427 (2026-06-18), explaining the same-version checksum change.
  - Ran `brew style --fix Casks/b/browseros.rb` (no offenses) and `brew audit --cask --online browseros` (error-free) against this branch.
  - This PR changes only the two `sha256` lines; `version`, `url`, `livecheck`, and `zap` are untouched. The `zap` trash paths (`~/Library/Application Support/BrowserOS`, `~/Library/Caches/BrowserOS`, `~/Library/Preferences/com.browseros.BrowserOS.plist`) were verified to exist on a machine with BrowserOS installed.
