### PR TITLE
platinum-notes 10.5.0.1256 (new cask)

### DIFF
--- a/Casks/p/platinum-notes.rb
+++ b/Casks/p/platinum-notes.rb
@@ -1,0 +1,46 @@
+cask "platinum-notes" do
+  version "10.5.0.1256,57"
+  sha256 :no_check
+
+  url "https://builds.mixedinkey.com/download/#{version.csv.second}/release/latest?key=public"
+  name "Platinum Notes"
+  desc "Improve audio quality of music files"
+  homepage "https://mixedinkey.com/platinum-notes/"
+
+  # The version for the latest file can only be found by checking the headers
+  # (`Location` or `Content-Disposition`) of the unversioned URL for the latest
+  # file. This URL includes a numeric ID that varies based on major version and
+  # platform (Mac, Windows).
+  livecheck do
+    url "https://mixedinkey.com/platinum-notes/download/"
+    regex(/Platinum(?:%2B|[+._-])Notes(?:%2B|[+._-])v?(\d+(?:\.\d+)+)/i)
+    strategy :page_match do |page, regex|
+      download_id = page[%r{href="https://builds\.mixedinkey\.com/download/(\d+)/[^"]+">Download for Mac}i, 1]
+      next if download_id.blank?
+
+      Homebrew::Livecheck::Strategy.page_headers(
+        "https://builds.mixedinkey.com/download/#{download_id}/release/latest?key=public",
+      )&.map do |headers|
+        match = (headers["location"] || headers["content-disposition"])&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{download_id}"
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on :macos
+
+  app "Platinum Notes #{version.major}.app"
+
+  uninstall quit: "com.mixedinkey.PlatinumNotes"
+
+  zap trash: [
+    "~/Library/Application Support/com.mixedinkey.PlatinumNotes",
+    "~/Library/Application Support/Mixedinkey",
+    "~/Library/Caches/com.mixedinkey.PlatinumNotes",
+    "~/Library/HTTPStorages/com.mixedinkey.PlatinumNotes",
+    "~/Library/Preferences/com.mixedinkey.PlatinumNotes.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Cask was authored following the mixed-in-key-live cask as a reference. The download URL was discovered by monitoring the network tab during download of purchased apps - each app has a unique numeric ID in the URL that is tied to the app and platform, not the version (57 for Platinum Notes, 67 for Mixed In Key, 55 for Mixed In Key Live, 45 for Mixed In Key Studio Edition, 17 for Flow 8 Deck, etc.)

If this cask is accepted, I can create and submit casks for the other mentioned apps as well.

AI was used to assist with writing the commit message and this PR description. All zap stanza paths were manually verified by installing and running the app.