### PR TITLE
apfelpad 0.6.1 (new cask)

### DIFF
--- a/Casks/a/apfelpad.rb
+++ b/Casks/a/apfelpad.rb
@@ -1,0 +1,29 @@
+cask "apfelpad" do
+  version "0.6.1"
+  sha256 "3a03849f778fdc2891b9c5234dc77cb6ca3e6eb07fc2a2b10743a52656eedd35"
+
+  url "https://github.com/Arthur-Ficial/apfelpad/releases/download/v#{version}/apfelpad-macos-arm64.zip",
+      verified: "github.com/Arthur-Ficial/apfelpad/"
+  name "apfelpad"
+  desc "Formula notepad for natural language, using on-device models"
+  homepage "https://apfelpad.franzai.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates false
+  depends_on arch: :arm64
+  depends_on formula: "apfel"
+  depends_on macos: :tahoe
+
+  app "apfelpad.app"
+
+  zap trash: [
+    "~/Library/Application Support/apfelpad",
+    "~/Library/Caches/com.fullstackoptimization.apfelpad",
+    "~/Library/HTTPStorages/com.fullstackoptimization.apfelpad",
+    "~/Library/Preferences/com.fullstackoptimization.apfelpad.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Requesting exception to repo star count. This is part of a bundle of apfel-based apps, which I would much prefer be installable & updatable through Homebrew official, rather than needing to trust the [upstream tap](https://github.com/Arthur-Ficial/homebrew-tap), which is itself generated by another repo.

I would (eventually) like to submit all the sibling apfel-based apps as casks, which may also require exceptions:
- [ ] https://apfel-chat.franzai.com
- [ ] https://apfel-clip.franzai.com
- [ ] https://github.com/Arthur-Ficial/apfel-gui
