### PR TITLE
blankie 2.0.0

### DIFF
--- a/Casks/b/blankie.rb
+++ b/Casks/b/blankie.rb
@@ -1,6 +1,6 @@
 cask "blankie" do
-  version "1.0.13"
-  sha256 "1fa5a506b145790b67a3c8f3a661fd4eb7eeec8a61a5326a81546e0a3a8aac56"
+  version "2.0.0"
+  sha256 "abf590162deef5b5896daa040a9f47d67eaf366e03d2e8a1f8b0a9c3afc583dd"
 
   url "https://github.com/codybrom/blankie/releases/download/v#{version}/Blankie.zip",
       verified: "github.com/codybrom/blankie/"
@@ -10,7 +10,7 @@ cask "blankie" do
 
   no_autobump! because: :bumped_by_upstream
 
-  depends_on macos: :sonoma
+  depends_on macos: :tahoe
 
   app "Blankie.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Claude Code (claude-sonnet-4-6) assisted with computing the SHA256, resolving the `depends_on macos:` version bump (`:sonoma` → `:tahoe`, reflecting Blankie 2.0's macOS 26 minimum), and opening the PR. I (the app author) manually verified the GitHub release asset, the SHA256 checksum, and the audit output.
