### PR TITLE
cpuinfo 1.6.0

### DIFF
--- a/Casks/c/cpuinfo.rb
+++ b/Casks/c/cpuinfo.rb
@@ -1,13 +1,11 @@
 cask "cpuinfo" do
-  version "1.5.1"
-  sha256 "e6037c41db55d6032bfb0c5f6ed6b62d8303a58b1a13a972522253aeebef427a"
+  version "1.6.0"
+  sha256 "d3cd0ebfd3ce57d475101d9401aeb659c053d93486d131078a8057e61274d20d"
 
-  url "https://github.com/yusukeshib/cpuinfo/raw/#{version}/dist/cpuinfo.zip"
+  url "https://github.com/yusukeshib/cpuinfo/releases/download/v#{version}/cpuinfo.zip"
   name "cpuinfo"
   desc "CPU meter menu bar app"
   homepage "https://github.com/yusukeshib/cpuinfo"
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on :macos
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`cpuinfo` is autobumped but the workflow failed to update to version 1.6.0 because the tag has a leading "v". This updates the version and switches the `url` to use the `cpuinfo.zip` asset from the GitHub release, as upstream has created a release for this version. This version of the app passes the Gatekeeper check, so I've also removed the `disable!` call.