### PR TITLE
mix-in-key*: various updates

### DIFF
--- a/Casks/m/mixed-in-key-live.rb
+++ b/Casks/m/mixed-in-key-live.rb
@@ -1,5 +1,5 @@
 cask "mixed-in-key-live" do
-  version "11.0.4.567"
+  version "11.0.4.567,55"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://builds.mixedinkey.com/download/#{version.csv.second}/release/latest?key=public"

--- a/Casks/m/mixed-in-key-live.rb
+++ b/Casks/m/mixed-in-key-live.rb
@@ -38,15 +38,15 @@ cask "mixed-in-key-live" do
 
   pkg "Mixed In Key Live.pkg"
 
-  bundle_id = "com.mixedinkey.MIK-Live"
-  uninstall quit: bundle_id, pkgutil: "com.mixedinkey.Mixed_In_Key_Live.pkg"
+  uninstall quit:    "com.mixedinkey.MIK-Live",
+            pkgutil: "com.mixedinkey.Mixed_In_Key_Live.pkg"
 
   zap trash: [
-    "~/Library/Application Support/#{bundle_id}",
+    "~/Library/Application Support/com.mixedinkey.MIK-Live",
     "~/Library/Application Support/Mixedinkey",
-    "~/Library/Caches/#{bundle_id}",
-    "~/Library/HTTPStorages/#{bundle_id}",
-    "~/Library/Preferences/#{bundle_id}.plist",
-    "~/Library/Saved Application State/#{bundle_id}.savedState",
+    "~/Library/Caches/com.mixedinkey.MIK-Live",
+    "~/Library/HTTPStorages/com.mixedinkey.MIK-Live",
+    "~/Library/Preferences/com.mixedinkey.MIK-Live.plist",
+    "~/Library/Saved Application State/com.mixedinkey.MIK-Live.savedState",
   ]
 end

--- a/Casks/m/mixed-in-key-live.rb
+++ b/Casks/m/mixed-in-key-live.rb
@@ -1,15 +1,36 @@
 cask "mixed-in-key-live" do
   version "11.0.4.567"
-  sha256 :no_check
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://builds.mixedinkey.com/download/55/release/latest?key=public"
+  url "https://builds.mixedinkey.com/download/#{version.csv.second}/release/latest?key=public"
   name "Mixed In Key Live"
   desc "Get the Key and BPM of any audio, instantly"
   homepage "https://mixedinkey.com/live"
 
+  # The version for the latest file can only be found by checking the headers
+  # (`Location` or `Content-Disposition`) of the unversioned URL for the latest
+  # file. This URL includes a numeric ID that varies based on major version and
+  # platform (Mac, Windows). The upstream download page is specific to a given
+  # major version, so we have to fetch multiple pages to identify the current
+  # URL for the latest file.
   livecheck do
-    url :url
-    strategy :header_match
+    url "https://mixedinkey.com/get-live/"
+    regex(/Mixed(?:%2B|[+._-])In(?:%2B|[+._-])Key(?:%2B|[+._-])Live(?:%2B|[+._-])v?(\d+(?:\.\d+)+)/i)
+    strategy :page_match do |page, regex|
+      # Find the current major version      # Find the download ID for the Mac version
+      download_id = page[%r{href=.*?/download/(\d+)/.+?download(?:-|\s+for\s+)mac}im, 1]
+      next if download_id.blank?
+
+      # Identify version from the filename in headers
+      Homebrew::Livecheck::Strategy.page_headers(
+        "https://builds.mixedinkey.com/download/#{download_id}/release/latest?key=public",
+      )&.map do |headers|
+        match = (headers["location"] || headers["content-disposition"])&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{download_id}"
+      end
+    end
   end
 
   auto_updates true

--- a/Casks/m/mixed-in-key.rb
+++ b/Casks/m/mixed-in-key.rb
@@ -1,6 +1,6 @@
 cask "mixed-in-key" do
   version "11.2.6.7433,67"
-  sha256 "c57af0c5cea5421cd85323a178f9c51ed861086661e495fd19262aab21c5415c"
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://builds.mixedinkey.com/download/#{version.csv.second}/release/latest?key=public"
   name "Mixed In Key"


### PR DESCRIPTION
Remove checksum, as the package is updated in place, and also apply the update `livecheck` to `mixed-in-key-live`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
