### PR TITLE
sessionwatcher 6.3.20 (new cask)

### DIFF
--- a/Casks/s/sessionwatcher.rb
+++ b/Casks/s/sessionwatcher.rb
@@ -1,6 +1,6 @@
 cask "sessionwatcher" do
-  version "6.5.21"
-  sha256 "e1467df9b676f23a8f955eda9b985cda638bc94f97b8a57dbe2b7dbb7a6602f7"
+  version "6.5.27"
+  sha256 "9869b1b26b68b5690da08596efcab2d1af574fbf2f59e84b729de4f21f6b798b"
 
   url "https://sessionwatcher-updates.vercel.app/downloads/SessionWatcher-#{version}.dmg",
       verified: "sessionwatcher-updates.vercel.app/"
@@ -25,6 +25,7 @@ cask "sessionwatcher" do
     "~/Library/Application Scripts/group.com.sessionwatcher.app",
     "~/Library/Application Support/SessionWatcher",
     "~/Library/Caches/com.sessionwatcher.app",
+    "~/Library/Caches/com.sessionwatcher.app.sparkle",
     "~/Library/Containers/com.sessionwatcher.app.widgets",
     "~/Library/Containers/com.sessionwatcher.app.writer",
     "~/Library/Group Containers/C4XW4P5L2Q.com.sessionwatcher.app",

--- a/Casks/s/sessionwatcher.rb
+++ b/Casks/s/sessionwatcher.rb
@@ -1,6 +1,6 @@
 cask "sessionwatcher" do
-  version "6.3.25"
-  sha256 "b3438000930a872899d4ba5ac3a1d6c98f50346c383191a86e0530b74443478e"
+  version "6.5.21"
+  sha256 "e1467df9b676f23a8f955eda9b985cda638bc94f97b8a57dbe2b7dbb7a6602f7"
 
   url "https://sessionwatcher-updates.vercel.app/downloads/SessionWatcher-#{version}.dmg",
       verified: "sessionwatcher-updates.vercel.app/"
@@ -19,11 +19,15 @@ cask "sessionwatcher" do
   app "SessionWatcher.app"
 
   zap trash: [
+    "~/Library/Application Scripts/C4XW4P5L2Q.com.sessionwatcher.app",
     "~/Library/Application Scripts/com.sessionwatcher.app.widgets",
+    "~/Library/Application Scripts/com.sessionwatcher.app.writer",
     "~/Library/Application Scripts/group.com.sessionwatcher.app",
     "~/Library/Application Support/SessionWatcher",
     "~/Library/Caches/com.sessionwatcher.app",
     "~/Library/Containers/com.sessionwatcher.app.widgets",
+    "~/Library/Containers/com.sessionwatcher.app.writer",
+    "~/Library/Group Containers/C4XW4P5L2Q.com.sessionwatcher.app",
     "~/Library/Group Containers/group.com.sessionwatcher.app",
     "~/Library/HTTPStorages/com.sessionwatcher.app",
     "~/Library/HTTPStorages/com.sessionwatcher.app.binarycookies",

--- a/Casks/s/sessionwatcher.rb
+++ b/Casks/s/sessionwatcher.rb
@@ -1,6 +1,6 @@
 cask "sessionwatcher" do
-  version "6.3.20"
-  sha256 "8193eca3b9dac25ee491c16b73141c652f1f98e651404e93545ea61d5913d95c"
+  version "6.3.25"
+  sha256 "b3438000930a872899d4ba5ac3a1d6c98f50346c383191a86e0530b74443478e"
 
   url "https://sessionwatcher-updates.vercel.app/downloads/SessionWatcher-#{version}.dmg",
       verified: "sessionwatcher-updates.vercel.app/"
@@ -19,9 +19,15 @@ cask "sessionwatcher" do
   app "SessionWatcher.app"
 
   zap trash: [
+    "~/Library/Application Scripts/com.sessionwatcher.app.widgets",
+    "~/Library/Application Scripts/group.com.sessionwatcher.app",
     "~/Library/Application Support/SessionWatcher",
     "~/Library/Caches/com.sessionwatcher.app",
+    "~/Library/Containers/com.sessionwatcher.app.widgets",
+    "~/Library/Group Containers/group.com.sessionwatcher.app",
     "~/Library/HTTPStorages/com.sessionwatcher.app",
+    "~/Library/HTTPStorages/com.sessionwatcher.app.binarycookies",
     "~/Library/Preferences/com.sessionwatcher.app.plist",
+    "~/Library/WebKit/com.sessionwatcher.app",
   ]
 end

--- a/Casks/s/sessionwatcher.rb
+++ b/Casks/s/sessionwatcher.rb
@@ -5,7 +5,7 @@ cask "sessionwatcher" do
   url "https://sessionwatcher-updates.vercel.app/downloads/SessionWatcher-#{version}.dmg",
       verified: "sessionwatcher-updates.vercel.app/"
   name "SessionWatcher"
-  desc "Menu-bar monitor for Claude, Codex, and Cursor usage"
+  desc "Menu bar monitor for AI coding assistant usage and limits"
   homepage "https://www.sessionwatcher.com/"
 
   livecheck do
@@ -14,7 +14,7 @@ cask "sessionwatcher" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "SessionWatcher.app"
 

--- a/Casks/s/sessionwatcher.rb
+++ b/Casks/s/sessionwatcher.rb
@@ -1,0 +1,27 @@
+cask "sessionwatcher" do
+  version "6.3.20"
+  sha256 "8193eca3b9dac25ee491c16b73141c652f1f98e651404e93545ea61d5913d95c"
+
+  url "https://sessionwatcher-updates.vercel.app/downloads/SessionWatcher-#{version}.dmg",
+      verified: "sessionwatcher-updates.vercel.app/"
+  name "SessionWatcher"
+  desc "Menu-bar monitor for Claude, Codex, and Cursor usage"
+  homepage "https://www.sessionwatcher.com/"
+
+  livecheck do
+    url "https://sessionwatcher-updates.vercel.app/api/appcast/sessionwatcher"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "SessionWatcher.app"
+
+  zap trash: [
+    "~/Library/Application Support/SessionWatcher",
+    "~/Library/Caches/com.sessionwatcher.app",
+    "~/Library/HTTPStorages/com.sessionwatcher.app",
+    "~/Library/Preferences/com.sessionwatcher.app.plist",
+  ]
+end


### PR DESCRIPTION
Adds a cask for **SessionWatcher**, a macOS menu-bar app that monitors usage
and rate limits for **Claude, Codex, Cursor, Copilot, Gemini, Antigravity, and
OpenCode**.

- Homepage: https://www.sessionwatcher.com/
- The download is a Developer ID-signed and Apple-notarized DMG (`spctl -a -t open` → accepted, source = Notarized Developer ID).
- The app self-updates via Sparkle, hence `auto_updates true`; `livecheck` reads the app's public Sparkle appcast (`strategy :sparkle`).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

This cask was drafted with the assistance of an AI coding agent (Claude). The
following were run and observed by the submitter (maintainer of the app) on
macOS before submitting:

- `brew audit --cask --new --online --strict sessionwatcher` — error-free.
- `brew style sessionwatcher` — no offenses.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask sessionwatcher` into a temporary `--appdir`, then `brew uninstall --cask sessionwatcher` — both succeeded. A temporary appdir was used to avoid disturbing the maintainer's already-installed copy.
- `brew fetch --cask sessionwatcher` — checksum matches the served DMG.
- `brew livecheck --cask sessionwatcher` — resolves the latest version from the Sparkle appcast.

**`zap` paths** were verified to exist on disk and all derive from the app's
bundle identifier `com.sessionwatcher.app`:
`~/Library/Application Support/SessionWatcher`, `~/Library/Caches/com.sessionwatcher.app`,
`~/Library/HTTPStorages/com.sessionwatcher.app`, and
`~/Library/Preferences/com.sessionwatcher.app.plist`.
