### PR TITLE
doppler-app: re-enable

### DIFF
--- a/Casks/d/doppler-app.rb
+++ b/Casks/d/doppler-app.rb
@@ -7,8 +7,10 @@ cask "doppler-app" do
   desc "Music player"
   homepage "https://brushedtype.co/doppler/"
 
-  # Download url is unreachable due to Cloudflare protections
-  disable! date: "2026-01-25", because: :unreachable
+  livecheck do
+    url "https://updates.brushedtype.co/doppler-macos/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
 
   depends_on macos: :big_sur
 


### PR DESCRIPTION
The cask was disabled on 2026-01-25 as `:unreachable`. The versioned download (`https://assets.brushedtype.co/Doppler-2.1.22.app.zip`) is reachable again (HTTP 200, content unchanged, identical sha256), so the original reason no longer applies. This re-enables the cask and adds a Sparkle `livecheck` against the appcast.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI assisted with editing the cask and drafting this PR. What was done and how the changes were manually verified:

- Re-enabled `doppler-app` by removing the `disable! ... because: :unreachable` stanza, after confirming the download is reachable again: `https://assets.brushedtype.co/Doppler-2.1.22.app.zip` returns HTTP 200 with the same `sha256` (`5eec9fa490fc6d9d287ab6c19d0854ff419ac80c398bfcab0f14dd4a4178e3b2`).
- Added a Sparkle `livecheck` against `https://updates.brushedtype.co/doppler-macos/appcast.xml`, using `&:short_version` so it returns `2.1.22` (the appcast also carries the build `9904`).
- `brew style --fix Casks/d/doppler-app.rb` — no offenses.
- `brew audit --cask --online --strict doppler-app` — error-free (exit 0).
- `brew livecheck --cask doppler-app` — `2.1.22 ==> 2.1.22`.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask doppler-app` — download and `sha256` verification succeeded; install reached app staging.
- `zap` paths were left unchanged from the previously shipped cask and reviewed against the bundle id `co.brushedtype.doppler-macos` (caches, HTTPStorages, preferences, saved state) plus the user data folders `~/.doppler`, `~/Library/Doppler`, and `~/Music/Doppler`.
