### PR TITLE
basecamp 5.1.3

### DIFF
--- a/Casks/b/basecamp.rb
+++ b/Casks/b/basecamp.rb
@@ -1,21 +1,22 @@
 cask "basecamp" do
   arch arm: "arm64", intel: "x64"
-  livecheck_arch = on_arch_conditional arm: "_arm64"
 
-  version "5.0.8"
-  sha256 arm:   "daa9ae879dfe01bb5fdc272f6aeed4ba2e124604fefbb13de08b719eb0ec1546",
-         intel: "d9611e6af466d015b6485b8d63c278f61bf880b288c9b6660aa8ce1b69874778"
+  version "5.1.3"
+  sha256 arm:   "a26fe02d79299f2f7feb444dbecb6cbd1c47416bf6eff774be42cf0264deda6c",
+         intel: "5e2af7ae9060c183036ccf02179bc9494b9b30d8bec2da72432df5fb2ce7d404"
 
   url "https://basecamp.com/desktop/Basecamp-#{version}-mac-#{arch}.zip"
   name "Basecamp"
   desc "All-In-One Toolkit for Working Remotely"
   homepage "https://basecamp.com/"
 
+  # This file is served with a `Content-Encoding: aws-chunked` header when
+  # compression is requested but that causes curl to error because it doesn't
+  # understand what decompression to apply.
   livecheck do
-    url "https://basecamp.com/desktop/mac#{livecheck_arch}/updates.json"
-    strategy :json do |json|
-      json["version"]
-    end
+    url "https://basecamp.com/desktop/latest-mac.yml",
+        compressed: false
+    strategy :electron_builder
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`basecamp` is autobumped but the workflow hasn't updated to any versions beyond 5.0.8 because the `updates.json` file that livecheck checks is still returning 5.0.8 as newest. The app checks a `latest-mac.yml` file instead and this lists 5.1.3 as newest but we weren't able to check that file before because it's served from AWS and the response uses `Content-Encoding: aws-chunked`, which curl doesn't understand. This updates the version and switches the `livecheck` block to check the YAML file now that we can disable compression, as it avoids the aforementioned issue.