### PR TITLE
pronotes: update livecheck

### DIFF
--- a/Casks/p/pronotes.rb
+++ b/Casks/p/pronotes.rb
@@ -7,15 +7,13 @@ cask "pronotes" do
   desc "Apple Notes extension"
   homepage "https://www.pronotes.app/"
 
-  # The HTTP response for the appcast contains a `Content-Encoding: aws-chunked`
-  # header and this causes curl to return an "Unrecognized content encoding
-  # type" error when the `--compressed` option is used. livecheck uses
-  # `--compressed` when fetching content, so this check will predictably fail
-  # until we can selectively disable compression in a `livecheck` block.
+  # This file is served with a `Content-Encoding: aws-chunked` header when
+  # compression is requested but that causes curl to error because it doesn't
+  # understand what decompression to apply.
   livecheck do
-    # url "https://assets.pronotes.app/downloads/appcast.xml"
-    # strategy :sparkle, &:short_version
-    skip "curl will only return the appcast content with compression disabled"
+    url "https://assets.pronotes.app/downloads/appcast.xml",
+        compressed: false
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/p/pronotes.rb
+++ b/Casks/p/pronotes.rb
@@ -17,7 +17,7 @@ cask "pronotes" do
   end
 
   auto_updates true
-  depends_on macos: :ventura
+  depends_on macos: :sonoma
 
   app "ProNotes.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `pronotes` `livecheck` block is set to skip as the appcast is served from AWS with a `Content-Encoding: aws-chunked` header when compression is requested. livecheck uses the `--compressed` curl argument by default and there hasn't been a way to omit this but I recently added a `compressed` `url` option to make it possible. This updates the `livecheck` block to check the appcast file without the `--compressed` argument, which avoids the aforementioned issue.