### PR TITLE
element, element@nightly: update livecheck

### DIFF
--- a/Casks/e/element.rb
+++ b/Casks/e/element.rb
@@ -7,13 +7,11 @@ cask "element" do
   desc "Matrix collaboration client"
   homepage "https://element.io/get-started"
 
-  # The `releases.json` file is served with a `Content-Encoding: aws-chunked`
-  # header, which will cause curl to error if the `--compressed` option is used.
-  # This checks the version on the directory listing page until we can account
-  # for this situation in livecheck.
   livecheck do
-    url "https://packages.element.io/desktop/update/macos/index.html"
-    regex(/href=.*?Element[._-]v?(\d+(?:\.\d+)+)[._-]universal[._-]mac\.zip/i)
+    url "https://packages.element.io/desktop/update/macos/releases.json"
+    strategy :json do |json|
+      json["currentRelease"]
+    end
   end
 
   auto_updates true

--- a/Casks/e/element@nightly.rb
+++ b/Casks/e/element@nightly.rb
@@ -7,13 +7,11 @@ cask "element@nightly" do
   desc "Matrix collaboration client"
   homepage "https://element.io/get-started"
 
-  # The `releases.json` file is served with a `Content-Encoding: aws-chunked`
-  # header, which will cause curl to error if the `--compressed` option is used.
-  # This checks the version on the directory listing page until we can account
-  # for this situation in livecheck.
   livecheck do
-    url "https://packages.element.io/nightly/update/macos/index.html"
-    regex(/href=.*?Element\s+Nightly[._-]v?(\d+(?:\.\d+)*)[._-]universal[._-]mac\.zip/i)
+    url "https://packages.element.io/nightly/update/macos/releases.json"
+    strategy :json do |json|
+      json["currentRelease"]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` blocks for `element` and `element@nightly` previously checked a `releases.json` file but we had to switch away from it because the file was served from AWS with a `Content-Encoding: aws-chunked` header that causes curl to error (as it doesn't understand how to decompress it). This file now seems to be served by Cloudflare, which correctly uses `Content-Encoding: gzip` in the response.

This updates these `livecheck` blocks to return to checking `releases.json`. If we run into the `aws-chunked` issue again, we can use the `compressed: false` `url` option to disable compression while continuing to check the JSON file.