### PR TITLE
display-pilot: update livecheck

### DIFF
--- a/Casks/d/display-pilot.rb
+++ b/Casks/d/display-pilot.rb
@@ -7,11 +7,21 @@ cask "display-pilot" do
   desc "Display control utility"
   homepage "https://www.benq.com/en-ap/monitor/software/display-pilot-2.html"
 
-  # The only checkable source of version information requires a referer to work,
-  # so we're skipping this for now.
-  # See: https://github.com/Homebrew/homebrew-cask/pull/219373#issuecomment-3054380576
   livecheck do
-    skip "Requires referer for request to work"
+    url "https://www.benq.com/api/esupport-tm/getFiles/en_gb/display%20pilot%202/en_gb,ge_ge",
+        referer: "https://www.benq.com/en-ap/support/downloads-faq/products/monitor/display-pilot-2/software-driver.html"
+    regex(/Display\s+Pilot\s+\d+(?:\s+for\s+Mac)?[._-]v?(\d+(?:\.\d+)+)(?:[._-]Mac)?[._-](\d+)/i)
+    strategy :json do |json, regex|
+      json.dig("response", "list", "detail")&.filter_map do |item|
+        next unless item["OS"]&.include?("Mac")
+        next if item["Description"].match?(/Release\s+Note/i)
+
+        match = item["Download"]&.match(regex)
+        next unless match
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
   end
 
   depends_on macos: :big_sur


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

We're using a `skip` `livecheck` block in the `display-pilot` cask as the only checkable source requires a referer and this wasn't possible in livecheck at the time. I added this feature in the interim time, so this updates the `livecheck` block to implement a check using the URLs that Bevan linked in the referenced PR comment.