### PR TITLE
cursor-cli 2026.06.24-00-45-58-9f61de7

### DIFF
--- a/Casks/c/cursor-cli.rb
+++ b/Casks/c/cursor-cli.rb
@@ -1,9 +1,9 @@
 cask "cursor-cli" do
   arch arm: "arm64", intel: "x64"
 
-  version "2026.06.04-5fd875e"
-  sha256 arm:   "1acc0f746c219bf93078e4ceebabd64e9a29b5f44a3746ce9a30b014b746d2c7",
-         intel: "bf4352cf73c40a83c98340bd5269a0a5cb84f5010427176bf6d64891eaca6226"
+  version "2026.06.24-00-45-58-9f61de7"
+  sha256 arm:   "39ad91c3275fefc092631387b77d12def96ba8e394493563a0bef3d44c81475c",
+         intel: "d8e8323cd2e4857d5eae889a55b69d979eee982535015c3c28af90d1099f8118"
 
   url "https://downloads.cursor.com/lab/#{version}/darwin/#{arch}/agent-cli-package.tar.gz"
   name "Cursor CLI"
@@ -12,7 +12,7 @@ cask "cursor-cli" do
 
   livecheck do
     url "https://cursor.com/install"
-    regex(%r{downloads\.cursor\.com/lab/v?(\d+(?:\.\d+)+(?:[._-]\h+)?)/}i)
+    regex(%r{downloads\.cursor\.com/lab/v?(\d+(?:[.-]\d+)+(?:[._-]\h+)?)/}i)
   end
 
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`cursor-cli` is autobumped but the workflow failed to update to version 2026.06.24-00-45-58-9f61de7 because the version format now (presumably) includes hours/minutes/seconds separated by hyphens before the hash suffix. This updates the version and adjusts the `livecheck` block regex to be able to match this format.