### PR TITLE
sonos: update livecheck

### DIFF
--- a/Casks/s/sonos.rb
+++ b/Casks/s/sonos.rb
@@ -8,7 +8,8 @@ cask "sonos" do
   homepage "https://www.sonos.com/"
 
   livecheck do
-    url "https://www.sonos.com/redir/controller_software_mac2"
+    url "https://www.sonos.com/redir/controller_software_mac2",
+        user_agent: :curl
     regex(%r{software/(\w+)/Sonos[._-]v?(\d+(?:[.-]\d+)+)\.dmg}i)
     strategy :header_match do |headers, regex|
       headers["location"]&.scan(regex)&.map { |match| "#{match[1]},#{match[0]}" }

--- a/audit_exceptions/simple_user_agent_for_homepage.json
+++ b/audit_exceptions/simple_user_agent_for_homepage.json
@@ -8,5 +8,6 @@
   "microsoft-powerpoint",
   "microsoft-word",
   "salesforce-cli",
+  "sonos",
   "webex"
 ]


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block for `sonos` fetches a redirecting URL using the `HeaderMatch` strategy but this check is giving an "Unable to get versions" error. The URL works fine when making a basic request with curl outside of livecheck and the same is true when using the basic curl user agent in the `livecheck` block (the default user agent and `:browser` both fail). This updates the `livecheck` block to use `user_agent: :curl`, which allows the check to work as expected.