### PR TITLE
studio-3t 2026.11.0

### DIFF
--- a/Casks/s/studio-3t.rb
+++ b/Casks/s/studio-3t.rb
@@ -2,9 +2,9 @@ cask "studio-3t" do
   arch arm: "-aarch64"
   livecheckarch = on_arch_conditional arm: "_aarch64"
 
-  version "2026.8.0"
-  sha256 arm:   "a94f17e537896662c2b6e878c4ecaffe20b572805dc6728775ab865f8800a24a",
-         intel: "1c66751087cfe15ed41f613099fd4dc8f3a8849c0eed0a3c505545d629c7d48f"
+  version "2026.11.0"
+  sha256 arm:   "a88fcf7822cfd0e6cc112edb4d8b42b28a069a23f5705802bc5584df13506e71",
+         intel: "3d0ac43a93644191170f9655a4054dad320e70de49f4a3268dcd0d66a4c8d6c5"
 
   url "https://download.studio3t.com/studio-3t/mac#{arch}/#{version}/Studio-3T.dmg"
   name "Studio 3T"
@@ -12,7 +12,8 @@ cask "studio-3t" do
   homepage "https://studio3t.com/"
 
   livecheck do
-    url "https://studio3t.com/download-thank-you/?OS=osx#{livecheckarch}"
+    url "https://studio3t.com/download-thank-you/?OS=osx#{livecheckarch}",
+        cookies: { "3t-can-download-software" => "1" }
     regex(%r{/v?(\d+(?:\.\d+)+)/Studio[._-]?3T\.dmg}i)
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`studio-3t` is autobumped but the workflow failed to update to version 2026.11.0 because livecheck is giving an "Unable to get versions" error. The `livecheck` block URL now redirects to the main download page (https://studio3t.com/download/) unless the request has a `3t-can-download-software=1` cookie set. This updates the version and adds the cookie to the `livecheck` block.