### PR TITLE
notepadexe 1.4.1883

### DIFF
--- a/Casks/n/notepadexe.rb
+++ b/Casks/n/notepadexe.rb
@@ -1,6 +1,6 @@
 cask "notepadexe" do
-  version "1.4.1803"
-  sha256 "769160491fe526458b303fef73b539e9ad05509593055af444ed96d4838f365f"
+  version "1.4.1883"
+  sha256 "c3524d32e81fd34d23f884612f0ef7354892eefece21ddf6017059118fe1bbd2"
 
   url "https://github.com/notepadhq/notepadexe-public/releases/download/#{version}/Notepad.zip",
       verified: "github.com/notepadhq/notepadexe-public/releases/download/"
@@ -9,7 +9,7 @@ cask "notepadexe" do
   homepage "https://notepadexe.com/"
 
   livecheck do
-    url "https://softwareupdate-notepadexe.swift.best/notepadexe-appcast.xml"
+    url "https://softwareupdate.notepadexe.com/appcast/notepadexe-appcast.xml"
     strategy :sparkle, &:short_version
   end
 
@@ -22,6 +22,7 @@ cask "notepadexe" do
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/best.swift.notepad.sfl*",
     "~/Library/Application Support/Notepad.exe",
     "~/Library/Autosave Information/Notepad.exe",
+    "~/Library/Caches/best.swift.Notepad",
     "~/Library/Caches/Notepad.exe",
     "~/Library/Caches/SentryCrash/Notepad.exe",
     "~/Library/HTTPStorages/best.swift.Notepad",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`notepadexe` is autobumped but the workflow failed to update to version 1.4.1883 because the host for the `livecheck` block URL no longer resolves. This updates the version and aligns the `livecheck` block with the URL used in the newest version of the app.