### PR TITLE
resilio-sync: update livecheck

### DIFF
--- a/Casks/r/resilio-sync.rb
+++ b/Casks/r/resilio-sync.rb
@@ -9,7 +9,10 @@ cask "resilio-sync" do
 
   livecheck do
     url "https://syncapp.zendesk.com/api/v2/help_center/en-us/articles/31386579044755"
-    regex(/u003ev?(\d+(?:\.\d+)+)[\\ "<]/i)
+    regex(/>\s*v?(\d+(?:\.\d+)+)[ (<]/i)
+    strategy :json do |json, regex|
+      json.dig("article", "body")&.scan(regex)&.map { |match| match[0] }
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block regex for `resilio-sync` no longer matches versions in the fetched content, so livecheck produces an "Unable to get versions" error. This updates the `livecheck` block to match versions in the current `body` string (containing HTML text). I've also added a `Json` `strategy` block, to ensure the check specifically matches within the `body` field in the JSON data.