### PR TITLE
paper 5.4.5

### DIFF
--- a/Casks/p/paper.rb
+++ b/Casks/p/paper.rb
@@ -1,16 +1,15 @@
 cask "paper" do
-  version "5.3.0"
-  sha256 "475c6938114873fc527486e8c116dbba34856420dcdcfbb767c74e9c8f16c3c6"
+  version "5.4.5"
+  sha256 "5411cbee2fd73f7f309e3df50d0e43264aa25f7b8f5f7bc17f0e25aea60c6660"
 
-  url "https://s3.nxn.fun/dl/paper-v#{version}.dmg",
-      verified: "s3.nxn.fun/"
+  url "https://www.paperapp.net/app/pap.er_v#{version}.dmg"
   name "pap.er"
   desc "Pap.er, 4K 5K HD Wallpaper Application"
-  homepage "https://paper.photos/"
+  homepage "https://www.paperapp.net/"
 
   livecheck do
     url :homepage
-    regex(/paper[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    regex(/pap\.?er[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`paper` is autobumped but the workflow failed to update to version 5.4.5 because the existing homepage no longer works. This updates the version and adjusts the cask accordingly.

For what it's worth, the previous homepage doesn't link to the new homepage and I had to find it independently. I looked at an archived snapshot of the old homepage (on archive.org) and the link to the app ID for the Mac App Store version is still the same, so that's something.