### PR TITLE
rockxy 0.28.0,44

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.27.2,43"
-  sha256 "34a64358804e5121fd255b992450fde95e8ef4f7cea3045aeac3a3b7d8a7d2af"
+  version "0.28.0,44"
+  sha256 "ffd54f378680ea136be48a64fc93d6ebfc566ff6941d98c8bd643ea21d9a5143"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance was used to update the existing `rockxy` cask version and SHA and to run/review release verification commands. I manually verified the cask diff, version `0.28.0,44`, SHA-256, download URL, livecheck result, `brew fetch --cask rockxy --force`, `brew install --dry-run --cask rockxy`, `brew audit --cask --online rockxy`, `brew style --fix rockxy`, `brew lgtm --online`, and the Homebrew CI results. The existing `zap` stanza paths were reviewed and left unchanged.

-----

Updates Rockxy to 0.28.0 build 44.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.28.0/Rockxy-0.28.0-44.dmg
- SHA-256: ffd54f378680ea136be48a64fc93d6ebfc566ff6941d98c8bd643ea21d9a5143
- Notarized: true
