### PR TITLE
meetmic: rename from quickwhisper

### DIFF
--- a/Casks/m/meetmic.rb
+++ b/Casks/m/meetmic.rb
@@ -1,16 +1,16 @@
-cask "quickwhisper" do
-  version "1.29.336"
-  sha256 "7a5dfe96fe5882ce120c45de07d3289702b789bde1277f0a13f720ae8eba733b"
+cask "meetmic" do
+  version "1.30.357"
+  sha256 "8aec9292ba3e296b7335738eaa7d0c691b25cc0f6d0cb22f892c3eaa691ed040"
 
-  url "https://quickwhisperapp.s3.us-west-002.backblazeb2.com/QuickWhisper_#{version}.zip",
-      verified: "quickwhisperapp.s3.us-west-002.backblazeb2.com/"
-  name "QuickWhisper"
+  url "https://meetmicapp.s3.us-west-002.backblazeb2.com/MeetMic_#{version}.zip",
+      verified: "meetmicapp.s3.us-west-002.backblazeb2.com/"
+  name "MeetMic"
   desc "Audio transcription tool"
-  homepage "https://quickwhisper.app/"
+  homepage "https://meetmic.app/"
 
   livecheck do
-    url "https://f002.backblazeb2.com/file/quickwhisperapp/appcast.xml"
-    regex(/QuickWhisper[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    url "https://f002.backblazeb2.com/file/meetmicapp/appcast.xml"
+    regex(/MeetMic[._-]v?(\d+(?:\.\d+)+)\.zip/i)
     strategy :sparkle do |item, regex|
       item.url[regex, 1]
     end
@@ -20,7 +20,7 @@ cask "quickwhisper" do
   depends_on macos: :sequoia
   depends_on arch: :arm64
 
-  app "QuickWhisper.app"
+  app "MeetMic.app"
 
   zap trash: [
     "~/Library/Application Scripts/ltd.iwt.QuickWhisper",

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -158,6 +158,7 @@
   "puzzles": "puzzles-app",
   "qlc-plus": "qlc+",
   "qlvideo": "quicklook-video",
+  "quickwhisper": "meetmic",
   "quit-all": "quitall",
   "r": "r-app",
   "rapidminer-studio": "ai-studio",


### PR DESCRIPTION
QuickWhisper has rebranded to **MeetMic**. The app now ships as `MeetMic.app` from `meetmicapp.s3...backblazeb2.com`, homepage https://meetmic.app/. This renames the cask and bumps to the current release `1.30.357`. The bundle identifier is unchanged (`ltd.iwt.QuickWhisper`), so the `zap` paths and existing user data are preserved across the rename.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) assisted in editing the cask and drafting this PR. Manual verification performed:

- Downloaded `MeetMic_1.30.357.zip` and confirmed the `sha256` matches.
- Extracted the app and read `Contents/Info.plist`: app is `MeetMic.app`, `CFBundleIdentifier` is `ltd.iwt.QuickWhisper` (unchanged from the old `quickwhisper` cask). The bundle id is intentionally retained across the rebrand for Sparkle update continuity, so the existing `zap` paths under `~/Library/.../ltd.iwt.QuickWhisper*` remain correct and were left as-is.
- Ran `brew style`, `brew audit --cask --online --new meetmic` (error-free), and `brew install --cask meetmic` / `brew uninstall --cask meetmic` locally. The install exercised the `cask_renames.json` entry and correctly migrated an existing `quickwhisper` install to `meetmic`.
