### PR TITLE
unity 6000.5.1f1

### DIFF
--- a/Casks/u/unity.rb
+++ b/Casks/u/unity.rb
@@ -1,9 +1,10 @@
 cask "unity" do
   arch arm: "Arm64"
+  livecheck_arch = on_arch_conditional arm: "ARM64", intel: "X86_64"
 
-  version "2023.2.20f1,0e25a174756c"
-  sha256 arm:   "432b014d7bf50f82cb2a0978571df5f1f515c59a2f6826761cb20c32d196763f",
-         intel: "c7e203a316b308acab23a81bba16c17be94c65fa210a4c0e5f083d83f2c10b3f"
+  version "6000.5.1f1,0d9463e84828"
+  sha256 arm:   "8876c35a17aa961bbbaf43cd8e7bd0e95f236ca25fa189831fb43a3a74e43377",
+         intel: "0419e5fc72a9b51505cf995df5fcbd41aeb0b2972c571ccd395670b33d0c1ea0"
 
   url "https://download.unity3d.com/download_unity/#{version.csv.second}/MacEditorInstaller#{arch}/Unity-#{version.csv.first}.pkg",
       verified: "download.unity3d.com/download_unity/"
@@ -12,22 +13,22 @@ cask "unity" do
   homepage "https://unity.com/"
 
   livecheck do
-    url "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
-    regex(%r{/(\h+)/MacEditorInstaller/Unity[._-]v?(\d+(?:\.\d+)+(?:f\d+)?)\.pkg}i)
+    url "https://services.api.unity.com/unity/editor/release/v1/releases?platform=MAC_OS&stream=SUPPORTED&architecture=#{livecheck_arch}&limit=1&offset=0"
+    regex(%r{/(\h+)/MacEditorInstaller#{arch}/Unity[._-]v?(\d+(?:\.\d+)+(?:f\d+)?)\.pkg}i)
     strategy :json do |json, regex|
-      json["official"]&.map do |release|
-        # Only use 202X.X.XfX versions until Unity 6 (6000) is a full release
-        next unless release["version"]&.start_with?("202")
-
-        match = release["downloadUrl"]&.match(regex)
-        next if match.blank?
-
-        "#{match[2]},#{match[1]}"
+      match = nil
+      json["results"]&.each do |item|
+        item["downloads"]&.each do |download|
+          match = download["url"]&.match(regex)
+          break if match
+        end
+        break if match
       end
+      next unless match
+
+      "#{match[2]},#{match[1]}"
     end
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on :macos
   depends_on cask: "unity-hub"
@@ -38,16 +39,17 @@ cask "unity" do
             pkgutil: "com.unity3d.UnityEditor5.x",
             delete:  "/Applications/Unity"
 
-  zap trash: [
-    "/Library/Application Support/Unity",
-    "~/Library/Application Support/Unity*",
-    "~/Library/Caches/com.unity3d.UnityEditor",
-    "~/Library/Logs/Unity",
-    "~/Library/Preferences/com.unity.BugReporterV2.plist",
-    "~/Library/Preferences/com.unity3d.UnityEditor5.x.plist",
-    "~/Library/Preferences/com.unity3d.unityhub.plist",
-    "~/Library/Preferences/unity.DefaultCompany.*",
-    "~/Library/Saved Application State/com.unity3d.unityhub.savedState",
-    "~/Library/Unity",
-  ]
+  zap delete: "/Library/Application Support/Unity",
+      trash:  [
+        "/Library/Application Support/Unity",
+        "~/Library/Application Support/Unity*",
+        "~/Library/Caches/com.unity3d.UnityEditor",
+        "~/Library/Logs/Unity",
+        "~/Library/Preferences/com.unity.BugReporterV2.plist",
+        "~/Library/Preferences/com.unity3d.UnityEditor5.x.plist",
+        "~/Library/Preferences/com.unity3d.unityhub.plist",
+        "~/Library/Preferences/unity.DefaultCompany.*",
+        "~/Library/Saved Application State/com.unity3d.unityhub.savedState",
+        "~/Library/Unity",
+      ]
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`unity` is autobumped but the `livecheck` block produces an "Unable to get versions" error as the URL gives a 404 (Not Found) response. However, even when the URL worked, this cask has been stuck on 202x versions for years because we added a temporary guard to the `strategy` block to skip Unity 6 versions when they were only in the "tech preview" stream. Unfortunately, we never revisited this situation to remove the guard and update the cask to version 6 after it stabilized.

This updates the cask to 6000.5.1f1 (the latest supported version) and reworks the `livecheck` block to check the releases API. I've set the check to only return one result but we can increase the number if/when it becomes a problem in the future.