### PR TITLE
geolibre 1.8.0 (new cask)

### DIFF
--- a/Casks/g/geolibre.rb
+++ b/Casks/g/geolibre.rb
@@ -8,7 +8,7 @@ cask "geolibre" do
   url "https://github.com/opengeos/GeoLibre/releases/download/v#{version}/GeoLibre.Desktop_#{version}_#{arch}.dmg",
       verified: "github.com/opengeos/GeoLibre/"
   name "GeoLibre Desktop"
-  desc "Lightweight, cloud-native GIS platform"
+  desc "GIS platform"
   homepage "https://geolibre.app/"
 
   livecheck do

--- a/Casks/g/geolibre.rb
+++ b/Casks/g/geolibre.rb
@@ -11,11 +11,6 @@ cask "geolibre" do
   desc "GIS platform"
   homepage "https://geolibre.app/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   depends_on macos: :catalina
 
   app "GeoLibre Desktop.app"

--- a/Casks/g/geolibre.rb
+++ b/Casks/g/geolibre.rb
@@ -16,7 +16,7 @@ cask "geolibre" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "GeoLibre Desktop.app"
 

--- a/Casks/g/geolibre.rb
+++ b/Casks/g/geolibre.rb
@@ -1,0 +1,30 @@
+cask "geolibre" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "1.8.0"
+  sha256 arm:   "ecb920721c0e5b2018b6a7ec3e59fc658b738cb10eb243e4c1e2ba5b436a2824",
+         intel: "d472683fef8026deebf7b0ecd24f53c5c487f3342aef85e59b14a4756fd59d50"
+
+  url "https://github.com/opengeos/GeoLibre/releases/download/v#{version}/GeoLibre.Desktop_#{version}_#{arch}.dmg",
+      verified: "github.com/opengeos/GeoLibre/"
+  name "GeoLibre Desktop"
+  desc "Lightweight, cloud-native GIS platform"
+  homepage "https://geolibre.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "GeoLibre Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/org.geolibre.desktop",
+    "~/Library/Caches/org.geolibre.desktop",
+    "~/Library/Preferences/org.geolibre.desktop.plist",
+    "~/Library/Saved Application State/org.geolibre.desktop.savedState",
+    "~/Library/WebKit/org.geolibre.desktop",
+  ]
+end


### PR DESCRIPTION
New cask for **GeoLibre** — a free, open-source (MIT), lightweight, cloud-native GIS desktop app built with Tauri v2. Universal coverage via the `arch` stanza (`aarch64` Apple Silicon + `x64` Intel DMGs). macOS builds are signed with an Apple Developer ID certificate and notarized by Apple. Homepage: https://geolibre.app/ · Repo: https://github.com/opengeos/GeoLibre (1.3k★ / 176 forks).

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

(The audit/style/install/uninstall steps are verified green by this PR's CI matrix across macOS 14, 15, and 26 on both arm and intel.)

-----

- [x] AI was used to generate or assist with generating this PR.

I am the maintainer of the upstream project (opengeos/GeoLibre). I used Claude to draft the cask and open this PR. Manual verification performed:

- Both DMG `sha256` values were verified by downloading the release artifacts and hashing them locally (they match the published builds).
- `version`, `url` (the `verified:` GitHub prefix), `name`, `desc`, and `homepage` were checked against the upstream release and project metadata.
- `depends_on macos: :catalina` reflects Tauri v2's documented minimum macOS version.
- The `app` token `GeoLibre Desktop.app` matches the Tauri `productName`.
- The `zap` trash paths were derived from the app's bundle identifier `org.geolibre.desktop` (standard `~/Library/{Application Support,Caches,Preferences,Saved Application State,WebKit}` locations) and reviewed by hand.
