### PR TITLE
openusage@beta 0.7.0-beta.15 (new cask)

### DIFF
--- a/Casks/o/openusage@beta.rb
+++ b/Casks/o/openusage@beta.rb
@@ -1,0 +1,41 @@
+cask "openusage@beta" do
+  version "0.7.0-beta.15"
+  sha256 "54125badebdcd2a706a43e0a4a94f221747720f7f18c6ac287db01c4cabe9455"
+
+  url "https://github.com/robinebers/openusage/releases/download/v#{version}/OpenUsage-#{version}.dmg",
+      verified: "github.com/robinebers/openusage/"
+  name "OpenUsage"
+  desc "AI usage tracker for Cursor, Claude Code, Codex and more"
+  homepage "https://www.openusage.ai/"
+
+  livecheck do
+    url :url
+    regex(/OpenUsage[._-]v?(\d+(?:\.\d+)+-beta(?:[.-]\d+)+)\.dmg/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next unless release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten.compact
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "openusage"
+  depends_on macos: :sequoia
+
+  app "OpenUsage.app"
+
+  zap trash: [
+    "~/Library/Caches/com.robinebers.openusage",
+    "~/Library/HTTPStorages/com.robinebers.openusage",
+    "~/Library/Logs/OpenUsage",
+    "~/Library/Preferences/com.robinebers.openusage.plist",
+    "~/Library/Preferences/com.robinebers.openusage.telemetry.plist",
+  ]
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -49,6 +49,7 @@
   "opencloud": "any",
   "openra@playtest": "all",
   "openshot-video-editor@daily": "all",
+  "openusage@beta": "any",
   "orcaslicer@nightly": "all",
   "osu@tachyon": "any",
   "playcover-community@beta": "all",


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online openusage@beta` is error-free.
- [x] `brew style --fix openusage@beta` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+openusage&type=pullrequests).
- [x] `brew audit --cask --new openusage@beta` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask openusage@beta` worked successfully.
- [x] `brew uninstall --cask openusage@beta` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including `zap` stanza paths*.

I used qwen3.6:27b-mlx + Ollama to draft this cask. It wrote the Ruby file, the `github_prerelease_allowlist.json` entry, and the `livecheck` block.

This is a new beta-channel cask for `openusage`. The upstream project publishes beta builds as separate GitHub pre-releases (`vX.Y.Z-beta.N`), similar to existing beta casks such as `firefox@beta`.

I manually verified the package, reviewed the upstream source, and tested a full install → run → `zap` uninstall cycle. All current `zap` entries were verified, and obsolete paths were removed.

`conflicts_with cask: "openusage"` is set because the stable and beta versions cannot coexist.

-----
