### PR TITLE
mate-translate: add auto_updates true, update homepage

### DIFF
--- a/Casks/m/mate-translate.rb
+++ b/Casks/m/mate-translate.rb
@@ -2,16 +2,18 @@ cask "mate-translate" do
   version "8.3.3"
   sha256 :no_check
 
-  url "https://gikken.co/mate/MateTranslate.dmg"
+  url "https://gikken.co/mate/MateTranslate.dmg",
+      verified: "gikken.co/mate/"
   name "Mate Translate"
   desc "Select text in any app and translate it"
-  homepage "https://gikken.co/mate-translate/mac/"
+  homepage "https://matetranslate.com/"
 
   livecheck do
     url "https://gikken.co/mate/appcast-sub.xml"
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on :macos
 
   app "Mate Translate.app"


### PR DESCRIPTION
Fixes mate-translate item in #170994.

While verifying, I noticed the homepage differs from the current domain. The old URL now redirects to [matetranslate.com](https://matetranslate.com) with 301, so I updated that as well.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI was used to assist with writing the commit message and PR description.