### PR TITLE
Add matrix cask

### DIFF
--- a/Casks/m/matrix.rb
+++ b/Casks/m/matrix.rb
@@ -1,0 +1,38 @@
+cask "matrix" do
+  version "0.1.87,119"
+  sha256 "b16e8d7f70a99783c2987a57cedbf2625eb150ee43da44e2f5c46e34786ed5af"
+
+  url "https://download.matrix.build/mac/#{version.csv.first}/Matrix-#{version.csv.first}-arm64.dmg"
+  name "Matrix"
+  desc "Workspace for coordinating AI agents"
+  homepage "https://matrix.build/"
+
+  livecheck do
+    url "https://download.matrix.build/mac/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "Matrix.app"
+
+  uninstall quit: "com.matrixai.app"
+
+  zap trash: [
+    "~/.browser-v2",
+    "~/.neo",
+    "~/Library/Application Support/com.matrixai.app",
+    "~/Library/Application Support/Matrix",
+    "~/Library/Caches/com.matrixai.app",
+    "~/Library/Caches/Matrix",
+    "~/Library/Caches/neo-cli-nodejs",
+    "~/Library/Caches/neo-cuadriver",
+    "~/Library/HTTPStorages/com.matrixai.app",
+    "~/Library/HTTPStorages/com.matrixai.app.binarycookies",
+    "~/Library/Preferences/com.matrixai.app.plist",
+    "~/Library/Saved Application State/com.matrixai.app.savedState",
+    "~/Library/WebKit/com.matrixai.app",
+  ]
+end


### PR DESCRIPTION
Adds the Matrix macOS app cask.\n\nMatrix is distributed as a signed and notarized stable DMG from the official download host. The app is closed-source, but Homebrew Cask accepts closed-source GUI applications.\n\nValidation run locally before opening this draft:\n- brew style --cask matrix\n- brew livecheck --cask matrix\n\nThe local machine cannot currently complete brew audit because its Xcode is 26.4 while Homebrew requires Xcode 27.0 in developer mode. This draft is opened first so CI can surface the remaining official-cask issues before marking ready for review.