### PR TITLE
matrix 0.1.88 (new cask)

### DIFF
--- a/Casks/m/matrix.rb
+++ b/Casks/m/matrix.rb
@@ -1,6 +1,6 @@
 cask "matrix" do
-  version "0.1.87"
-  sha256 "b16e8d7f70a99783c2987a57cedbf2625eb150ee43da44e2f5c46e34786ed5af"
+  version "0.1.88"
+  sha256 "a0ec48c6e87f50336c4c689c6055701be075051d3bd396fe11c20fb886248114"
 
   url "https://download.matrix.build/mac/#{version}/Matrix-#{version}-arm64.dmg"
   name "Matrix"
@@ -21,14 +21,10 @@ cask "matrix" do
   uninstall quit: "com.matrixai.app"
 
   zap trash: [
-    "~/.browser-v2",
-    "~/.neo",
     "~/Library/Application Support/com.matrixai.app",
     "~/Library/Application Support/Matrix",
     "~/Library/Caches/com.matrixai.app",
     "~/Library/Caches/Matrix",
-    "~/Library/Caches/neo-cli-nodejs",
-    "~/Library/Caches/neo-cuadriver",
     "~/Library/HTTPStorages/com.matrixai.app",
     "~/Library/HTTPStorages/com.matrixai.app.binarycookies",
     "~/Library/Preferences/com.matrixai.app.plist",

--- a/Casks/m/matrix.rb
+++ b/Casks/m/matrix.rb
@@ -1,0 +1,38 @@
+cask "matrix" do
+  version "0.1.87,119"
+  sha256 "b16e8d7f70a99783c2987a57cedbf2625eb150ee43da44e2f5c46e34786ed5af"
+
+  url "https://download.matrix.build/mac/#{version.csv.first}/Matrix-#{version.csv.first}-arm64.dmg"
+  name "Matrix"
+  desc "Workspace for coordinating AI agents"
+  homepage "https://matrix.build/"
+
+  livecheck do
+    url "https://download.matrix.build/mac/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "Matrix.app"
+
+  uninstall quit: "com.matrixai.app"
+
+  zap trash: [
+    "~/.browser-v2",
+    "~/.neo",
+    "~/Library/Application Support/com.matrixai.app",
+    "~/Library/Application Support/Matrix",
+    "~/Library/Caches/com.matrixai.app",
+    "~/Library/Caches/Matrix",
+    "~/Library/Caches/neo-cli-nodejs",
+    "~/Library/Caches/neo-cuadriver",
+    "~/Library/HTTPStorages/com.matrixai.app",
+    "~/Library/HTTPStorages/com.matrixai.app.binarycookies",
+    "~/Library/Preferences/com.matrixai.app.plist",
+    "~/Library/Saved Application State/com.matrixai.app.savedState",
+    "~/Library/WebKit/com.matrixai.app",
+  ]
+end

--- a/Casks/m/matrix.rb
+++ b/Casks/m/matrix.rb
@@ -1,8 +1,8 @@
 cask "matrix" do
-  version "0.1.87,119"
+  version "0.1.87"
   sha256 "b16e8d7f70a99783c2987a57cedbf2625eb150ee43da44e2f5c46e34786ed5af"
 
-  url "https://download.matrix.build/mac/#{version.csv.first}/Matrix-#{version.csv.first}-arm64.dmg"
+  url "https://download.matrix.build/mac/#{version}/Matrix-#{version}-arm64.dmg"
   name "Matrix"
   desc "Workspace for coordinating AI agents"
   homepage "https://matrix.build/"

--- a/Casks/m/matrix.rb
+++ b/Casks/m/matrix.rb
@@ -9,7 +9,7 @@ cask "matrix" do
 
   livecheck do
     url "https://download.matrix.build/mac/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI helped draft the cask and iterate on Homebrew audit feedback. Manual verification performed:

- Confirmed the stable download URL and SHA-256 for Matrix 0.1.87.
- Confirmed Sparkle livecheck against `https://download.matrix.build/mac/appcast.xml`.
- Ran `brew style --cask matrix` locally with no offenses.
- Ran `brew audit --cask --online techx-academy/matrix/matrix` successfully in GitHub Actions using the same cask content.
- Ran install, Info.plist version verification, and uninstall successfully in GitHub Actions from the `techx-academy/homebrew-matrix` tap.
- Confirmed Homebrew/homebrew-cask PR CI passed `brew fetch --cask matrix`, `brew audit --cask matrix`, `brew install --cask matrix`, and `brew uninstall --cask matrix`.
- Reviewed `zap` paths against Matrix app support/cache/preferences/web data locations used by the macOS app.

Local `brew audit --cask --new --online matrix` is blocked by the local machine's Xcode 26.4 requirement for Xcode 27.0. Homebrew/homebrew-cask PR CI completed successfully on the official runner.

-----
