### PR TITLE
Update Mailmaster to version 5.6.3.1488

### DIFF
--- a/Casks/m/mailmaster.rb
+++ b/Casks/m/mailmaster.rb
@@ -1,6 +1,6 @@
 cask "mailmaster" do
-  version "5.5.6.1476"
-  sha256 "95b8d8aa22eba8c1dbb497eb92cc16975b1af071e62fef4f94259e11bcf21791"
+  version "5.6.3.1488"
+  sha256 "2937dc1481765390d576124d1275db3e73f9db373bed14bc17ea880b4936de8c"
 
   url "https://res.126.net/dl/client/macmail/dashi/mail#{version.major}.dmg",
       verified:   "res.126.net/dl/client/macmail/dashi/",


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version
- [x] `brew audit --cask --online mailmaster` is error-free.
- [x] `brew style --fix mailmaster` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the token reference
- [ ] Checked the cask was not already refused
- [ ] `brew audit --cask --new mailmaster` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask mailmaster` worked successfully.
- [ ] `brew uninstall --cask mailmaster` worked successfully.