### PR TITLE
Update Mailmaster to version 5.6.3.1488

### DIFF
--- a/Casks/m/mailmaster.rb
+++ b/Casks/m/mailmaster.rb
@@ -1,6 +1,6 @@
 cask "mailmaster" do
-  version "5.5.6.1476"
-  sha256 "95b8d8aa22eba8c1dbb497eb92cc16975b1af071e62fef4f94259e11bcf21791"
+  version "5.6.3.1488"
+  sha256 "2937dc1481765390d576124d1275db3e73f9db373bed14bc17ea880b4936de8c"
 
   url "https://res.126.net/dl/client/macmail/dashi/mail#{version.major}.dmg",
       verified:   "res.126.net/dl/client/macmail/dashi/",


### PR DESCRIPTION
## Important: Before submitting a pull request
- [X] The submission is for a stable version or documented exception.
- [X] `brew audit --cask --online mailmaster` reports no errors.
- [X] `brew style --fix mailmaster` reports no offenses.

### Changes made
Upgrade MailMaster to stable version 5.6.3.1488
1. Fixed version format to comma-separated `5.6.3.1488` following Homebrew spec
2. Updated sha256 checksum for new official `mail5.dmg` installer
3. Modified livecheck regex `split(/[,.]/)` to support comma build number
4. Download URL template `mail#{version.major}.dmg` resolves to correct CDN link
5. Local test passed: install / uninstall / audit / style all clean

### New SHA256 Checksum
2937dc1481765390d576124d1275db3e73f9db373bed14bc17ea880b4936de8c

### Verification
Download source URL: https://res.126.net/dl/client/macmail/dashi/mail5.dmg
Local installation test successful with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask mailmaster`