### PR TITLE
cursor-cli: track prod channel in livecheck

### DIFF
--- a/Casks/c/cursor-cli.rb
+++ b/Casks/c/cursor-cli.rb
@@ -11,7 +11,7 @@ cask "cursor-cli" do
   homepage "https://cursor.com/"
 
   livecheck do
-    url "https://cursor.com/install"
+    url "https://cursor.com/install?channel=prod"
     regex(%r{downloads\.cursor\.com/lab/v?(\d+(?:[.-]\d+)+(?:[._-]\h+)?)/}i)
   end
 


### PR DESCRIPTION
This pins the `cursor-cli` livecheck to Cursor's **prod** (stable) release channel instead of relying on the undocumented default of `https://cursor.com/install`.

I'm from Cursor (Anysphere), the upstream of this app.

### Why

The Cursor CLI is published on two channels:

- `lab` — bleeding-edge / nightly builds
- `prod` — the stable channel intended for general users

A subtlety: **both channels are served from the same `downloads.cursor.com/lab/<version>/` storage prefix** — the channel only selects *which version string* is served, not the URL path. (There is no separate `/prod/` download path.) So the `url` stanza intentionally stays on `/lab/`; only the livecheck source needs to express the channel.

```
cursor.com/install?channel=<lab|prod>
        │
        ├─ channel=lab  → version "2026.06.27-..."   (nightly)
        └─ channel=prod → version "2026.06.26-..."   (stable)   ← what a Homebrew cask should ship
                                  │
                                  ▼
        downloads.cursor.com/lab/<version>/darwin/<arch>/agent-cli-package.tar.gz
```

Previously the livecheck hit `https://cursor.com/install` with no channel, which happens to resolve to `prod` today, but that default is not contractual. Passing `?channel=prod` makes the cask explicitly and durably track the stable channel so a future change to the default can't auto-bump Homebrew users onto nightly `lab` builds.

### What changed

- `livecheck` `url`: `https://cursor.com/install` → `https://cursor.com/install?channel=prod`

No version/sha change is needed: the current pinned version (`2026.06.26-7079533`) is already the prod build, so this is a no-op for the currently shipped artifact and only affects future auto-bumps. The `regex` is unchanged because the prod install script still emits `downloads.cursor.com/lab/<version>/` URLs.