### PR TITLE
zed@preview: fix completion generation

### DIFF
--- a/Casks/z/zed@preview.rb
+++ b/Casks/z/zed@preview.rb
@@ -23,6 +23,11 @@ cask "zed@preview" do
   app "Zed Preview.app"
   binary "#{appdir}/Zed Preview.app/Contents/MacOS/cli", target: "zed-preview"
 
+  preflight do
+    FileUtils.ln_s "#{appdir}/Zed Preview.app/Contents/MacOS/cli",
+                   "#{staged_path}/zed-preview"
+  end
+
   generate_completions_from_executable "zed-preview", "--completions"
 
   zap trash: [


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Fixes the following warning introduced via #271770.

```
Warning: Failed to generate zsh completions from zed-preview: Failure while executing; `/usr/bin/sandbox-exec -f /private/tmp/homebrew-sandbox20260627-87322-r0w7fq/homebrew.sb /usr/bin/env HOME=/private/tmp/homebrew-cask-home20260627-87322-7oxckc SHELL=zsh /bin/sh -c output=\$1\;\ shift\;\ exec\ \"\$@\"\ \>\ \"\$output\"\ 2\>/dev/null sh /private/tmp/homebrew-cask-completions20260627-87322-92iyh5 zed-preview --completions zsh` exited with 127.
```