### PR TITLE
valkey-admin 1.0.1 (new cask)

### DIFF
--- a/Casks/v/valkey-admin.rb
+++ b/Casks/v/valkey-admin.rb
@@ -1,0 +1,20 @@
+cask "valkey-admin" do
+  arch arm: "-arm64"
+
+  version "1.0.1"
+  sha256 arm:   "348bb49f2edbf0f48a43ae440703c23cdaecccfbe0dc797a86e44fdc02351752",
+         intel: "958f640429c8a801cc0a71c681b5cb07379ef2bc687c96cb5ab79beba16cb8db"
+
+  url "https://github.com/valkey-io/valkey-admin/releases/download/v#{version}/Valkey.Admin-#{version}#{arch}.dmg",
+      verified: "github.com/valkey-io/valkey-admin/"
+  name "Valkey Admin"
+  desc "Administration tool for Valkey clusters and standalone instances"
+  homepage "https://valkey-admin.valkey.io/"
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Valkey Admin.app"
+
+  zap trash: "~/Library/Application Support/Valkey Admin"
+end


### PR DESCRIPTION
<!-- Title: valkey-admin 1.0.1 (new cask) -->
-----

Adds Valkey Admin, an administration tool for Valkey clusters and standalone instances.

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code, claude-opus-4-8) drafted the cask from the upstream v1.0.1 GitHub release.

I manually verified: both `sha256` from the downloaded arm64/intel DMGs; `depends_on` and the `Valkey Admin.app` bundle id `com.valkey.admin` from the app's `Info.plist`; notarization via `spctl`/`codesign` (Developer ID); `brew audit --cask --new --online valkey-admin` and `brew style valkey-admin` error-free; `install`/`uninstall` clean; and the default `livecheck` resolves to 1.0.1. The `zap` path `~/Library/Application Support/Valkey Admin` was confirmed against the bundle id across repeated install/launch/quit cycles; it is the only path created reliably (this Electron app nests its cache/state there), so conventional bundle-id paths that did not reproduce were left out.
