### PR TITLE
altersend: add Linux AppImage support

### DIFF
--- a/Casks/a/altersend.rb
+++ b/Casks/a/altersend.rb
@@ -1,22 +1,38 @@
 cask "altersend" do
-  arch arm: "-arm64"
+  on_macos do
+    arch arm: "-arm64"
+  end
+  on_linux do
+    arch arm: "arm64", intel: "x86_64"
+  end
 
   version "1.3.0"
-  sha256 arm:   "9cdc23e64c5a0c8061bdab0c30e99015ff72196f2b2f97f1a35f6a80b38a2f3e",
-         intel: "b9247fa96b159cd5cd47c73c38d795e43496411ee19ed3395fcc90557ab485f1"
+  sha256 arm:          "9cdc23e64c5a0c8061bdab0c30e99015ff72196f2b2f97f1a35f6a80b38a2f3e",
+         intel:        "b9247fa96b159cd5cd47c73c38d795e43496411ee19ed3395fcc90557ab485f1",
+         arm64_linux:  "1ff8777e50dc520f6f9025b8af3ded81004fa17e34235975629047e7f0a17202",
+         x86_64_linux: "90fe44646c91403cb7eba9e10af7bc881bc2f78514bfc405737b6f36705dffb4"
 
-  url "https://github.com/denislupookov/altersend/releases/download/v#{version}/AlterSend-#{version}#{arch}.dmg",
+  artifact = on_system_conditional macos: "AlterSend-#{version}#{arch}.dmg",
+                                   linux: "AlterSend-#{arch}.AppImage"
+
+  url "https://github.com/denislupookov/altersend/releases/download/v#{version}/#{artifact}",
       verified: "github.com/denislupookov/altersend/"
   name "AlterSend"
   desc "Secure, peer-to-peer file transfer app"
   homepage "https://altersend.com/"
 
-  depends_on macos: :monterey
+  on_macos do
+    depends_on macos: :monterey
 
-  app "AlterSend.app"
+    app "AlterSend.app"
 
-  zap trash: [
-    "~/Library/Application Support/AlterSend",
-    "~/Library/Preferences/com.altersend.desktop.plist",
-  ]
+    zap trash: [
+      "~/Library/Application Support/AlterSend",
+      "~/Library/Preferences/com.altersend.desktop.plist",
+    ]
+  end
+
+  on_linux do
+    app_image artifact, target: "AlterSend.AppImage"
+  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI used to help me reorganize faster the cask with Linux Appimage support.
-----
