### PR TITLE
tolaria: add Linux AppImage support (x86_64)

### DIFF
--- a/Casks/t/tolaria.rb
+++ b/Casks/t/tolaria.rb
@@ -2,10 +2,11 @@ cask "tolaria" do
   arch arm: "Silicon", intel: "Intel"
 
   version "2026.06.26,2026.6.26"
-  sha256 arm:   "ab1aec880c24f9abadb3a976de1f8014e6fd68834b1882c0619454de82dcafab",
-         intel: "8e7ddd3d6eaad35d18782ffa473d090fb7eba149d512fcd43d23034ecd0b1a12"
 
-  url "https://github.com/refactoringhq/tolaria/releases/download/v#{version.csv.first.dots_to_hyphens}/Tolaria_#{version.csv.second || version}_macOS_#{arch}.dmg",
+  artifact = on_system_conditional linux: "Tolaria_#{version.csv.second || version}_amd64.AppImage",
+                                   macos: "Tolaria_#{version.csv.second || version}_macOS_#{arch}.dmg"
+
+  url "https://github.com/refactoringhq/tolaria/releases/download/v#{version.csv.first.dots_to_hyphens}/#{artifact}",
       verified: "github.com/refactoringhq/tolaria/"
   name "Tolaria"
   desc "Markdown knowledgebase manager"
@@ -30,15 +31,29 @@ cask "tolaria" do
     end
   end
 
-  auto_updates true
-  depends_on :macos
+  on_macos do
+    sha256 arm:   "ab1aec880c24f9abadb3a976de1f8014e6fd68834b1882c0619454de82dcafab",
+           intel: "8e7ddd3d6eaad35d18782ffa473d090fb7eba149d512fcd43d23034ecd0b1a12"
 
-  app "Tolaria.app"
+    auto_updates true
 
-  zap trash: [
-    "~/Library/Application Support/com.tolaria.app",
-    "~/Library/Caches/club.refactoring.tolaria",
-    "~/Library/Preferences/club.refactoring.tolaria.plist",
-    "~/Library/WebKit/club.refactoring.tolaria",
-  ]
+    app "Tolaria.app"
+
+    uninstall quit: "club.refactoring.tolaria"
+
+    zap trash: [
+      "~/Library/Application Support/com.tolaria.app",
+      "~/Library/Caches/club.refactoring.tolaria",
+      "~/Library/Preferences/club.refactoring.tolaria.plist",
+      "~/Library/WebKit/club.refactoring.tolaria",
+    ]
+  end
+
+  on_linux do
+    sha256 "f941c28453892a8e4e86144e87f06c21edbf30b54485b1e143032510c6ff783d"
+
+    depends_on arch: :x86_64
+
+    app_image artifact, target: "Tolaria.AppImage"
+  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI used to help me reorganize faster the cask with Linux Appimage support.
(Appimage available only for Linux x86/x64, no arm release)
-----
