### PR TITLE
onexrayse 26.6.3 (new cask)

### DIFF
--- a/Casks/o/onexray.rb
+++ b/Casks/o/onexray.rb
@@ -1,0 +1,19 @@
+cask "onexray" do
+  version "26.6.3"
+  sha256 "09e10e0d33bf864f70e9e359bd3bbb9c6e9f110061ea2ad355ed02266510a05f"
+
+  url "https://github.com/OneXray/OneXray/releases/download/v#{version}/OneXray-macos-universal.zip",
+      verified: "github.com/OneXray/OneXray/"
+  name "OneXray"
+  desc "Cross-platform Xray-core client"
+  homepage "https://onexray.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+
+  app "OneXraySE.app"
+end

--- a/Casks/o/onexray.rb
+++ b/Casks/o/onexray.rb
@@ -16,4 +16,11 @@ cask "onexray" do
   depends_on macos: :monterey
 
   app "OneXraySE.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/group.net.yuandev.onexray.se",
+    "~/Library/Containers/net.yuandev.onexray.se",
+    "~/Library/Containers/net.yuandev.onexray.se.tun",
+    "~/Library/Group Containers/group.net.yuandev.onexray.se",
+  ]
 end

--- a/Casks/o/onexrayse.rb
+++ b/Casks/o/onexrayse.rb
@@ -1,4 +1,4 @@
-cask "onexray" do
+cask "onexrayse" do
   version "26.6.3"
   sha256 "09e10e0d33bf864f70e9e359bd3bbb9c6e9f110061ea2ad355ed02266510a05f"
 
@@ -7,11 +7,6 @@ cask "onexray" do
   name "OneXray"
   desc "Cross-platform Xray-core client"
   homepage "https://onexray.com/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   depends_on macos: :monterey
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance was used to draft the initial cask stanza and the zap stanza, and to run the validation checklist. I manually verified that `v26.6.3` is a stable GitHub release, the macOS ZIP downloads successfully, the SHA-256 matches the release asset digest, and the archive contains `OneXraySE.app`. The zap paths were derived from the app bundle identifier `net.yuandev.onexray.se`, the tunnel extension bundle identifier `net.yuandev.onexray.se.tun`, the sandbox entitlements, and the App Group `group.net.yuandev.onexray.se`; only current-user Library paths are included. I also verified `brew audit --cask --online onexray/cask/onexray`, `brew style --fix onexray/cask/onexray`, `brew audit --cask --new onexray/cask/onexray`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask onexray/cask/onexray`, and `brew uninstall --cask onexray/cask/onexray`.

-----
