### PR TITLE
spacedrive: update livecheck

### DIFF
--- a/Casks/s/spacedrive.rb
+++ b/Casks/s/spacedrive.rb
@@ -5,6 +5,13 @@ cask "spacedrive" do
   sha256 arm:   "d018fa1a3b312d480b972700df7a5722f22da2a16d6ad8c997667f6708e70b47",
          intel: "1355c219e5817bfa071c4de2cccca44fcc05ac81a134cbe6c4489e32b9d27d9f"
 
+  on_arm do
+    depends_on macos: :big_sur
+  end
+  on_intel do
+    depends_on macos: :catalina
+  end
+
   url "https://github.com/spacedriveapp/spacedrive/releases/download/#{version}/Spacedrive-darwin-#{arch}.dmg"
   name "Spacedrive"
   desc "Open source cross-platform file explorer"

--- a/Casks/s/spacedrive.rb
+++ b/Casks/s/spacedrive.rb
@@ -11,10 +11,8 @@ cask "spacedrive" do
   homepage "https://github.com/spacedriveapp/spacedrive"
 
   livecheck do
-    url "https://www.spacedrive.com/api/releases"
-    strategy :json do |json|
-      json.map { |item| item["version"] }
-    end
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block URL for `spacedrive` is returning a 404 (Not Found) response. The 0.4.3 version of the app checks this URL, so it also fails to fetch new version information. There is are unstable alpha 2.0.0 versions on GitHub but I didn't observe the app checking for new versions.

For the time being, this updates the `livecheck` block to simply use the `GithubLatest` strategy, which correctly returns 0.4.3 as the latest stable version.