### PR TITLE
weka 3.8.7

### DIFF
--- a/Casks/w/weka.rb
+++ b/Casks/w/weka.rb
@@ -1,19 +1,22 @@
 cask "weka" do
-  arch arm: "arm-osx", intel: "osx"
+  arch arm: "arm", intel: "x64"
 
-  version "3.8.6"
-  sha256 arm:   "85de453da3bb41c952da48eee0bf574d1da7ee4fa6fd3a8e2d7a81a89d55d3d7",
-         intel: "282d5ff81960d1ae43ee6e4e8eaa7ae8c341666a214e859728e15214af80383b"
+  version "3.8.7"
+  sha256 arm:   "d1d77d42d3eeb8828bdff128857b5ad6c91447b9587397463d4ca58f6d7472bd",
+         intel: "0373c7ff005ef9a653dd9d5b933e3623a7474deff0990ba4a2c42ea287235f73"
 
-  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-azul-zulu-#{arch}.dmg",
+  url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-bellsoft-#{arch}-osx.dmg",
       verified: "sourceforge.net/weka/"
   name "Weka"
   desc "Collection of machine learning algorithms for data mining tasks"
   homepage "https://ml.cms.waikato.ac.nz/weka"
 
+  # Upstream may use an even-numbered minor version to indicate stable releases,
+  # so we omit versions with an odd-numbered minor to avoid developer releases
+  # (using the same file name format) on this page.
   livecheck do
     url "https://waikato.github.io/weka-wiki/downloading_weka/"
-    regex(/href=.*?weka[._-]v?(\d+(?:[.-]\d+)+)[._-]azul[._-]zulu[._-]#{arch}\.dmg/i)
+    regex(/href=.*?weka[._-]v?(\d+[.-]\d*[02468](?:[.-]\d+)*)[^"' >]*?[._-]#{arch}(?:[._-]osx)?\.dmg/i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
       next if match.blank?
@@ -21,6 +24,8 @@ cask "weka" do
       match[1].tr("-", ".")
     end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on :macos
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`weka` is autobumped but the workflow failed to update to version 3.8.7 because the `livecheck` block regex isn't able to match the version from the current file name URLs because the files use a `-bellsoft-#{arch}-osx` suffix format (instead of the previous `-azul-zulu-#{arch}`) and the arch suffix has changed (both include `-osx` at the end and Intel is now explicitly `-x64`). This updates the version and adjusts the cask accordingly.