### PR TITLE
jamovi 2.7.34.0

### DIFF
--- a/Casks/j/jamovi.rb
+++ b/Casks/j/jamovi.rb
@@ -1,9 +1,9 @@
 cask "jamovi" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.7.31.0"
-  sha256 arm:   "d4b4cdde56616eea9aa28198ac891727ff1adc5b37ce1730b82dfaa827a6f69e",
-         intel: "e3ae78d57de912dab5915352372b6ed797a1c2bc0ce1eb73a5c6aae44ad0de64"
+  version "2.7.34.0"
+  sha256 arm:   "f75c2035f17b111fc2b3d4d7a7659472451ae22ee7c01f3219d26b490983d80d",
+         intel: "a40773fd74626ad4eaf4994be1879bd9c1ee3cda1c55c4a681f725373a65c00f"
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos-#{arch}.dmg",
       referer: "https://www.jamovi.org/download.html"

--- a/Casks/j/jamovi.rb
+++ b/Casks/j/jamovi.rb
@@ -14,7 +14,7 @@ cask "jamovi" do
   # The download page will redirect to the homepage unless a `referer` is used.
   livecheck do
     url "https://www.jamovi.org/download.html",
-        referer: "https://www.jamovi.org"
+        referer: "https://www.jamovi.org/"
     regex(/href=.*?jamovi[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block URL for `jamovi` is redirecting to the homepage again despite having a referer. The upstream website uses a referer with a trailing forward slash and adding that to the `referer` value fixes the issue.