### PR TITLE
Add Pling v1.0.0

### DIFF
--- a/Casks/p/pling.rb
+++ b/Casks/p/pling.rb
@@ -1,0 +1,17 @@
+cask "pling" do
+  version "1.0.0"
+  sha256 "3f510966db093e7198c354daa38a648597520897cb25b9515282aca3e73e7fc4"
+
+  url "https://github.com/johnnyfekete/pling/releases/download/v#{version}/Pling.zip"
+  name "Pling"
+  desc "Retro tally counter for the menu bar"
+  homepage "https://pling.johnnyfekete.com/"
+
+  depends_on macos: ">= :sonoma"
+
+  app "Pling.app"
+
+  zap trash: [
+    "~/Library/Containers/com.johnnyfekete.DailyScore",
+  ]
+end


### PR DESCRIPTION
## Description

Adds [Pling](https://pling.johnnyfekete.com/), a retro tally counter that lives in the macOS menu bar. Game Boy-style pixel aesthetic, global hotkey support, daily log, and achievement milestones. Privacy-focused — local storage only, no accounts or analytics.

- **App name:** Pling
- **Homepage:** https://pling.johnnyfekete.com/
- **macOS 14+ (Sonoma)**
- **Signed and notarized**
- **Also available on the [Mac App Store](https://apps.apple.com/app/pling)**