### PR TITLE
Aside v1.0.626.1 (New Cask)

### DIFF
--- a/Casks/a/aside.rb
+++ b/Casks/a/aside.rb
@@ -1,6 +1,6 @@
 cask "aside" do
-  version "1.0.626.1"
-  sha256 "ad85eea5bd6e542444d8504047e14525c9f96ecdb3305e7552f01964c9f5704d"
+  version "1.0.630.1"
+  sha256 "8e2dc722f57fe9f08884bbf4c7a577e2938e3eab7ef1496412a893c49ad93216"
 
   url "https://releases.aside.com/dev-updater/Aside-#{version}.dmg"
   name "Aside"

--- a/Casks/a/aside.rb
+++ b/Casks/a/aside.rb
@@ -4,7 +4,7 @@ cask "aside" do
 
   url "https://releases.aside.com/dev-updater/Aside-#{version}.dmg"
   name "Aside"
-  desc "Most intelligent AI assistant, but it's a browser"
+  desc "Web browser with built-in AI assistant"
   homepage "https://aside.com/"
 
   livecheck do

--- a/Casks/a/aside.rb
+++ b/Casks/a/aside.rb
@@ -1,0 +1,54 @@
+cask "aside" do
+  version "1.0.626.1"
+  sha256 "ad85eea5bd6e542444d8504047e14525c9f96ecdb3305e7552f01964c9f5704d"
+
+  url "https://releases.aside.com/dev-updater/Aside-#{version}.dmg"
+  name "Aside"
+  desc "The most intelligent AI assistant, but it's a browser."
+  homepage "https://aside.com/"
+
+  livecheck do
+    url "https://ptqgesmtzwdmeiknncqc.supabase.co/functions/v1/omaha/version_info.json"
+    strategy :json do |json|
+      json.dig("platforms", "mac", "version")
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Aside.app"
+
+  uninstall quit:      "at.studio.AsideBrowser",
+            launchctl: "at.studio.AsideBrowser.UpdaterPrivilegedHelper",
+            delete:    [
+              "/Library/LaunchDaemons/at.studio.AsideBrowser.UpdaterPrivilegedHelper.plist",
+              "/Library/PrivilegedHelperTools/at.studio.AsideBrowser.UpdaterPrivilegedHelper",
+            ]
+
+  zap launchctl: [
+        "at.studio.AsideKeystone.agent",
+        "at.studio.AsideKeystone.daemon",
+      ],
+      trash: [
+        "/Library/Aside/Aside Brand.plist",
+        "/Library/Aside/AsideSoftwareUpdate",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/at.studio.AsideBrowser.sfl*",
+        "~/Library/Application Support/Aside",
+        "~/Library/Caches/Aside",
+        "~/Library/Caches/at.studio.AsideKeystone",
+        "~/Library/Caches/at.studio.AsideKeystone.Agent",
+        "~/Library/Caches/at.studio.AsideBrowser",
+        "~/Library/HTTPStorages/at.studio.AsideBrowser",
+        "~/Library/HTTPStorages/at.studio.AsideBrowser.binarycookies",
+        "~/Library/LaunchAgents/at.studio.AsideKeystone.agent.plist",
+        "~/Library/LaunchAgents/at.studio.AsideKeystone.xpcservice.plist",
+        "~/Library/Preferences/at.studio.AsideKeystone.Agent.plist",
+        "~/Library/Preferences/at.studio.AsideBrowser.plist",
+        "~/Library/Saved Application State/at.studio.AsideBrowser.savedState",
+        "~/Library/WebKit/at.studio.AsideBrowser",
+      ],
+      rmdir: [
+        "/Library/Aside",
+      ]
+end

--- a/Casks/a/aside.rb
+++ b/Casks/a/aside.rb
@@ -4,7 +4,7 @@ cask "aside" do
 
   url "https://releases.aside.com/dev-updater/Aside-#{version}.dmg"
   name "Aside"
-  desc "The most intelligent AI assistant, but it's a browser."
+  desc "Most intelligent AI assistant, but it's a browser"
   homepage "https://aside.com/"
 
   livecheck do
@@ -19,8 +19,8 @@ cask "aside" do
 
   app "Aside.app"
 
-  uninstall quit:      "at.studio.AsideBrowser",
-            launchctl: "at.studio.AsideBrowser.UpdaterPrivilegedHelper",
+  uninstall launchctl: "at.studio.AsideBrowser.UpdaterPrivilegedHelper",
+            quit:      "at.studio.AsideBrowser",
             delete:    [
               "/Library/LaunchDaemons/at.studio.AsideBrowser.UpdaterPrivilegedHelper.plist",
               "/Library/PrivilegedHelperTools/at.studio.AsideBrowser.UpdaterPrivilegedHelper",
@@ -30,25 +30,23 @@ cask "aside" do
         "at.studio.AsideKeystone.agent",
         "at.studio.AsideKeystone.daemon",
       ],
-      trash: [
+      trash:     [
         "/Library/Aside/Aside Brand.plist",
         "/Library/Aside/AsideSoftwareUpdate",
-        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/at.studio.AsideBrowser.sfl*",
         "~/Library/Application Support/Aside",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/at.studio.AsideBrowser.sfl*",
         "~/Library/Caches/Aside",
+        "~/Library/Caches/at.studio.AsideBrowser",
         "~/Library/Caches/at.studio.AsideKeystone",
         "~/Library/Caches/at.studio.AsideKeystone.Agent",
-        "~/Library/Caches/at.studio.AsideBrowser",
         "~/Library/HTTPStorages/at.studio.AsideBrowser",
         "~/Library/HTTPStorages/at.studio.AsideBrowser.binarycookies",
         "~/Library/LaunchAgents/at.studio.AsideKeystone.agent.plist",
         "~/Library/LaunchAgents/at.studio.AsideKeystone.xpcservice.plist",
-        "~/Library/Preferences/at.studio.AsideKeystone.Agent.plist",
         "~/Library/Preferences/at.studio.AsideBrowser.plist",
+        "~/Library/Preferences/at.studio.AsideKeystone.Agent.plist",
         "~/Library/Saved Application State/at.studio.AsideBrowser.savedState",
         "~/Library/WebKit/at.studio.AsideBrowser",
       ],
-      rmdir: [
-        "/Library/Aside",
-      ]
+      rmdir:     "/Library/Aside"
 end


### PR DESCRIPTION
## Description

Adds a new cask for Aside, the most intelligent AI assistant, but it's a browser.

The app is distributed as a versioned DMG from the vendor release host, is signed with Developer ID, and includes a stapled notarization ticket.

## Verification Details

- Download URL: https://releases.aside.com/dev-updater/Aside-1.0.626.1.dmg
- Homepage: https://aside.com/
- Version: 1.0.626.1
- SHA-256: `ad85eea5bd6e542444d8504047e14525c9f96ecdb3305e7552f01964c9f5704d`
- App bundle: `Aside.app`
- Bundle identifier: `at.studio.AsideBrowser`
- Minimum macOS version: 12.0 / Monterey
- Architectures: universal, `x86_64` and `arm64`
- Code signing authority: `Developer ID Application: At Inc. (8CPD4K4TBB)`
- Gatekeeper assessment: accepted, `source=Notarized Developer ID`
- Livecheck URL: https://ptqgesmtzwdmeiknncqc.supabase.co/functions/v1/omaha/version_info.json
- Livecheck version key: `platforms.mac.version`
- Cask description: `Most intelligent AI assistant, but it's a browser`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI assistance was used to draft the cask and PR body. Manual verification performed:

- Downloaded the DMG and computed the SHA-256.
- Mounted the DMG and inspected `Aside.app`.
- Read `Info.plist` to confirm the app bundle name, bundle identifier, version, and minimum macOS version.
- Ran `codesign -dv --verbose=4` to confirm the Developer ID signature, universal architecture, and stapled notarization ticket.
- Ran `spctl --assess --type execute --verbose=4` to confirm Gatekeeper accepts the app as a notarized Developer ID application.
- Verified the livecheck JSON returns `platforms.mac.version` and `platforms.mac.url`.
- Ran `brew audit --cask --online aside` successfully.
- Ran `brew style --fix aside`; it corrected stanza ordering/alignment on the first run and reported no offenses on the second run. The corrected cask file is included in this PR.
- Reviewed updater-related bundle identifiers and paths for the `uninstall` and `zap` stanzas, including `at.studio.AsideBrowser.UpdaterPrivilegedHelper`, `at.studio.AsideKeystone.agent`, `at.studio.AsideKeystone.daemon`, `/Library/Aside`, and the app's Application Support, Cache, HTTPStorages, Preferences, Saved Application State, and WebKit paths.
