### PR TITLE
postman: fix Intel arch string to use osx_64

### DIFF
--- a/Casks/p/postman.rb
+++ b/Casks/p/postman.rb
@@ -1,5 +1,5 @@
 cask "postman" do
-  arch arm: "osx_arm64", intel: "osx64"
+  arch arm: "osx_arm64", intel: "osx_64"
 
   version "12.16.4"
   sha256 arm:   "38c7213481b3176c80bc4b1295ef0c60b807fee8f72ee46857a097032e0687d7",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI was used to assist with writing the commit message and PR description.


While investigating issue #272185, I opened the version check URL manually and noticed that the JSON response returns a download link with `osx_64`, not `osx64` as currently used in the cask. Since the check endpoint accepts both variants, I unified the Intel arch string to `osx_64` to match the actual download URL format.

```json
{"notes":"{\"Release Notes\":[]}","version":"12.16.4","pub_date":"2026-06-26T02:56:54.000Z","name":"Postman 12.16.4","url":"https://dl.pstmn.io/download/version/12.16.4/osx_64"}
```

