### PR TITLE
slashy 1.3.45 (new cask)

### DIFF
--- a/Casks/s/slashy.rb
+++ b/Casks/s/slashy.rb
@@ -1,0 +1,24 @@
+cask "slashy" do
+  version "1.3.45"
+  sha256 "42cae2c938b78327bff4e98131a8e4f29c75a90c84f15f02067873ab998e0b7a"
+
+  url "https://dl.slashy.com/Slashy-#{version}-universal.dmg"
+  name "Slashy"
+  desc "Email client for Gmail"
+  homepage "https://www.slashy.com/"
+
+  livecheck do
+    url "https://dl.slashy.com/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Slashy.app"
+
+  zap trash: [
+    "~/Library/Application Support/slashyemail",
+    "~/Library/Preferences/com.slashy.email.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

I used claude code to draft the first version of cask but it used latest as version. So I set up http proxy to find out the electron updater url and updated the cask file to use versioned downloads.

Then, I created zap paths using `brew createzap slashy` and verified again with `find ~/Library -maxdepth 5 -iname "*slashy*" -o -iname "*com.slashy*"`. In the end, only `Application Support/slashyemail` and `Preferences/com.slashy.email.plist` were found.