### PR TITLE
itsypad 1.16.0 (new cask)

### DIFF
--- a/Casks/i/itsypad.rb
+++ b/Casks/i/itsypad.rb
@@ -1,0 +1,18 @@
+cask "itsypad" do
+  version "1.16.0"
+  sha256 "bd00989b810b75944e0e21706409fcd51edc9bdec91458548f152fbfe9c9a4e2"
+
+  url "https://github.com/nickustinov/itsypad-macos/releases/download/v#{version}/Itsypad-#{version}.dmg"
+  name "Itsypad"
+  desc "Tiny, fast scratchpad and clipboard manager"
+  homepage "https://github.com/nickustinov/itsypad-macos"
+
+  depends_on macos: :sonoma
+
+  app "Itsypad.app"
+
+  zap trash: [
+    "~/Library/Application Support/Itsypad",
+    "~/Library/Preferences/com.nickustinov.itsypad.plist",
+  ]
+end


### PR DESCRIPTION
Adds a new cask for **Itsypad**, a tiny, fast scratchpad and clipboard manager for Mac.

- Homepage / repo: https://github.com/nickustinov/itsypad-macos (MIT, 380+ stars)
- Notarized Developer ID DMG from GitHub releases
- Replaces the unofficial `nickustinov/tap/itsypad` cask once merged

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI (Claude Code) drafted the cask and ran all the verification commands above locally on macOS (Apple Silicon). I am the maintainer of the upstream project. The `zap` paths were verified manually: the app's bundle identifier is `com.nickustinov.itsypad` (confirmed in `Itsypad.app/Contents/Info.plist`), matching `~/Library/Preferences/com.nickustinov.itsypad.plist`, and the app creates `~/Library/Application Support/Itsypad`. `brew install`/`uninstall` placed and removed `/Applications/Itsypad.app` cleanly.
