### PR TITLE
subtitle-studio 1.9.8 (new cask)

### DIFF
--- a/Casks/s/subtitle-studio.rb
+++ b/Casks/s/subtitle-studio.rb
@@ -1,0 +1,27 @@
+cask "subtitle-studio" do
+  version "1.9.8"
+  sha256 "945ff0828b9f4dac53551eaec4ae47efa9fa95e64706b2195514a9acb86be23f"
+
+  url "https://assets.subtitlestudio.ai/releases/Subtitle%20Studio-arm64-#{version}.dmg"
+  name "Subtitle Studio"
+  desc "Offline AI subtitle generator"
+  homepage "https://subtitlestudio.ai/"
+
+  livecheck do
+    url "https://subtitlestudio.ai/api/update/check"
+    strategy :json do |json|
+      json["latestVersion"]
+    end
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :monterey
+
+  app "Subtitle Studio.app"
+
+  zap trash: [
+    "~/Library/Application Support/subtitle-studio",
+    "~/Library/Preferences/com.subtitle.studio.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

I used createzap and `find ~/Library` to search for `subtitle` and create zaps. I also double-checked the website, which clearly states that no x86 version is available for now, so depends_on arch64 was added as well.

The update API is a bit complex & non-standard here, so I used AI to extract this address from the bundled JS file and check the API parameters.