### PR TITLE
opentypeless 1.1.50 (new cask)

### DIFF
--- a/Casks/o/opentypeless.rb
+++ b/Casks/o/opentypeless.rb
@@ -1,0 +1,19 @@
+cask "opentypeless" do
+  version "1.1.46"
+  sha256 "bb00542ca448a69b9192117be1c479ecdba097999455752d0d8654b72b3de58f"
+
+  url "https://github.com/tover0314-w/opentypeless/releases/download/v#{version}/OpenTypeless_#{version}_universal.dmg",
+      verified: "github.com/tover0314-w/opentypeless/"
+  name "OpenTypeless"
+  desc "AI voice input, rewriting, and voice Q&A tool"
+  homepage "https://www.opentypeless.com/"
+
+  livecheck do
+    url "https://github.com/tover0314-w/opentypeless"
+    strategy :github_latest
+  end
+
+  depends_on macos: :catalina
+
+  app "OpenTypeless.app"
+end

--- a/Casks/o/opentypeless.rb
+++ b/Casks/o/opentypeless.rb
@@ -1,6 +1,6 @@
 cask "opentypeless" do
-  version "1.1.46"
-  sha256 "bb00542ca448a69b9192117be1c479ecdba097999455752d0d8654b72b3de58f"
+  version "1.1.50"
+  sha256 "ebc9f56748d961361445f0962b62793ce5cba47d357ead53f5a31c1a3bcb375e"
 
   url "https://github.com/tover0314-w/opentypeless/releases/download/v#{version}/OpenTypeless_#{version}_universal.dmg",
       verified: "github.com/tover0314-w/opentypeless/"
@@ -16,4 +16,12 @@ cask "opentypeless" do
   depends_on macos: :catalina
 
   app "OpenTypeless.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.opentypeless.app",
+    "~/Library/Caches/com.opentypeless.app",
+    "~/Library/Caches/opentypeless",
+    "~/Library/WebKit/com.opentypeless.app",
+    "~/Library/WebKit/opentypeless",
+  ]
 end


### PR DESCRIPTION
-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online opentypeless` is error-free.
- [x] `brew style --fix opentypeless` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new opentypeless` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask opentypeless` worked successfully.
- [x] `brew uninstall --cask opentypeless` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI assistance was used to draft the cask update and this PR text. I manually verified the following on macOS:

- Updated the cask to the stable OpenTypeless v1.1.50 release.
- Downloaded the universal DMG and verified SHA-256 `ebc9f56748d961361445f0962b62793ce5cba47d357ead53f5a31c1a3bcb375e`.
- Mounted the DMG and confirmed it contains `OpenTypeless.app` with version `1.1.50` and bundle identifier `com.opentypeless.app`.
- Ran `codesign --verify --deep --strict --verbose=2`, `spctl -a -vvv -t install`, and `xcrun stapler validate`; all passed.
- Ran `brew style --fix`, `brew audit --cask --new`, and `brew audit --cask --online`; all passed.
- Installed the cask into a temporary app directory and uninstalled it successfully.
- Verified the `zap` paths against directories created by a locally used OpenTypeless installation:
  - `~/Library/Application Support/com.opentypeless.app`
  - `~/Library/Caches/com.opentypeless.app`
  - `~/Library/Caches/opentypeless`
  - `~/Library/WebKit/com.opentypeless.app`
  - `~/Library/WebKit/opentypeless`

-----
