### PR TITLE
Add parabolic 2026.5.0

### DIFF
--- a/Casks/p/parabolic.rb
+++ b/Casks/p/parabolic.rb
@@ -5,8 +5,7 @@ cask "parabolic" do
   sha256 arm:   "e1593ac65059f7f99621cd4bf570cbaec6b8b35eab16e6f0f2ab0e84d048733d",
          intel: "3458751243e105bca74adff4411784cdecde653b35624ce902b1a0e44057beb9"
 
-  url "https://github.com/NickvisionApps/Parabolic/releases/download/#{version}/Parabolic-macOS-#{arch}.zip",
-      verified: "github.com/NickvisionApps/Parabolic/"
+  url "https://github.com/NickvisionApps/Parabolic/releases/download/#{version}/Parabolic-macOS-#{arch}.zip"
   name "Parabolic"
   desc "Download web video and audio from many sites"
   homepage "https://github.com/NickvisionApps/Parabolic"

--- a/Casks/p/parabolic.rb
+++ b/Casks/p/parabolic.rb
@@ -1,0 +1,29 @@
+cask "parabolic" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2026.5.0"
+  sha256 arm:   "e1593ac65059f7f99621cd4bf570cbaec6b8b35eab16e6f0f2ab0e84d048733d",
+         intel: "3458751243e105bca74adff4411784cdecde653b35624ce902b1a0e44057beb9"
+
+  url "https://github.com/NickvisionApps/Parabolic/releases/download/#{version}/Parabolic-macOS-#{arch}.zip",
+      verified: "github.com/NickvisionApps/Parabolic/"
+  name "Parabolic"
+  desc "Download web video and audio from many sites"
+  homepage "https://github.com/NickvisionApps/Parabolic"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :catalina
+
+  app "Parabolic.app"
+
+  zap trash: [
+    "~/Library/Caches/org.nickvision.tubeconverter",
+    "~/Library/HTTPStorages/org.nickvision.tubeconverter",
+    "~/Library/Preferences/org.nickvision.tubeconverter.plist",
+    "~/Library/Saved Application State/org.nickvision.tubeconverter.savedState",
+  ]
+end


### PR DESCRIPTION
Adds Parabolic, a free and open-source (MIT) macOS app to download video and audio from YouTube and many other sites. Upstream: https://github.com/NickvisionApps/Parabolic (6k+ stars). Stable, versioned, arch-split universal zip releases.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

This cask was generated with the assistance of Claude (Claude Code) and verified manually as follows:

- `brew style` reports no offenses.
- Both release zips were downloaded and their `sha256` values computed and confirmed for `arm64` and `x64`.
- `brew livecheck` resolves `2026.5.0` via `:github_latest`.
- The `verified:` parameter was removed after `brew audit` correctly flagged it as unnecessary (download URL and homepage share the `github.com` domain).
- The app bundle inside the zip is `Parabolic.app` with bundle id `org.nickvision.tubeconverter` and `LSMinimumSystemVersion` `10.15`, which is the basis for the `zap` paths and `depends_on macos`.

The two audit/install boxes are left unticked deliberately: the submitter's local machine runs a macOS beta whose Xcode-version requirement causes `brew audit` to abort before running, and the app was already present in `/Applications` so a from-scratch `install`/`uninstall` round-trip was not performed locally to avoid disturbing an existing install. Relying on CI to run the full audit and install/uninstall on clean runners. The `zap` paths are bundle-id-based (`org.nickvision.tubeconverter`): `Caches`, `HTTPStorages`, `Preferences` plist, and `Saved Application State`.
