### PR TITLE
hermes-desktop 0.17.0 (new cask)

### DIFF
--- a/Casks/h/hermes-desktop.rb
+++ b/Casks/h/hermes-desktop.rb
@@ -1,0 +1,38 @@
+cask "hermes-desktop" do
+  version "0.17.0,c9269fbfb689"
+  sha256 "b61e047efe3059faf1c55fec3252e661f2d2a993a7a3eebf5cc6a9aa5c1790f5"
+
+  url "https://hermes-assets.nousresearch.com/Hermes-Setup.dmg?build=#{version.csv.second}"
+  name "Hermes Agent Desktop"
+  desc "Open-source desktop AI agent"
+  homepage "https://hermes-agent.nousresearch.com/desktop"
+
+  livecheck do
+    url :homepage
+    regex(/Hermes\s+Agent\s+v?(\d+(?:\.\d+)+)/i)
+    strategy :page_match do |page, regex|
+      version_match = page.match(regex)
+      next unless version_match
+
+      build_match = page.match(/Hermes[._-]Setup\.dmg\?build=(\h+)/i)
+      next unless build_match
+
+      "#{version_match[1]},#{build_match[1]}"
+    end
+  end
+
+  depends_on macos: :big_sur
+
+  app "Hermes.app"
+
+  uninstall quit: "com.nousresearch.hermes.setup"
+
+  zap trash: [
+    "~/Library/Application Support/Hermes",
+    "~/Library/Caches/com.nousresearch.hermes.setup",
+    "~/Library/HTTPStorages/com.nousresearch.hermes.setup",
+    "~/Library/Preferences/com.nousresearch.hermes.setup.plist",
+    "~/Library/Saved Application State/com.nousresearch.hermes.setup.savedState",
+    "~/Library/WebKit/com.nousresearch.hermes.setup",
+  ]
+end


### PR DESCRIPTION
New cask for **Hermes Agent Desktop** from Nous Research. Installs `Hermes.app` from the official macOS DMG advertised at https://hermes-agent.nousresearch.com/desktop.

Continues #268274, which could not be reopened (its branch had been force-pushed / was too far behind `main` for the GitHub reopen API). Updated to the current version `0.17.0` (build `c9269fbfb689`) per @samford's feedback that the build identifier had moved on, and rebased onto current `main`. The server returns the same setup DMG regardless of the `?build=` query param, so the `sha256` is unchanged. Livecheck already uses `regex` + `\s+` + `\h` as @samford suggested.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude) was used to update the version/build, refine the livecheck, and draft this PR. Manual verification performed:

- Mounted the DMG and inspected `Hermes.app`: `CFBundleIdentifier` is `com.nousresearch.hermes.setup` and `LSMinimumSystemVersion` is `11.0`. The `uninstall quit:` / `zap` identifiers and `depends_on macos: :big_sur` were checked against this real bundle, not AI-guessed (re @bevanjkay's question on #268274).
- `brew style --fix Casks/h/hermes-desktop.rb` — no offenses.
- `brew livecheck --cask hermes-desktop` — resolves `0.17.0,c9269fbfb689`.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask hermes-desktop` then `brew uninstall --cask hermes-desktop` — both succeeded.
- `brew audit --cask --online/--new` could not be run locally (this machine's Xcode predates the version Homebrew now requires and the audit aborts on that check); relying on CI for it.

-----
