### PR TITLE
Add pocket-bard cask

### DIFF
--- a/Casks/p/pocket-bard.rb
+++ b/Casks/p/pocket-bard.rb
@@ -8,7 +8,7 @@ cask "pocket-bard" do
 
   url "https://downloads.pocketbard.app/desktop/channels/stable/pocketbard-#{version.csv.first}-#{version.csv.second}-mac-#{arch}.zip"
   name "Pocket Bard"
-  desc "Easiest immersive audio solution for your TTRPG toolkit"
+  desc "TTRPG ambient audio and sound effects"
   homepage "https://www.pocketbard.app/"
 
   livecheck do
@@ -24,11 +24,9 @@ cask "pocket-bard" do
   app "Pocket Bard.app"
 
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.pocketbard.pocketbard.sfl*",
-    "~/Library/Application Support/pocketbard",
+    "~/Library/Application Support/com.pocketbard.pocketbard",
     "~/Library/Caches/com.pocketbard.pocketbard",
     "~/Library/HTTPStorages/com.pocketbard.pocketbard",
     "~/Library/Preferences/com.pocketbard.pocketbard.plist",
-    "~/Library/Saved Application State/com.pocketbard.pocketbard.savedState",
   ]
 end

--- a/Casks/p/pocket-bard.rb
+++ b/Casks/p/pocket-bard.rb
@@ -1,0 +1,34 @@
+cask "pocket-bard" do
+  arch arm: "aarch64", intel: "amd64"
+  livecheck_arch = on_arch_conditional arm: "aarch64", intel: "amd64"
+
+  version "3.1.15,232"
+  sha256 arm:   "bcc4764e6ecef1554db1f4bddedc0890e6a2397df28d91a8eb999b361662c892",
+         intel: "039c40ad73efc8853bca38f2b26d18aa2b213d9b478833e3282a17ebf8d632ae"
+
+  url "https://downloads.pocketbard.app/desktop/channels/stable/pocketbard-#{version.csv.first}-#{version.csv.second}-mac-#{arch}.zip"
+  name "Pocket Bard"
+  desc "Easiest immersive audio solution for your TTRPG toolkit"
+  homepage "https://www.pocketbard.app/"
+
+  livecheck do
+    url "https://downloads.pocketbard.app/desktop/channels/stable/appcast-#{livecheck_arch}.rss"
+    strategy :sparkle do |item|
+      "#{item.short_version},#{item.version.split(".").last}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "Pocket Bard.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.pocketbard.pocketbard.sfl*",
+    "~/Library/Application Support/pocketbard",
+    "~/Library/Caches/com.pocketbard.pocketbard",
+    "~/Library/HTTPStorages/com.pocketbard.pocketbard",
+    "~/Library/Preferences/com.pocketbard.pocketbard.plist",
+    "~/Library/Saved Application State/com.pocketbard.pocketbard.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Cursor AI assisted with drafting the `pocket-bard` cask from the official download page and Sparkle appcast. Manual verification performed:

- `brew audit --cask --online pocket-bard` (passed)
- `brew audit --cask --new pocket-bard` (passed)
- `brew style --fix Casks/p/pocket-bard.rb` (no offenses)
- `brew livecheck --cask pocket-bard` (3.1.15,232 current)
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask pocket-bard` (installed to `/Applications/Pocket Bard.app`)
- `codesign --verify --deep --strict` and `spctl -a -vv -t install` (accepted, Notarized Developer ID, Pocket Bard Inc.)
- `brew uninstall --cask pocket-bard` (removed cleanly)

`zap` paths were inferred from bundle ID (`com.pocketbard.pocketbard`) and app filesystem name (`pocketbard` from `-Dapp.fsname`); no support files were created during install-only testing without launching the app.

-----
