### PR TITLE
raycast-glaze 0.8.0 (new cask)

### DIFF
--- a/Casks/g/glaze-raycast.rb
+++ b/Casks/g/glaze-raycast.rb
@@ -1,0 +1,41 @@
+cask "glaze-raycast" do
+  version "0.8.0"
+  sha256 "a8c23e5c92fe7d0b53add89b3e27ede58be1ec20d8c28356708dfc579eba38d8"
+
+  url "https://glaze.raycast-releases.com/Glaze_#{version}_CI_Production_7639b72eb7_arm64.dmg",
+      verified: "glaze.raycast-releases.com/"
+  name "Glaze"
+  desc "Build custom desktop apps for you and your team"
+  homepage "https://www.glaze.app/"
+
+  livecheck do
+    url "https://glaze.raycast-releases.com/latest.json"
+    regex(/Glaze[._-]v?(\d+(?:\.\d+)+)[._-]CI/i)
+    strategy :json do |json, regex|
+      json["url"][regex, 1]
+    end
+  end
+
+  no_autobump! because: :bumped_by_upstream
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :tahoe
+
+  app "Glaze.app"
+
+  uninstall launchctl: [
+              "app.glaze.macos.main.cross-app-broker",
+              "app.glaze.macos.main.updater",
+              "app.glaze.macos.main.updater.daemon",
+            ],
+            quit:      "app.glaze.macos.main"
+
+  zap trash: [
+    "~/Library/Application Support/app.glaze.macos.main",
+    "~/Library/Caches/app.glaze.macos.main",
+    "~/Library/HTTPStorages/app.glaze.macos.main",
+    "~/Library/Preferences/app.glaze.macos.main.plist",
+    "~/Library/Saved Application State/app.glaze.macos.main.savedState",
+  ]
+end

--- a/Casks/r/raycast-glaze.rb
+++ b/Casks/r/raycast-glaze.rb
@@ -1,4 +1,4 @@
-cask "glaze-raycast" do
+cask "raycast-glaze" do
   version "0.8.0"
   sha256 "a8c23e5c92fe7d0b53add89b3e27ede58be1ec20d8c28356708dfc579eba38d8"
 
@@ -16,9 +16,8 @@ cask "glaze-raycast" do
     end
   end
 
-  no_autobump! because: :bumped_by_upstream
-
   auto_updates true
+  conflicts_with cask: "glaze-app"
   depends_on arch: :arm64
   depends_on macos: :tahoe
 

--- a/Casks/r/raycast-glaze.rb
+++ b/Casks/r/raycast-glaze.rb
@@ -1,8 +1,8 @@
 cask "raycast-glaze" do
-  version "0.8.0"
+  version "0.8.0,7639b72eb7"
   sha256 "a8c23e5c92fe7d0b53add89b3e27ede58be1ec20d8c28356708dfc579eba38d8"
 
-  url "https://glaze.raycast-releases.com/Glaze_#{version}_CI_Production_7639b72eb7_arm64.dmg",
+  url "https://glaze.raycast-releases.com/Glaze_#{version.csv.first}_CI_Production_#{version.csv.second}_arm64.dmg",
       verified: "glaze.raycast-releases.com/"
   name "Glaze"
   desc "Build custom desktop apps for you and your team"
@@ -10,9 +10,12 @@ cask "raycast-glaze" do
 
   livecheck do
     url "https://glaze.raycast-releases.com/latest.json"
-    regex(/Glaze[._-]v?(\d+(?:\.\d+)+)[._-]CI/i)
+    regex(/Glaze[._-]v?(\d+(?:\.\d+)+)[._-]CI[._-]Production[._-](\h+)[._-]arm64/i)
     strategy :json do |json, regex|
-      json["url"][regex, 1]
+      match = json["url"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
     end
   end
 
@@ -34,7 +37,8 @@ cask "raycast-glaze" do
     "~/Library/Application Support/app.glaze.macos.main",
     "~/Library/Caches/app.glaze.macos.main",
     "~/Library/HTTPStorages/app.glaze.macos.main",
+    "~/Library/Logs/app.glaze.macos.main",
     "~/Library/Preferences/app.glaze.macos.main.plist",
-    "~/Library/Saved Application State/app.glaze.macos.main.savedState",
+    "~/Library/WebKit/app.glaze.macos.main",
   ]
 end


### PR DESCRIPTION
New cask for Glaze by Raycast (https://www.glaze.app). Built and tested locally on macOS 27.0. The token is disambiguated from the existing `glaze-app` cask (a different app) and the `glaze` core formula.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI drafted the cask; I manually verified the download source (`www.glaze.app` → `glaze.raycast-releases.com` DMG), the SHA-256, the bundle metadata (`app.glaze.macos.main`, version 0.8.0, min macOS 26/Tahoe, arm64-only), the `launchctl`/`quit` labels (confirmed removed during `brew uninstall`), and the `zap` paths (bundle-identifier based). Built, installed, and uninstalled locally on macOS 27.0.

-----
