### PR TITLE
Update uniclipboard to 0.17.0

### DIFF
--- a/Casks/u/uniclipboard.rb
+++ b/Casks/u/uniclipboard.rb
@@ -8,7 +8,7 @@ cask "uniclipboard" do
   url "https://github.com/UniClipboard/UniClipboard/releases/download/v#{version}/UniClipboard_#{version}_#{arch}.dmg",
       verified: "github.com/UniClipboard/UniClipboard/"
   name "UniClipboard"
-  desc "Cross-device clipboard syncing tool"
+  desc "Privacy-first cross-device clipboard sync"
   homepage "https://www.uniclipboard.app/"
 
   livecheck do


### PR DESCRIPTION
Updates uniclipboard to 0.17.0.

Release: https://github.com/UniClipboard/UniClipboard/releases/tag/v0.17.0

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

This cask PR was generated by the UniClipboard automated release CI. `brew style` runs in CI on a macOS runner; the unchecked items (`brew audit --cask --online`/`--new`, install, uninstall) require local macOS testing not performed in CI and are validated by BrewTestBot.