### PR TITLE
mana 0.2.9 (new cask)

### DIFF
--- a/Casks/m/mana.rb
+++ b/Casks/m/mana.rb
@@ -13,7 +13,7 @@ cask "mana" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "Mana.app"
 

--- a/Casks/m/mana.rb
+++ b/Casks/m/mana.rb
@@ -1,0 +1,29 @@
+cask "mana" do
+  version "0.2.9"
+  sha256 "b07fea60573043df7f5d51f7adbc786a93ad13897c2ec930e7971298149b6ed5"
+
+  url "https://downloads.silent-spell.com/Mana-#{version}.dmg"
+  name "Mana"
+  desc "Menu bar tracker for AI coding assistant quotas"
+  homepage "https://silent-spell.com/"
+
+  livecheck do
+    url "https://downloads.silent-spell.com/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Mana.app"
+
+  uninstall quit: "com.silent-spell.mana"
+
+  zap trash: [
+    "~/Library/Application Support/Mana",
+    "~/Library/Caches/com.silent-spell.mana",
+    "~/Library/HTTPStorages/com.silent-spell.mana",
+    "~/Library/Logs/Mana",
+    "~/Library/Preferences/com.silent-spell.mana.plist",
+  ]
+end


### PR DESCRIPTION
[Mana](https://silent-spell.com/) is a macOS menu bar app that tracks usage quotas of AI coding assistants (Claude Code, Codex, Antigravity). Vendor submission: signed + notarized Developer ID app; the cask URL serves the exact stapled DMG that the app's Sparkle appcast (`https://downloads.silent-spell.com/appcast.xml`) serves, so Homebrew installs and Sparkle self-updates stay byte-identical. In the checklist below, `<cask>` = `mana` (commands were run against a local tap copy of this file).

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

How AI was used: the cask file and this PR were drafted with Claude Code, operated interactively by Mana's developer, who reviewed every line. Manual verification on macOS 15 (arm64), Homebrew 5.1.11 — every checklist command above was actually executed locally against a local-tap copy of this cask (audit ran as `--online --strict --new`), plus `brew livecheck mana` (resolves 0.2.9 from the Sparkle appcast) and `brew install --cask --adopt` over an existing Sparkle-managed installation. The `zap` paths were not guessed: each one was confirmed to exist on a real machine with a long-running Mana install (`~/Library/Application Support/Mana`, `~/Library/Caches/com.silent-spell.mana`, `~/Library/HTTPStorages/com.silent-spell.mana`, `~/Library/Logs/Mana`, `~/Library/Preferences/com.silent-spell.mana.plist`). The DMG is the vendor's signed, notarized and stapled release.

-----
