### PR TITLE
june 0.0.26 (new cask)

### DIFF
--- a/Casks/j/june.rb
+++ b/Casks/j/june.rb
@@ -1,0 +1,32 @@
+cask "june" do
+  version "0.0.26"
+  sha256 "099535af4df02f1a14fe8baee281bdb1d5dc533362db10229e13372c39367563"
+
+  url "https://github.com/open-software-network/os-june-releases/releases/download/v#{version}/June_universal.dmg",
+      verified: "github.com/open-software-network/os-june-releases/"
+  name "June"
+  desc "AI assistant for meeting notes, dictation, and agent work"
+  homepage "https://opensoftware.co/june"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "June.app"
+
+  uninstall launchctl: "ai.hermes.gateway",
+            quit:      "co.opensoftware.june"
+
+  zap trash: [
+    "~/Library/Application Support/co.opensoftware.june",
+    "~/Library/Caches/co.opensoftware.june",
+    "~/Library/HTTPStorages/co.opensoftware.june",
+    "~/Library/Preferences/co.opensoftware.june.plist",
+    "~/Library/Saved Application State/co.opensoftware.june.savedState",
+    "~/Library/WebKit/co.opensoftware.june",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) helped draft the cask and this PR description. All changes were verified manually on macOS: `brew style`, `brew audit --cask --new`, `brew livecheck`, and a full `HOMEBREW_NO_INSTALL_FROM_API=1 brew install` / launch / `brew uninstall` cycle. The `zap` paths were confirmed against the files the app actually creates under `~/Library` (bundle id `co.opensoftware.june`), and the `uninstall launchctl` label against the LaunchAgent the app installs.

-----

`brew audit --cask --new june` reports a single error: the notability check, because the download repository has 0 stars. Details below; everything else in the audit passes.

### Notability

June's source lives at [open-software-network/os-june](https://github.com/open-software-network/os-june) (164 stars, 13 forks), while binaries are published from a separate releases-only repository, [open-software-network/os-june-releases](https://github.com/open-software-network/os-june-releases) (0 stars), so the notability audit keys off the wrong repo. The [Acceptable Casks documentation](https://docs.brew.sh/Acceptable-Casks) lists an explicit exception for "a popular app that has its own website but the developers use GitHub for hosting the binaries", which is exactly this layout. Existing casks with the same split: `tana` (tanainc/tana-desktop-releases), `amie` (amieso/electron-releases), `dot` (prateekkeshari/dot-releases).

### App details

- Developer ID signed (ALONGSIDE FINANCE, INC.) and notarized, with the ticket stapled to the DMG.
- Universal binary (arm64 + x86_64), requires macOS 14 (`depends_on macos: :sonoma`).
- Self-updates via the Tauri updater, hence `auto_updates true`.
- `livecheck` uses `:github_latest` on the releases repo and resolves the current version correctly.
