### PR TITLE
Add aurora-music 1.2.0

### DIFF
--- a/Casks/a/aurora-music.rb
+++ b/Casks/a/aurora-music.rb
@@ -1,0 +1,26 @@
+cask "aurora-music" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.2.0"
+  sha256 arm:   "b36b55e8cfbdbf3b99f29becbafa39574606d736e15dc821142e88e680444874",
+         intel: "f6c9248c49ce1c2d6d03cbb0f15d0e331beb3b74d13f76d88d83d66c61d1956d"
+
+  url "https://github.com/nanjingya/Aurora-Music/releases/download/v#{version}/Aurora-Music-#{version}-mac-#{arch}.dmg",
+      verified: "github.com/nanjingya/Aurora-Music/"
+  name "Aurora Music"
+  desc "Immersive music player with lyrics stage, particle visuals, and 3D playlist shelf"
+  homepage "https://github.com/nanjingya/Aurora-Music"
+
+  livecheck do
+    url :homepage
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+
+  app "Aurora Music.app"
+
+  zap trash: [
+    "~/Library/Application Support/Aurora Music",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `aurora-music` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online aurora-music` is error-free.
- [x] `brew style --fix aurora-music` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+aurora-music&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new aurora-music` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask aurora-music` worked successfully.
- [x] `brew uninstall --cask aurora-music` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Cursor) assisted with drafting the cask file and PR description. I manually verified:

- SHA256 checksums for both arm64 and x64 DMGs from the v1.2.0 GitHub Release
- `brew style --fix` on `Casks/a/aurora-music.rb` (desc length + zap stanza)
- `brew audit --cask --online aurora-music` via personal tap `nanjingya/tap`
- Install/uninstall on Apple Silicon via `brew install --cask aurora-music` / `brew uninstall --cask aurora-music`
- `zap` path: `~/Library/Application Support/Aurora Music` (Electron `app.getPath('userData')` on macOS)

-----

## Summary

Add [Aurora Music](https://github.com/nanjingya/Aurora-Music), an open-source immersive desktop music player for macOS.

- **Homepage**: https://github.com/nanjingya/Aurora-Music
- **Latest release**: v1.2.0 (stable GitHub Release)
- **Architecture**: separate arm64 / x64 DMGs

Upstream author: `nanjingya`. Personal tap mirror: `brew tap nanjingya/tap`.