### PR TITLE
harper-desktop 2.6.0 (new cask)

### DIFF
--- a/Casks/h/harper-desktop.rb
+++ b/Casks/h/harper-desktop.rb
@@ -1,0 +1,23 @@
+cask "harper-desktop" do
+  version "2.6.0"
+  sha256 "1a62cb2fe8be6f4ec797923dfa7f07d81469d5b75c649f6c7fbfc8d253f0a9dc"
+
+  url "https://github.com/Automattic/harper/releases/download/v#{version}/Harper_#{version}_universal.dmg",
+      verified: "github.com/Automattic/harper/"
+  name "Harper Desktop"
+  desc "Grammar checker for developers"
+  homepage "https://writewithharper.com/"
+
+  depends_on macos: :sonoma
+
+  app "Harper.app"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/harper-desktop_*.plist",
+    "~/Library/Application Support/harper-desktop",
+    "~/Library/Caches/com.elijahpotter.harper-desktop",
+    "~/Library/LaunchAgents/Harper.plist",
+    "~/Library/Logs/DiagnosticReports/harper-desktop-*ips",
+    "~/Library/WebKit/com.elijahpotter.harper-desktop",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Brew audit flags the desktop suffix (`cask token mentions desktop`) but this seems incorrect to me because:

- Homebrew core already includes `harper`: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/h/harper.rb
- Harper specifically name the desktop app `Harper Desktop` - https://writewithharper.com/desktop which seems to fit the Docker Desktop style exception