### PR TITLE
itsypin 2.0.0 (new cask)

### DIFF
--- a/Casks/i/itsypin.rb
+++ b/Casks/i/itsypin.rb
@@ -1,0 +1,20 @@
+cask "itsypin" do
+  version "2.0.0"
+  sha256 "cbb5f8d4a2f799205431e9a3dc89ab593066e71acab51cb2ae3a77da7ce53b04"
+
+  url "https://github.com/nickustinov/itsypin-macos/releases/download/v#{version}/Itsypin-#{version}.dmg"
+  name "Itsypin"
+  desc "Pin websites to the menu bar or floating bubbles"
+  homepage "https://github.com/nickustinov/itsypin-macos"
+
+  depends_on macos: :ventura
+
+  app "Itsypin.app"
+
+  zap trash: [
+    "~/Library/Caches/com.itsypin.app",
+    "~/Library/HTTPStorages/com.itsypin.app",
+    "~/Library/Preferences/com.itsypin.app.plist",
+    "~/Library/WebKit/com.itsypin.app",
+  ]
+end


### PR DESCRIPTION
Adds [Itsypin](https://github.com/nickustinov/itsypin-macos) — pin websites to the macOS menu bar or as floating bubbles on the screen edge. Signed and notarized universal binary, distributed via GitHub releases.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+itsypin&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

The cask file and this PR were prepared with AI assistance (Claude Code), driven by the app's developer. All checklist items above were actually executed locally (audit online/new, style, install, uninstall). The `zap` paths were verified against a real installation — each listed path exists on disk after using the app; a `Saved Application State` path was removed from the draft because the app (an `LSUIElement` agent) never creates one.