### PR TITLE
voiceinput 0.75.7 (new cask)

### DIFF
--- a/Casks/v/voiceinput.rb
+++ b/Casks/v/voiceinput.rb
@@ -1,0 +1,27 @@
+cask "voiceinput" do
+  version "0.75.7"
+  sha256 "e5130276de813133abfb01ad55259a410710ccad9ba9d18ba7c505635ee112ae"
+
+  url "https://dl.voiceinput.app/VoiceInput_v#{version}.dmg"
+  name "VoiceInput"
+  name "声忆"
+  desc "Hold a key, speak, release to type"
+  homepage "https://voiceinput.app/"
+
+  livecheck do
+    url "https://dl.voiceinput.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "VoiceInput.app"
+
+  zap trash: [
+    "~/Library/Application Support/VoiceInput",
+    "~/Library/Caches/com.jiangfyi.voiceinput",
+    "~/Library/Preferences/com.jiangfyi.voiceinput.plist",
+    "~/Library/Saved Application State/com.jiangfyi.voiceinput.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

## About VoiceInput (声忆)

VoiceInput is a macOS menu-bar voice-to-text app: hold a hotkey, speak, release to insert transcribed text into the focused field. Website: https://voiceinput.app/

- Notarized, code-signed DMG, distributed from our own domain (`dl.voiceinput.app`), URL is versioned per release.
- Ships with a Sparkle appcast at `https://dl.voiceinput.app/appcast.xml`, so I added a `livecheck` block using the `:sparkle` strategy.
- This cask has been running for a while in my own tap (`depthsky2016/homebrew-tap`) as `voiceinput.rb`, unchanged apart from adapting it to the official repo's directory convention (`Casks/v/voiceinput.rb`) and adding the `livecheck` block.

## Local verification notes (honest status — please read before the checklist above)

I'm being explicit here because I don't want the checkboxes above to overstate what I actually ran:

- `brew style` on this file: ran locally, **0 offenses**. Checkbox above reflects this truthfully.
- `brew audit --cask --new` / `--online`: **could not run** on this machine. `brew audit` currently gates on `Your Xcode (26.6) at /Applications/Xcode.app is too outdated. Please update to Xcode 27.0`, which blocks *any* audit invocation in this environment, unrelated to this cask's content. Left both audit checkboxes unchecked accordingly.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask voiceinput` / `brew uninstall --cask voiceinput` against this exact file (from the official repo path): **not yet run**, left unchecked. I have run install/uninstall repeatedly against the equivalent cask body in my personal tap (`depthsky2016/homebrew-tap`, same URL/sha256/app/zap stanza), so the cask is known-working end to end, but I did not want to tick the box for a run I hadn't performed against this specific PR's file. Happy to run and confirm if a maintainer wants that before merge.
- sha256 was independently re-verified: downloaded the DMG fresh and ran `shasum -a 256` locally; it matches the value in the cask, and the downloaded file size (23,941,708 bytes) matches the `length` attribute in the Sparkle appcast entry for this version.