### PR TITLE
Add onit-sidekick 3.0

### DIFF
--- a/Casks/s/sidekick.rb
+++ b/Casks/s/sidekick.rb
@@ -1,0 +1,29 @@
+cask "sidekick" do
+  version "3.0"
+  sha256 "1aaeee17ffb4b05ca2a9168a2319dd9b4d31f485868433a858acfda86a23a4d8"
+
+  url "https://github.com/synth-inc/onit/releases/download/v#{version}/SideKick-#{version}.dmg",
+      verified: "github.com/synth-inc/onit/"
+  name "SideKick"
+  desc "AI chat panel that docks next to your active window with on-screen context"
+  homepage "https://www.getonit.ai/"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/synth-inc/onit/main/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "SideKick.app"
+
+  uninstall quit: "inc.synth.onit.sidekick"
+
+  zap trash: [
+    "~/Library/Caches/inc.synth.onit.sidekick",
+    "~/Library/HTTPStorages/inc.synth.onit.sidekick",
+    "~/Library/Preferences/inc.synth.onit.sidekick.plist",
+    "~/Library/Saved Application State/inc.synth.onit.sidekick.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

An AI assistant helped author this `onit-sidekick` cask and open the PR. Manual verification performed:

- The app (SideKick) is Developer ID–signed and notarized; Gatekeeper acceptance confirmed (`spctl -a` → accepted).
- `brew audit --cask --new --online onit-sidekick` — error-free.
- `brew style onit-sidekick` — no offenses.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask onit-sidekick` and `brew uninstall --cask onit-sidekick` — both succeeded locally.
- `zap` paths were derived from the app's bundle identifier `inc.synth.onit.sidekick` (Caches, HTTPStorages, Preferences, Saved Application State) and reviewed manually.

-----
