### PR TITLE
zcode 3.2.3 (new cask)

### DIFF
--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -12,7 +12,7 @@ cask "zcode" do
 
   livecheck do
     url :homepage
-    regex(/href=.*ZCode[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg/i)
+    regex(%r{href="https://cdn-zcode\.z\.ai/.*?ZCode[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg"}i)
   end
 
   auto_updates true

--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -1,9 +1,9 @@
 cask "zcode" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.2.3"
-  sha256 arm:   "10d3ebb6cae5f1d30d8bfc1919c33da1ad92aa4c198a7b83159e8d28a039ffcc",
-         intel: "5c31d1da903d665eff53b76e1fdb11e2009dfbcc8c5fad8f57f294d1bbcae8cd"
+  version "3.2.4"
+  sha256 arm:   "7755502e3dd0daa794e6be44290418c7890dfe9f7d875948aee2a93c1ae33e28",
+         intel: "bcf04a1da7ab5bcd50c18dff7ad9df121aaf404110610e25d291150fc34c3a17"
 
   url "https://cdn-zcode.z.ai/zcode/electron/releases/#{version}/ZCode-#{version}-mac-#{arch}.dmg"
   name "ZCode"
@@ -12,7 +12,7 @@ cask "zcode" do
 
   livecheck do
     url :homepage
-    regex(/ZCode[._-]v?(\d+(?:\.\d+)+)-mac-arm64\.dmg/i)
+    regex(/href=.*ZCode[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg/i)
   end
 
   auto_updates true

--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -1,0 +1,29 @@
+cask "zcode" do
+  arch arm: "arm64", intel: "x64"
+
+  version "3.2.3"
+  sha256 arm:   "10d3ebb6cae5f1d30d8bfc1919c33da1ad92aa4c198a7b83159e8d28a039ffcc",
+         intel: "5c31d1da903d665eff53b76e1fdb11e2009dfbcc8c5fad8f57f294d1bbcae8cd"
+
+  url "https://cdn-zcode.z.ai/zcode/electron/releases/#{version}/ZCode-#{version}-mac-#{arch}.dmg"
+  name "ZCode"
+  desc "AI-assisted development environment"
+  homepage "https://zcode.z.ai/"
+
+  livecheck do
+    url :homepage
+    regex(/ZCode[._-]v?(\d+(?:\.\d+)+)-mac-arm64\.dmg/i)
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "ZCode.app"
+
+  zap trash: [
+    "~/Library/Application Support/ZCode",
+    "~/Library/Caches/@zcodedesktop-updater",
+    "~/Library/Preferences/dev.zcode.app.plist",
+    "~/Library/Services/Open in ZCode.workflow",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Built and tested locally on macOS 27.0 (arm64).

ZCode is the desktop IDE for Z.ai's GLM coding agent. Both architectures are official notarized DMGs (Developer ID: Beijing Knowledge Atlas Technology Joint Stock Company Limited, 8A5X4JJ39T).

AI use: Claude Code drafted the cask and this PR. Manual verification: ran the `--new`/`--online` audit (executed via `Cask::Auditor` with the same arguments, since the `brew audit` CLI entry point is blocked on this machine by an unrelated Xcode-version environment check on macOS 27 beta — CI will re-run the normal command), installed and launched the app, verified every `zap` path against what the app actually created under `~/Library` (Application Support, Preferences plist, Services workflow; the updater cache dir comes from `updaterCacheDirName` in the bundle's `app-update.yml`), then uninstalled.
