### PR TITLE
jubler 10.0.0

### DIFF
--- a/Casks/j/jubler.rb
+++ b/Casks/j/jubler.rb
@@ -1,8 +1,11 @@
 cask "jubler" do
-  version "9.0.1"
-  sha256 "20af1deb410e2d81f5612a33546375a4c6c3085072ea2ed01852b8ac018d0633"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://github.com/teras/Jubler/releases/download/v#{version}/Jubler-#{version}.dmg",
+  version "10.0.0"
+  sha256 arm:   "68b241a9fa4dd1d1d9c747871664d506be01df9fdd8b683976ed5cf107fc9ccb",
+         intel: "3f8fabd5195a65c0c1a82e4b95d6bf76de83cc2796fe42ea554f433464dfaeca"
+
+  url "https://github.com/teras/Jubler/releases/download/v#{version}/Jubler-#{version}-#{arch}.dmg",
       verified: "github.com/teras/Jubler/"
   name "Jubler"
   desc "Subtitle editor"
@@ -23,8 +26,4 @@ cask "jubler" do
     "~/Library/Preferences/com.panayotis.jubler.config.old",
     "~/Library/Preferences/com.panayotis.jubler.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`jubler` is autobumped but the workflow failed to update to version 10.0.0 because upstream now offers separate ARM and Intel dmg files. This updates the version and adjusts the cask accordingly.