### PR TITLE
twake 5.4.0

### DIFF
--- a/Casks/t/twake.rb
+++ b/Casks/t/twake.rb
@@ -1,11 +1,11 @@
 cask "twake" do
-  arch arm: "-arm64"
+  arch arm: "arm64", intel: "x64"
 
-  version "5.3.0"
-  sha256 arm:   "c30d21c9a6a61320a5aa64fd11f1915a7bbbb61e457c2e1dc1d5d029746e3b14",
-         intel: "661ce84a8e75b816d97c620387ab05ca62920e5a37d6aa5d5291cfd0d8153a2e"
+  version "5.4.0"
+  sha256 arm:   "4029c0b22b14ebf8b0444f2549d1cc956427e9319a5fbc75e73dda4191a0f0d8",
+         intel: "9b99363160894de08aafb0c678e7737887d2c908758994b3f0a5d355fbd045b3"
 
-  url "https://github.com/cozy-labs/cozy-desktop/releases/download/v#{version}/Twake-Desktop-#{version}#{arch}.dmg",
+  url "https://github.com/cozy-labs/cozy-desktop/releases/download/v#{version}/Twake-Desktop-#{arch}.dmg",
       verified: "github.com/cozy-labs/cozy-desktop/"
   name "Twake Desktop"
   desc "File synchronisation for Twake Workplace"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`twake` is autobumped but the workflow failed to update to version 5.4.0 because the dmg file name no longer includes a version and the Intel file now includes an `-x64` suffix. This updates the version and adjusts the cask accordingly.