### PR TITLE
keeperdb 2.2.0 (new cask)

### DIFF
--- a/Casks/k/keeperdb.rb
+++ b/Casks/k/keeperdb.rb
@@ -5,7 +5,7 @@ cask "keeperdb" do
   url "https://keepersecurity.com/pam/keeperdb/v#{version}/KeeperDB_#{version}_universal.dmg"
   name "KeeperDB"
   desc "Database management tool for Postgres, MySQL, SQLite, MSSQL, Oracle, Redshift"
-  homepage "https://www.keepersecurity.com/"
+  homepage "https://www.keepersecurity.com/keeperdb/"
 
   livecheck do
     url "https://keepersecurity.com/pam/keeperdb/latest.txt"

--- a/Casks/k/keeperdb.rb
+++ b/Casks/k/keeperdb.rb
@@ -1,0 +1,25 @@
+cask "keeperdb" do
+  version "2.2.0"
+  sha256 "17ccc6ce7b6cf4fe527fe5c5ca35d24cc476976002f828f3c75f6308ad39a960"
+
+  url "https://keepersecurity.com/pam/keeperdb/v#{version}/KeeperDB_#{version}_universal.dmg"
+  name "KeeperDB"
+  desc "Database management tool for Postgres, MySQL, SQLite, MSSQL, Oracle, Redshift"
+  homepage "https://www.keepersecurity.com/"
+
+  livecheck do
+    url "https://keepersecurity.com/pam/keeperdb/latest.txt"
+    regex(/VERSION=(\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on macos: :catalina
+
+  app "KeeperDB.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.keepersecurity.keeperdb",
+    "~/Library/Caches/com.keepersecurity.keeperdb",
+    "~/Library/Preferences/com.keepersecurity.keeperdb.plist",
+    "~/Library/Saved Application State/com.keepersecurity.keeperdb.savedState",
+  ]
+end

--- a/Casks/k/keeperdb.rb
+++ b/Casks/k/keeperdb.rb
@@ -16,10 +16,17 @@ cask "keeperdb" do
 
   app "KeeperDB.app"
 
+  uninstall quit: "com.keepersecurity.keeperdb"
+
   zap trash: [
-    "~/Library/Application Support/com.keepersecurity.keeperdb",
+    "~/Library/Application Support/KeeperDB",
     "~/Library/Caches/com.keepersecurity.keeperdb",
+    "~/Library/Caches/keeperdb-desktop",
+    "~/Library/HTTPStorages/com.keepersecurity.keeperdb",
+    "~/Library/HTTPStorages/com.keepersecurity.keeperdb.binarycookies",
+    "~/Library/Logs/KeeperDB",
     "~/Library/Preferences/com.keepersecurity.keeperdb.plist",
-    "~/Library/Saved Application State/com.keepersecurity.keeperdb.savedState",
+    "~/Library/WebKit/com.keepersecurity.keeperdb",
+    "~/Library/WebKit/keeperdb-desktop",
   ]
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assisted with drafting this cask; it was then manually verified on macOS against the stable v2.2.0 release: `brew audit --cask --online`, `brew style --fix`, and `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask` + `brew uninstall --cask` all succeeded. Download URL + SHA256 confirmed against the vendor's published release, app is Apple-signed/notarized, and the [`zap`](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths match the bundle identifier `com.keepersecurity.keeperdb`.

-----
