### PR TITLE
Add claude-token-monitor-bar 1.2.1

### DIFF
--- a/Casks/c/claude-token-monitor-bar.rb
+++ b/Casks/c/claude-token-monitor-bar.rb
@@ -1,6 +1,6 @@
 cask "claude-token-monitor-bar" do
   version "1.2.1"
-  sha256 "469e0096c498eea3e493b76514fccdd332beac40858e353748ca90ecea06f7b7"
+  sha256 "8a5554181edbedabc070a1d2c634106d7d3ac2f7b412362bfe42338e2246ce8b"
 
   url "https://github.com/HAOGRE/ClaudeTokenMonitorBar-macOS/releases/download/v#{version}/ClaudeTokenMonitorBar-v#{version}.dmg"
   name "ClaudeTokenMonitorBar"
@@ -9,10 +9,19 @@ cask "claude-token-monitor-bar" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   depends_on macos: :sonoma
 
   app "ClaudeTokenMonitorBar.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.haogre.claudetokenmonitor",
+    "~/Library/Caches/com.haogre.claudetokenmonitor",
+    "~/Library/Containers/com.haogre.claudetokenmonitor",
+    "~/Library/HTTPStorages/com.haogre.claudetokenmonitor",
+    "~/Library/Preferences/com.haogre.claudetokenmonitor.plist",
+    "~/Library/Saved Application State/com.haogre.claudetokenmonitor.savedState",
+  ]
 end

--- a/Casks/c/claude-token-monitor-bar.rb
+++ b/Casks/c/claude-token-monitor-bar.rb
@@ -1,0 +1,18 @@
+cask "claude-token-monitor-bar" do
+  version "1.2.1"
+  sha256 "469e0096c498eea3e493b76514fccdd332beac40858e353748ca90ecea06f7b7"
+
+  url "https://github.com/HAOGRE/ClaudeTokenMonitorBar-macOS/releases/download/v#{version}/ClaudeTokenMonitorBar-v#{version}.dmg"
+  name "ClaudeTokenMonitorBar"
+  desc "Menu bar monitor for Claude Code token usage and costs"
+  homepage "https://github.com/HAOGRE/ClaudeTokenMonitorBar-macOS"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on macos: :sonoma
+
+  app "ClaudeTokenMonitorBar.app"
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with updating the PR body and cask metadata. I manually verified:

- `brew style --fix claude-token-monitor-bar` reports no offenses.
- `brew livecheck --cask claude-token-monitor-bar` reports current/latest `1.2.1`.
- `brew audit --cask --online --new claude-token-monitor-bar` still fails because the app is not signed by a distributor that meets Gatekeeper requirements.
- `zap` paths were checked against the app bundle id `com.haogre.claudetokenmonitor` and local Library paths for Preferences, Caches, Containers, HTTPStorages, Application Scripts, and Saved Application State.
- Install/uninstall was not rerun locally because `/Applications/ClaudeTokenMonitorBar.app` already exists on this machine.
- This replaces #272983, which GitHub refuses to reopen because its branch was force-pushed or recreated.

-----
