### PR TITLE
docker-desktop: remove docker-compose linking

### DIFF
--- a/Casks/d/docker-desktop.rb
+++ b/Casks/d/docker-desktop.rb
@@ -37,8 +37,6 @@ cask "docker-desktop" do
          target: "/usr/local/bin/docker-credential-osxkeychain"
   binary "#{appdir}/Docker.app/Contents/Resources/bin/kubectl",
          target: "/usr/local/bin/kubectl.docker"
-  binary "#{appdir}/Docker.app/Contents/Resources/cli-plugins/docker-compose",
-         target: "/usr/local/cli-plugins/docker-compose"
   bash_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.bash-completion"
   bash_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.bash-completion"
   fish_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.fish-completion"


### PR DESCRIPTION
This symlink is broken and it seems it's unnecessary at all.

Docker Desktop will create symlinks for CLI plugins on the first run, so this manual step seems unnecessary. On my machine, it created a symlink to `docker-compose` in `~/.docker/cli-plugins/docker-compose` anyways. And if I run `docker info` I see that Docker loads all CLI plugins from `~/.docker/cli-plugins` and does not use `/usr/local/cli-plugins/docker-compose`.

Also, according to [Docker Compose CLI plugin manual installation instructions](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually) it should be placed in `/usr/local/lib/docker/cli-plugins` and not `/usr/local/cli-plugins`.

I'm also not sure whether all the other symlinks created by this Cask in `/usr/local/bin` are necessary. Because even when they exist, Docker Desktop will still ask the user where to install CLI binaries. This functionality exists in Docker Desktop for a while already, so I think it's safe to simplify this Cask to just copying `Docker.app`. That way it won't need `sudo`. Also, Docker Desktop can install all the binaries it needs in `~/.docker/bin`, so it's possible to install Docker Desktop without `sudo` at all, but this Cask forces global binaries. Don't know whether it's by design, or just a legacy.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
