### PR TITLE
gitwand 3.2.0 (new cask)

### DIFF
--- a/Casks/g/gitwand.rb
+++ b/Casks/g/gitwand.rb
@@ -1,0 +1,30 @@
+cask "gitwand" do
+  version "3.2.0"
+  sha256 "66bf75aafca88eb9c8102d0d7da68d30f191102ec9a10645f8426aa119397ee8"
+
+  url "https://github.com/devlint/GitWand/releases/download/v#{version}/GitWand_#{version}_universal.dmg",
+      verified: "github.com/devlint/GitWand/"
+  name "GitWand"
+  desc "Git client with deterministic merge-conflict auto-resolution"
+  homepage "https://gitwand.devlint.fr/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "GitWand.app"
+
+  zap trash: [
+    "~/Library/Application Support/gitwand",
+    "~/Library/Caches/com.gitwand.desktop",
+    "~/Library/Caches/gitwand-desktop",
+    "~/Library/Preferences/com.gitwand.desktop.plist",
+    "~/Library/Saved Application State/com.gitwand.desktop.savedState",
+    "~/Library/WebKit/com.gitwand.desktop",
+    "~/Library/WebKit/gitwand-desktop",
+  ]
+end


### PR DESCRIPTION
Adds [GitWand](https://gitwand.devlint.fr/) — a free, open-source (MIT) native Git client (Tauri 2 + Rust) with a deterministic merge-conflict resolution engine. Signed and notarized (Developer ID), auto-updates via the built-in Tauri updater. Repository: https://github.com/devlint/GitWand (105 stars).

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

The cask was drafted with AI assistance (Claude Code), then verified end-to-end on a real macOS machine (Apple Silicon): `brew style`, `brew audit --cask --new` and `brew audit --cask --online` all pass; the cask was installed from a local tap, the app was confirmed Gatekeeper-accepted (`spctl`: Notarized Developer ID) and launched, then uninstalled cleanly. The `zap` stanza paths were determined empirically by enumerating `~/Library` after running the installed app — they are the paths the app actually creates. I am the developer of GitWand.
