### PR TITLE
bosun 1.2.2 (new cask)

### DIFF
--- a/Casks/b/bosun.rb
+++ b/Casks/b/bosun.rb
@@ -2,7 +2,8 @@ cask "bosun" do
   version "1.2.2"
   sha256 "f51d35ca30652fc227a1e66eec3c40a28ddeda35a78ac08523a1c593c634bb7a"
 
-  url "https://github.com/iwunkhaus/bosun-releases/releases/download/#{version}/Bosun.dmg"
+  url "https://github.com/iwunkhaus/bosun-releases/releases/download/#{version}/Bosun.dmg",
+      verified: "github.com/iwunkhaus/bosun-releases/"
   name "Bosun"
   desc "Menu bar network port, tunnel, VPN, and Docker visibility tool"
   homepage "https://bosun.dev/"

--- a/Casks/b/bosun.rb
+++ b/Casks/b/bosun.rb
@@ -1,0 +1,29 @@
+cask "bosun" do
+  version "1.2.2"
+  sha256 "f51d35ca30652fc227a1e66eec3c40a28ddeda35a78ac08523a1c593c634bb7a"
+
+  url "https://github.com/iwunkhaus/bosun-releases/releases/download/#{version}/Bosun.dmg"
+  name "Bosun"
+  desc "Menu bar network port, tunnel, VPN, and Docker visibility tool"
+  homepage "https://bosun.dev/"
+
+  livecheck do
+    url "https://bosun.dev/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Bosun.app"
+
+  uninstall quit: "dev.cuprite.bosun"
+
+  zap trash: [
+    "~/Library/Application Support/Bosun",
+    "~/Library/Application Support/CrashReporter/Bosun_*.plist",
+    "~/Library/Caches/dev.cuprite.bosun",
+    "~/Library/HTTPStorages/dev.cuprite.bosun",
+    "~/Library/Preferences/dev.cuprite.bosun.plist",
+  ]
+end


### PR DESCRIPTION
Adds Bosun, a native macOS menu bar app that shows every listening port, ngrok/Cloudflare tunnel, active VPN connection, and Docker container mapped to its process — with one-click kill.

- Signed with Developer ID, notarized and stapled
- Distributed as a plain `.app` inside a `.dmg`, no installer/pkg
- Auto-updates via Sparkle; `livecheck` uses `strategy :sparkle` against the app's own `appcast.xml`
- Closed-source, paid with a 14-day free trial (no bundling/SetApp dependency)

**Update:** this PR originally hosted the `.dmg` on a GitHub repo (`bosun-releases`) used only for release binaries, which failed the automated notability audit (0 forks/watchers/stars, and self-submission raises the threshold to 90/90/225 — unreachable for a binary-hosting-only repo). Rather than rely on the documented notability exception for vendor-hosted apps, the download and Sparkle appcast were moved to the vendor's own domain (`dl.bosun.dev`), which resolves the audit outright. Bumped to the current release, 1.2.4, in the process.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

This cask was drafted with AI assistance (Claude), using the official Cask Cookbook and comparable real casks (HazeOver, CleanShot) as reference. The app owner manually verified: the sha256 against the actual release asset, code signing/notarization/Gatekeeper acceptance of the shipped binary via `codesign`/`spctl`/`stapler validate`, and the `zap` trash paths against files actually created by the running app (found via `find ~/Library/{Application Support,Caches,Preferences,HTTPStorages} -iname '*bosun*'` on a machine that had run it), including a stale legacy bundle ID that was excluded from the zap list. `brew audit --cask --new`, `install`, and `uninstall` were run locally against a full tap checkout after the hosting change, all passing.

-----
