### PR TITLE
muesli 0.7.1 (new cask)

### DIFF
--- a/Casks/m/muesli.rb
+++ b/Casks/m/muesli.rb
@@ -10,7 +10,7 @@ cask "muesli" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/m/muesli.rb
+++ b/Casks/m/muesli.rb
@@ -1,0 +1,26 @@
+cask "muesli" do
+  version "0.7.1"
+  sha256 "b911e5e14874cf971590f8943eb55eba2bba839fc8a881544a8939eaafa1e2ee"
+
+  url "https://github.com/Muesli-HQ/muesli/releases/download/v#{version}/Muesli-#{version}.dmg",
+      verified: "github.com/Muesli-HQ/muesli/"
+  name "Muesli"
+  desc "Local-first dictation and meeting transcription"
+  homepage "https://muesli.works/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "Muesli.app"
+
+  zap trash: [
+    "~/.cache/muesli",
+    "~/Library/Application Support/Muesli",
+  ]
+end


### PR DESCRIPTION
Adds Muesli, a local-first macOS app for dictation and meeting transcription on Apple Silicon. Speech-to-text runs locally on device, and releases are distributed from the official `Muesli-HQ/muesli` GitHub releases page.

This follows up on the earlier closed attempt, https://github.com/Homebrew/homebrew-cask/pull/254741. That PR was closed because it did not use the Homebrew PR template. For this submission, I rechecked the current cask against the relevant Homebrew requirements and ran the full validation checklist below.

Notability: `Muesli-HQ/muesli` is the canonical public repository and currently has 656 stars and 68 forks, which clears Homebrew's GitHub notability thresholds.

Manual package checks performed:

- Verified the current stable release is `v0.7.1`, not draft/prerelease.
- Verified the DMG SHA-256: `b911e5e14874cf971590f8943eb55eba2bba839fc8a881544a8939eaafa1e2ee`.
- Verified the app is signed with Developer ID, notarized, and stapled.
- Verified Gatekeeper accepts the app with `spctl`: `source=Notarized Developer ID`.
- Verified `zap` paths against the app's existing maintained Homebrew tap and known local data locations: `~/.cache/muesli` and `~/Library/Application Support/Muesli`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance: Codex helped adapt the cask from the maintained `Muesli-HQ/homebrew-muesli` tap and compare it against recent accepted Homebrew Cask submissions, especially `typewhisper 1.4.0 (new cask)`. I manually verified the release metadata, sha256, signing/notarization/Gatekeeper status, and ran:

- `brew style --fix muesli`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --cask --online --new muesli`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --appdir=/tmp/muesli-homebrew-cask-test... muesli`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew uninstall --cask muesli`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew lgtm --online`

-----
