### PR TITLE
tablething 0.15.4 (new cask)

### DIFF
--- a/Casks/t/tablething.rb
+++ b/Casks/t/tablething.rb
@@ -1,0 +1,27 @@
+cask "tablething" do
+  version "0.15.4"
+  sha256 "b608226f2921f349a804dbb5af0a520fdbdd0dd7ecc098aa3e83806eec2feaf4"
+
+  url "https://github.com/tablething/tablething/releases/download/v#{version}/Tablething_#{version}_universal.dmg",
+      verified: "github.com/tablething/tablething/"
+  name "Tablething"
+  desc "Database client to query any datasource with AI built in"
+  homepage "https://tablething.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :catalina
+
+  app "Tablething.app"
+
+  zap trash: [
+    "~/Library/Application Support/app.tablething.desktop",
+    "~/Library/Caches/app.tablething.desktop",
+    "~/Library/Preferences/app.tablething.desktop.plist",
+    "~/Library/Saved Application State/app.tablething.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with researching the upstream project, drafting the cask, and writing the PR description. Changes were manually verified by running `brew audit --cask --new tablething`, `brew style --fix`, `brew install --cask tablething`, and `brew uninstall --cask tablething`. The `zap` paths were verified against local `~/Library/Application Support/app.tablething.desktop`, `~/Library/Caches/app.tablething.desktop`, `~/Library/Preferences/app.tablething.desktop.plist`, and the app's `CFBundleIdentifier` (`app.tablething.desktop`).

-----

Adds [Tablething](https://tablething.com/), a free database client with AI-assisted querying. The cask installs the universal macOS DMG from GitHub Releases (v0.15.4).