### PR TITLE
pokerth 2.1.0

### DIFF
--- a/Casks/p/pokerth.rb
+++ b/Casks/p/pokerth.rb
@@ -1,12 +1,16 @@
 cask "pokerth" do
-  version "2.0.8"
-  sha256 "c35ba20313883caac2cce5be6910b3c05f3db5f284f509ff12340d7fc0da07c3"
+  version "2.1.0"
+  sha256 "9c2384aaf5a08b52ce2cc0f39a2843027e516a79cf0d2075fb7362810d4095db"
 
-  url "https://downloads.sourceforge.net/pokerth/PokerTH-Widget-#{version}.dmg",
+  url "https://downloads.sourceforge.net/pokerth/PokerTH-#{version}-Combined.dmg",
       verified: "downloads.sourceforge.net/pokerth/"
   name "PokerTH"
   desc "Free Texas hold'em poker"
   homepage "https://www.pokerth.net/"
+
+  livecheck do
+    url "https://sourceforge.net/projects/pokerth/rss?path=/pokerth"
+  end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`pokerth` is autobumped but the workflow failed to update to version 2.1.0 because the dmg file now includes the Widget and QML client combined. This updates the version and adjusts the `url` accordingly.

Besides that, this adds a `livecheck` block that uses a SourceForge RSS feed URL that's restricted to the `/pokerth` directory where the release files are found. There are other directories in the project that we don't need/want to check, so this helps to ensure that release files aren't pushed out of the feed by unrelated files.