### PR TITLE
Add Shotbox 0.8.1 (new cask)

### DIFF
--- a/Casks/s/shotbox.rb
+++ b/Casks/s/shotbox.rb
@@ -1,0 +1,25 @@
+cask "shotbox" do
+  version "0.8.1"
+  sha256 "8c635fe17354a66615af581a6b5e59ac94a5d550c05b9c4b489a43bd975b1b41"
+
+  url "https://dl-box.gatheon.com/Shotbox-#{version}.dmg"
+  name "Shotbox"
+  desc "Auto-titles screenshots and indexes their text for search"
+  homepage "https://box.gatheon.com/"
+
+  livecheck do
+    url "https://dl-box.gatheon.com/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "Shotbox.app"
+
+  zap trash: [
+    "~/Library/Application Support/Shotbox",
+    "~/Library/Caches/fyi.jiang.shotbox",
+    "~/Library/Preferences/fyi.jiang.shotbox.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Shotbox is a macOS menu-bar screenshot tool by the same developer as the already-submitted `voiceinput` cask (#272864). It auto-titles screenshots and OCRs their text (Apple Vision, on-device) so they become searchable, without any cloud upload.

- `brew style --fix Casks/s/shotbox.rb` is clean (0 offenses).
- `brew audit --cask --online` was not run in this environment (no local Xcode/SDK gate check performed here), so left unchecked rather than falsely claimed.
- Install/uninstall in a clean environment was not performed in this pass, so left unchecked.
- `zap` trash paths (`~/Library/Application Support/Shotbox`, `~/Library/Caches/fyi.jiang.shotbox`, `~/Library/Preferences/fyi.jiang.shotbox.plist`) were verified to exist on a real install of the app by the developer/maintainer.
- App is Developer ID signed and notarized; download URL and sha256 were verified via `brew fetch --cask` against the maintainer's own tap (depthsky2016/tap) prior to filing this PR.
