### PR TITLE
Add Filewise 0.5.1 (new cask)

### DIFF
--- a/Casks/f/filewise.rb
+++ b/Casks/f/filewise.rb
@@ -1,0 +1,26 @@
+cask "filewise" do
+  version "0.5.1"
+  sha256 "dcfb0ca7d4f918b8c97a5fa67dd105e4e0d5a207f4ee6d028d800cdc4a42068e"
+
+  url "https://dl-filewise.gatheon.com/Filewise_v#{version}_slim.dmg"
+  name "Filewise"
+  desc "Content-aware file organizer that renames and sorts documents"
+  homepage "https://filewise.gatheon.com/"
+
+  livecheck do
+    url "https://dl-filewise.gatheon.com/appcast-slim.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Filewise.app"
+
+  zap trash: [
+    "~/Library/Application Support/Filewise",
+    "~/Library/Caches/fyi.jiang.guiwei",
+    "~/Library/Preferences/fyi.jiang.guiwei.plist",
+    "~/Library/Saved Application State/fyi.jiang.guiwei.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Filewise is a macOS content-aware file organizer by the same developer as the already-submitted `voiceinput` cask (#272864). It reads file content locally (local AI + Apple Vision OCR) to rename and sort documents (invoices, contracts, screenshots, scans); it only renames/moves, never deletes, and every step is undoable.

- `brew style --fix Casks/f/filewise.rb` is clean (0 offenses).
- `brew audit --cask --online` was not run in this environment (no local Xcode/SDK gate check performed here), so left unchecked rather than falsely claimed.
- Install/uninstall in a clean environment was not performed in this pass, so left unchecked.
- `zap` trash paths (`~/Library/Application Support/Filewise`, `~/Library/Caches/fyi.jiang.guiwei`, `~/Library/Preferences/fyi.jiang.guiwei.plist`, `~/Library/Saved Application State/fyi.jiang.guiwei.savedState`) were verified to exist on a real install of the app by the developer/maintainer. Note: the `.app` bundle and `CFBundleName` are `Filewise`, but `CFBundleIdentifier`/`CFBundleExecutable` retain the earlier internal name `Guiwei`, which is why the cache/prefs/saved-state paths use `fyi.jiang.guiwei` while the app support folder uses `Filewise`.
- App is Developer ID signed and notarized; download URL and sha256 were verified via `brew fetch --cask` against the maintainer's own tap (depthsky2016/tap) prior to filing this PR.
