### PR TITLE
routeconverter 3.5

### DIFF
--- a/Casks/r/routeconverter.rb
+++ b/Casks/r/routeconverter.rb
@@ -1,18 +1,18 @@
 cask "routeconverter" do
   arch arm: "aarch64", intel: "x64"
 
-  version "3.4.1"
-  sha256 arm:   "968d1900456306fd5ba0d4adea74db6a0e52b01b975180272902603766ded45d",
-         intel: "e0089f0d0c68542b887e3871df1a55db47777866ff29b5305a9777af3b61b61a"
+  version "3.5"
+  sha256 arm:   "a11b491672d6524a86b5315ef6892b8d1a1573b16c23968be988ef0fd3c2f05c",
+         intel: "3b4b80099a2e1c97f25a00d43070fa066d00af4fd5898237625cf1ebfe929da8"
 
-  url "https://static.routeconverter.com/download/previous-releases/#{version}/RouteConverterMacOpenSource-#{arch}.app.zip"
+  url "https://releases.routeconverter.com/previous-releases/#{version}/RouteConverterMac-#{arch}.app.zip"
   name "RouteConverter"
   desc "GPS tool to display, edit, enrich and convert routes, tracks and waypoints"
   homepage "https://www.routeconverter.com/"
 
   livecheck do
-    url "https://static.routeconverter.com/download/previous-releases/"
-    regex(/href=.*?v?(\d+(?:\.\d+)+)/i)
+    url "https://releases.routeconverter.com/previous-releases/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
@@ -23,9 +23,4 @@ cask "routeconverter" do
   app "RouteConverter.app"
 
   zap trash: "~/.routeconverter"
-
-  # The aarch64 zip contains the same Intel app as the x64 zip for now.
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`routeconverter` is autobumped but the workflow failed to update to version 3.5 because the file name no longer contains "OpenSource". Besides that, the ARM app is built for ARM in this version, so we no longer need the Rosetta caveat. This updates the version and adjusts the cask accordingly. The static.routeconverter.com URLs are redirecting, so this also updates them to resolve the redirections.

Besides that, this updates the `livecheck` block regex to use the standard regex for matching version directories like `1.2.3/`, as the existing regex is looser and could potentially match a version from an unrelated directory if one ever appears in the future.