### PR TITLE
lumide 0.14.0 (new cask)

### DIFF
--- a/Casks/l/lumide.rb
+++ b/Casks/l/lumide.rb
@@ -5,7 +5,7 @@ cask "lumide" do
   url "https://github.com/SoFluffyOS/lumide/releases/download/#{version}/Lumide_macOS.dmg",
       verified: "github.com/SoFluffyOS/lumide/"
   name "Lumide"
-  desc "Agent-native code editor built with Flutter"
+  desc "Agent-native code editor"
   homepage "https://lumide.dev/"
 
   depends_on macos: :catalina

--- a/Casks/l/lumide.rb
+++ b/Casks/l/lumide.rb
@@ -1,0 +1,22 @@
+cask "lumide" do
+  version "0.14.0"
+  sha256 "e015981edc9bc2c5b674e1aca9360b8c18575b349cbb92c93dec9945109d41d7"
+
+  url "https://github.com/SoFluffyOS/lumide/releases/download/#{version}/Lumide_macOS.dmg",
+      verified: "github.com/SoFluffyOS/lumide/"
+  name "Lumide"
+  desc "Agent-native code editor built with Flutter"
+  homepage "https://lumide.dev/"
+
+  depends_on macos: :catalina
+
+  app "Lumide.app"
+
+  zap trash: [
+    "~/Library/Application Support/io.sofluffy.lumide",
+    "~/Library/Caches/io.sofluffy.lumide",
+    "~/Library/HTTPStorages/io.sofluffy.lumide",
+    "~/Library/Preferences/io.sofluffy.lumide.plist",
+    "~/Library/Saved Application State/io.sofluffy.lumide.savedState",
+  ]
+end


### PR DESCRIPTION
New cask for [Lumide](https://lumide.dev), a code editor built in Flutter & Dart for people who want an IDE to feel like a desktop tool: fast startup, low memory use, and no Electron layer. Distributed as a universal macOS DMG via the project's official [GitHub releases](https://github.com/soFluffyOS/lumide/releases). 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI assistance: cask authored with Claude Code (Claude Opus 4.8) — identifying release assets, bundle id `io.sofluffy.lumide`, and stanza structure. I personally reviewed the cask, ran install/uninstall, and verified the zap paths on macOS Tahoe.

-----