### PR TITLE
adrafinil 1.3.0 (new cask)

### DIFF
--- a/Casks/a/adrafinil.rb
+++ b/Casks/a/adrafinil.rb
@@ -1,0 +1,28 @@
+cask "adrafinil" do
+  version "1.3.0"
+  sha256 "0b466fce5ced1db6764afa3d05603ad22cba759d1b6f4ebdd48f1a7e249bb9d6"
+
+  url "https://github.com/kageroumado/adrafinil/releases/download/v#{version}/Adrafinil-#{version}.dmg",
+      verified: "github.com/kageroumado/adrafinil/"
+  name "Adrafinil"
+  desc "Keep your Mac awake while AI coding agents are working"
+  homepage "https://kagerou.glass/adrafinil/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :tahoe"
+
+  app "Adrafinil.app"
+
+  uninstall quit: "glass.kagerou.adrafinil"
+
+  zap trash: [
+    "~/Library/Caches/glass.kagerou.adrafinil",
+    "~/Library/Preferences/glass.kagerou.adrafinil.plist",
+    "~/Library/Saved Application State/glass.kagerou.adrafinil.savedState",
+  ]
+end

--- a/Casks/a/adrafinil.rb
+++ b/Casks/a/adrafinil.rb
@@ -8,11 +8,6 @@ cask "adrafinil" do
   desc "Keep your computer awake while AI coding agents are working"
   homepage "https://kagerou.glass/adrafinil/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
   depends_on macos: :tahoe
 

--- a/Casks/a/adrafinil.rb
+++ b/Casks/a/adrafinil.rb
@@ -5,7 +5,7 @@ cask "adrafinil" do
   url "https://github.com/kageroumado/adrafinil/releases/download/v#{version}/Adrafinil-#{version}.dmg",
       verified: "github.com/kageroumado/adrafinil/"
   name "Adrafinil"
-  desc "Keep your Mac awake while AI coding agents are working"
+  desc "Keep your computer awake while AI coding agents are working"
   homepage "https://kagerou.glass/adrafinil/"
 
   livecheck do
@@ -14,7 +14,7 @@ cask "adrafinil" do
   end
 
   auto_updates true
-  depends_on macos: ">= :tahoe"
+  depends_on macos: :tahoe
 
   app "Adrafinil.app"
 


### PR DESCRIPTION
[Adrafinil](https://kagerou.glass/adrafinil/) is a macOS menu bar utility that keeps your computer awake exclusively while AI coding agents (Claude Code, Cursor, Codex, Cline, etc.) are actively working. Unlike always-on caffeine-style utilities, it only blocks sleep during agent sessions and restores normal sleep behavior otherwise.

- **Source**: https://github.com/kageroumado/adrafinil (MIT, 341 stars)
- **Distribution**: Signed and notarized DMG from GitHub Releases
- **Requires**: macOS Tahoe (26+)

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+adrafinil&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code was used to draft the cask file. All checks (`brew audit --cask --online`, `brew audit --cask --new`, `brew style --fix`, `brew install --cask`, `brew uninstall --cask`) were run locally and verified by hand. The `zap` stanza paths were determined by inspecting the app's bundle identifier (`glass.kagerou.adrafinil`) from the DMG's `Info.plist` and listing standard macOS per-app directories (`~/Library/Caches/`, `~/Library/Preferences/`, `~/Library/Saved Application State/`).

-----
