### PR TITLE
writersproof 1.5.2 (new cask)

### DIFF
--- a/Casks/w/writersproof.rb
+++ b/Casks/w/writersproof.rb
@@ -1,0 +1,27 @@
+cask "writersproof" do
+  version "1.5.2"
+  sha256 "8815a762d6a221cb852d97c79b5b815db791ced9d88af3e0e54d0a79a61f0684"
+
+  url "https://updates.writerslogic.com/macos/WritersProof-#{version}.dmg"
+  name "WritersProof"
+  desc "Cryptographic authorship witnessing for writers and creators"
+  homepage "https://writersproof.com"
+
+  depends_on macos: ">= :sonoma"
+
+  app "WritersProof.app"
+
+  zap trash: [
+    "~/Library/Application Support/WritersProof",
+    "~/Library/Application Support/CPOP",
+    "~/.writersproof",
+    "~/Library/Caches/com.writerslogic.witnessd",
+    "~/Library/HTTPStorages/com.writerslogic.witnessd",
+    "~/Library/Preferences/com.writerslogic.witnessd.plist",
+    "~/Library/Saved Application State/com.writerslogic.witnessd.savedState",
+  ],
+  rmdir: [
+    "~/Library/Application Support/WritersProof",
+    "~/Library/Application Support/CPOP",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online writersproof` is error-free.
- [x] `brew style --fix writersproof` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new writersproof` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask writersproof` worked successfully.
- [x] `brew uninstall --cask writersproof` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Claude assisted with the initial cask structure. All checks were run locally on macOS:
- `brew style --fix writersproof` corrected 21 offenses (homepage trailing slash, `depends_on macos: :sonoma` syntax, array alphabetization, indentation alignment); zero offenses after.
- `brew audit --cask --new writersproof` passed clean after adding `verified: "updates.writerslogic.com/"` to the URL stanza and a `livecheck` block using `strategy :sparkle, &:short_version` against the Sparkle appcast.
- `brew audit --cask --online writersproof` passed clean.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask writersproof` installed successfully — app moved to `/Applications/WritersProof.app`.
- `brew uninstall --cask writersproof` removed `/Applications/WritersProof.app` and purged `/opt/homebrew/Caskroom/writersproof/1.5.2/`.
- `zap` paths verified: WritersProof 1.5.2 creates `~/Library/Application Support/WritersProof`, `~/Library/Caches/com.writerslogic.witnessd`, `~/Library/HTTPStorages/com.writerslogic.witnessd`, `~/Library/Preferences/com.writerslogic.witnessd.plist`, `~/Library/Saved Application State/com.writerslogic.witnessd.savedState`, and `~/.writersproof`. All listed in the `zap` stanza.

-----