### PR TITLE
snapzy 1.28.1

### DIFF
--- a/Casks/s/snapzy.rb
+++ b/Casks/s/snapzy.rb
@@ -1,6 +1,6 @@
 cask "snapzy" do
-  version "1.28.0"
-  sha256 "3732ea45f8d60337c088117876aa4d4d83aeee333713125f45f836f035196832"
+  version "1.28.1"
+  sha256 "3b1f8ebcbb0d3c9a7044421dd2884c3faa80c0d7159ad82b50802163b3e9c76c"
 
   url "https://github.com/duongductrong/Snapzy/releases/download/v#{version}/Snapzy-v#{version}.dmg",
       verified: "github.com/duongductrong/Snapzy/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online snapzy` is error-free.
- [x] `brew style --fix snapzy` reports no offenses.

### Description
Update `snapzy` cask to the latest stable release `v1.28.1`.

- Release page: https://github.com/duongductrong/Snapzy/releases/tag/v1.28.1
- App homepage: https://snapzy.app/

### Changes
- Bump `version` from `1.28.0` to `1.28.1`.
- Update `sha256` checksum to `3b1f8ebcbb0d3c9a7044421dd2884c3faa80c0d7159ad82b50802163b3e9c76c` matching the official `Snapzy-v1.28.1.dmg` release asset.

### AI Disclosure
- AI (Antigravity coding assistant) was used to assist in identifying the latest release, downloading the asset, computing the SHA-256 checksum, and editing the cask file. The version and checksum changes have been manually verified against the official repository release.
