### PR TITLE
mkvtoolnix-app 100.0-1

### DIFF
--- a/Casks/m/mkvtoolnix-app.rb
+++ b/Casks/m/mkvtoolnix-app.rb
@@ -12,12 +12,14 @@ cask "mkvtoolnix-app" do
 
   livecheck do
     url "https://mkvtoolnix.download/macos/releases/"
-    regex(%r{.*?/MKVToolNix[._-]v?(\d+(?:[.-]\d+)+)[._-]#{arch}\.dmg}i)
+    regex(/href=.*?MKVToolNix[._-]v?(\d+(?:[.-]\d+)+)[._-]#{arch}\.dmg/i)
     strategy :page_match do |page, regex|
-      major_version = page.scan(%r{href=".*?releases/(\d+(?:\.\d+)+)/}i)&.max&.first
-      next if major_version.blank?
+      main_version = page.scan(%r{href=.*?releases/v?(\d+(?:\.\d+)+)/}i)
+                         .max_by { |match| Version.new(match[0]) }
+                         &.first
+      next if main_version.blank?
 
-      version_directory = Homebrew::Livecheck::Strategy.page_content("https://mkvtoolnix.download/macos/releases/#{major_version}/")
+      version_directory = Homebrew::Livecheck::Strategy.page_content("https://mkvtoolnix.download/macos/releases/#{main_version}/")
       version_directory[:content]&.scan(regex)&.map { |match| match[0] }
     end
   end

--- a/Casks/m/mkvtoolnix-app.rb
+++ b/Casks/m/mkvtoolnix-app.rb
@@ -1,9 +1,9 @@
 cask "mkvtoolnix-app" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "99.0-1"
-  sha256 arm:   "8d3f3b5428fcdfcbbdc48f63a49d2919f64583889747a6197fcc6d582f4d9a4d",
-         intel: "eae9cd5fcd6d48723f6f6bbeed959f784dcaae1a7d48b10fae61b51c2a3f0140"
+  version "100.0-1"
+  sha256 arm:   "155ded045a35bd1079ba466c2e1011bdcb1a85b74c984ed5627841cd313850a0",
+         intel: "aea7ab9c7146943fd9535b2ea60c074deeea3181a9c6736e58e1437456906c0a"
 
   url "https://mkvtoolnix.download/macos/releases/#{version.split("-").first}/MKVToolNix-#{version}-#{arch}.dmg"
   name "MKVToolNix"


### PR DESCRIPTION
Bump deployed packages to the latest release, 100-0.1

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`brew audit --cask --online mkvtoolnix-app` is reporting:

```
$ brew audit --cask --online mkvtoolnix-app
==> Downloading and extracting artifacts
==> Downloading https://mkvtoolnix.download/macos/releases/100.0/MKVToolNix-100.0-1-arm64.dmg
########################################################################################################################### 100.0%
==> Downloading https://mkvtoolnix.download/macos/releases/100.0/MKVToolNix-100.0-1-arm64.dmg
Already downloaded: /Users/graham/Library/Caches/Homebrew/downloads/f2c45cdd10bd11d3a22e29e5665e990497e0bd1179dedad9578fa7963c2bf31a--MKVToolNix-100.0-1-arm64.dmg
audit for mkvtoolnix-app: failed
 - Version '100.0-1' differs from '99.0-1' retrieved by livecheck.
mkvtoolnix-app
  * Version '100.0-1' differs from '99.0-1' retrieved by livecheck.
Error: 1 problem in 1 cask detected.
```

Even though I've followed the same process as with previous bump-update PRs. Could this be because the major version string is now three characters, and the livecheck code is expecting two, or 100 < 99 in a string comparison? Clearly I'm clutching at straws...

IIRC @bevanjkay was kind enough to construct that livecheck for me (due to my lack of experience with Ruby) so they may be able to answer that question.

Thanks for your help!