### PR TITLE
vivaldi: use dmg instead of tarball

### DIFF
--- a/Casks/v/vivaldi.rb
+++ b/Casks/v/vivaldi.rb
@@ -1,8 +1,8 @@
 cask "vivaldi" do
   version "8.0.4033.57"
-  sha256 "76342f8dc4ad3f02301430a5423d343fa3c0e524227460114e38438a4bc935ab"
+  sha256 "a2d8c970bec75d9af787acceb4498ce2dc2a6f4bbb7f7e4ae39c94fed68a6a77"
 
-  url "https://downloads.vivaldi.com/stable-auto/Vivaldi.#{version}.universal.tar.xz"
+  url "https://downloads.vivaldi.com/stable-auto/Vivaldi.#{version}.universal.dmg"
   name "Vivaldi"
   desc "Web browser with built-in email client focusing on customization and control"
   homepage "https://vivaldi.com/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The asset URL for `vivaldi` is currently returning a 404 (Not Found) response, though the appcast still references the tarball that the cask uses. The upstream homepage has instead linked to a versioned dmg file for years, so this updates the cask `url` to use the dmg file. We can always switch back to a tarball in the future if there's any benefit to it but this will fix the broken URL for now.

Fixes #273488.