### PR TITLE
sabaki 0.60.0

### DIFF
--- a/Casks/s/sabaki.rb
+++ b/Casks/s/sabaki.rb
@@ -1,11 +1,11 @@
 cask "sabaki" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.52.2"
-  sha256 arm:   "e2cf00aa5ca0c2a675db847978466ba87ac2af9db33209ba7774be545b0f904c",
-         intel: "5e1a38772cc6926b1880341df128ae2f6172b29128cbb206782c84df6d7ec743"
+  version "0.60.0"
+  sha256 arm:   "b088788113a84748d75f63067efb99a98e95e0229dfb03d565295c70c524ed50",
+         intel: "c44b9f253351e84d91b40cfd51257d12fc6772980791fbdf42e253f7f17ca992"
 
-  url "https://github.com/SabakiHQ/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-#{arch}.7z",
+  url "https://github.com/SabakiHQ/Sabaki/releases/download/v#{version}/sabaki-v#{version}-mac-#{arch}.dmg",
       verified: "github.com/SabakiHQ/Sabaki/"
   name "Sabaki"
   desc "Go board and SGF editor"
@@ -16,9 +16,7 @@ cask "sabaki" do
     strategy :github_latest
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
-  depends_on :macos
+  depends_on macos: :monterey
 
   app "Sabaki.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`sabaki` is autobumped but the workflow failed to update to version 0.60.0 because upstream is using dmg files for this version instead of 7-Zip. This updates the version and adjusts the `url` accordingly. This also removes the `disable!` call, as this version of the app passes Gatekeeper checks.