### PR TITLE
electerm: update homepage, desc, and use mirror download URL

### DIFF
--- a/Casks/e/electerm.rb
+++ b/Casks/e/electerm.rb
@@ -5,14 +5,13 @@ cask "electerm" do
   sha256 arm:   "b26f85ec1f80c841e133516764dc4f26f20aab1024bdd20968385bebac4ff74c",
          intel: "6629b1cfef78b1516c221091434e0f05f666eabeda36a682fa3bba3d1d259a73"
 
-  url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac-#{arch}.dmg",
-      verified: "github.com/electerm/electerm/"
+  url "https://mirror.electerm.org/https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac-#{arch}.dmg"
   name "electerm"
-  desc "Terminal/ssh/sftp client"
-  homepage "https://electerm.html5beta.com/"
+  desc "Free and open-sourced terminal/ssh/sftp/telnet/serialport/RDP/VNC/Spice/ftp client (linux, mac, win)"
+  homepage "https://electerm.org"
 
   livecheck do
-    url "https://electerm.html5beta.com/data/electerm-github-release.json"
+    url "https://electerm.org/data/electerm-github-release.json"
     strategy :json do |json|
       json.dig("release", "tag_name")&.sub("v", "")
     end

--- a/Casks/e/electerm.rb
+++ b/Casks/e/electerm.rb
@@ -7,7 +7,7 @@ cask "electerm" do
 
   url "https://mirror.electerm.org/https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac-#{arch}.dmg"
   name "electerm"
-  desc "Free open-sourced terminal/ssh/sftp/telnet/serialport/RDP/VNC/Spice/ftp client"
+  desc "Terminal/ssh/sftp/telnet/serialport/RDP/VNC/Spice/ftp client"
   homepage "https://electerm.org/"
 
   livecheck do

--- a/Casks/e/electerm.rb
+++ b/Casks/e/electerm.rb
@@ -7,8 +7,8 @@ cask "electerm" do
 
   url "https://mirror.electerm.org/https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac-#{arch}.dmg"
   name "electerm"
-  desc "Free and open-sourced terminal/ssh/sftp/telnet/serialport/RDP/VNC/Spice/ftp client (linux, mac, win)"
-  homepage "https://electerm.org"
+  desc "Free open-sourced terminal/ssh/sftp/telnet/serialport/RDP/VNC/Spice/ftp client"
+  homepage "https://electerm.org/"
 
   livecheck do
     url "https://electerm.org/data/electerm-github-release.json"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. WorkBuddy AI assistant helped draft the cask changes and prepared the PR. Changes were manually verified:
  - `brew style --fix Casks/e/electerm.rb` passes with no offenses
  - Homepage URL verified accessible at https://electerm.org
  - Mirror download URLs verified resolvable (both x64 and arm64 variants)
  - SHA256 values unchanged (same binary, only download source changed)
  - Note: `brew audit --cask --online` could not be run due to Homebrew CLI changes (`brew audit [path]` is disabled); the audit check was not performed locally.

-----

## Changes

- **Homepage**: `https://electerm.html5beta.com/` → `https://electerm.org/`
- **Description**: Shortened to under 80 chars, platform mentions removed per Homebrew convention: `Free open-sourced terminal/ssh/sftp/telnet/serialport/RDP/VNC/Spice/ftp client`
- **Download URL**: Changed to use mirror at `https://mirror.electerm.org/` instead of GitHub direct downloads, removed `verified` parameter since the mirror is now the trust origin
- **Livecheck**: URL updated from electerm.html5beta.com to electerm.org

### Why

The project has migrated from electerm.html5beta.com to electerm.org as its official homepage. The mirror provides faster downloads and reduces load on GitHub releases.