### PR TITLE
fliqlo 1.9.5: fix checksum

### DIFF
--- a/Casks/f/fliqlo.rb
+++ b/Casks/f/fliqlo.rb
@@ -9,7 +9,7 @@ cask "fliqlo" do
   end
   on_sonoma :or_newer do
     version "1.9.5"
-    sha256 "1ddea8596ccc9aaf60d49dc4cd2293bfe9be694c8daf5c3918153c89906a755b"
+    sha256 "eac70be43c503997ff5176cfec5a2240d833f9748b5e7375f26ecfd222d03eeb"
 
     livecheck do
       url :homepage


### PR DESCRIPTION
`brew upgrade --cask fliqlo` fails with a SHA-256 mismatch.

Expected: 1ddea8596ccc9aaf60d49dc4cd2293bfe9be694c8daf5c3918153c89906a755b
Actual:   eac70be43c503997ff5176cfec5a2240d833f9748b5e7375f26ecfd222d03eeb

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

I used an AI assistant (Claude) to help me walk through the Homebrew CLI steps (git branch, commit, push, gh pr create) for fixing a checksum mismatch. The SHA256 change itself is the actual value reported by `brew upgrade --cask fliqlo` on my machine, which I verified matches the value in the error output. No zap stanza changes were made.

-----