### PR TITLE
wireless-workbench 7.8.2: update download URL

### DIFF
--- a/Casks/w/wireless-workbench.rb
+++ b/Casks/w/wireless-workbench.rb
@@ -1,15 +1,15 @@
 cask "wireless-workbench" do
-  version "7.8.1,56"
-  sha256 "d543614acf0b8a9293dae4859f8ccd73f7eace9e92c8d34ba7ab1ab6353959fe"
+  version "7.8.2,63"
+  sha256 "2ebbbe27ad8f3abdcf542f8f68bacaa707fcb49fa9fa9a98fcff78406b7d37a3"
 
-  url "https://content-files.shure.com/Software/wireless-workbench/#{version.csv.first.dots_to_hyphens}/Wireless-Workbench-macOS-#{version.csv.first}#{".#{version.csv.second}" if version.csv.second}.pkg"
+  url "https://content-files.shure.com/Software/wireless-workbench/#{version.csv.first.dots_to_hyphens}/ShureWWB_x64-mac.#{version.csv.first}#{".#{version.csv.second}" if version.csv.second}.pkg"
   name "Wireless Workbench"
   desc "Desktop app for RF coordination and wireless system management"
   homepage "https://www.shure.com/en-US/products/software/wwb?variant=WWB"
 
   livecheck do
     url "https://www.shure.com/en-US/sw/wwb-mac"
-    regex(/Wireless[._-]Workbench(?:[._-]macOS)?[._-]v?(\d+(?:\.\d+){1,2})((?:\.\d+)*)?\.pkg/)
+    regex(/ShureWWB(?:_x64)?-mac\.(\d+(?:\.\d+){1,2})((?:\.\d+)*)?\.pkg/)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)
       next unless match
@@ -20,7 +20,7 @@ cask "wireless-workbench" do
 
   depends_on macos: :ventura
 
-  pkg "Wireless-Workbench-macOS-#{version.csv.first}#{".#{version.csv.second}" if version.csv.second}.pkg"
+  pkg "ShureWWB_x64-mac.#{version.csv.first}#{".#{version.csv.second}" if version.csv.second}.pkg"
 
   uninstall pkgutil: "com.shure.WWB"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
A look at `curl -IL https://www.shure.com/en-US/sw/wwb-mac` revealed:
The download URL changed from:
`https://content-files.shure.com/Software/wireless-workbench/7-8-2/Wireless-Workbench-macOS-7.8.2.63.pkg
`
to:
`https://content-files.shure.com/Software/wireless-workbench/7-8-2/ShureWWB_x64-mac.7.8.2.63.pkg`

This PR updates the download URL and installed package filename to match the new upstream installer name, and fixes the livecheck regex so autobump can continue detecting new releases.