### PR TITLE
prevail 0.2.167 (new cask)

### DIFF
--- a/Casks/p/prevail.rb
+++ b/Casks/p/prevail.rb
@@ -1,0 +1,29 @@
+cask "prevail" do
+  version "0.2.167"
+  sha256 "0e1090ae3a45e3950ea1b4a7aeab3f848604b03558ca6f11481dde0a26e23890"
+
+  url "https://github.com/fru-dev3/prevail-desktop/releases/download/v#{version}/Prevail_#{version}_aarch64.dmg",
+      verified: "github.com/fru-dev3/prevail-desktop/"
+  name "Prevail"
+  desc "Local-first AI life OS over a plain-markdown vault"
+  homepage "https://prevail.sh/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :ventura
+
+  app "Prevail.app"
+
+  zap trash: [
+    "~/Library/Application Support/sh.prevail.desktop",
+    "~/Library/Caches/sh.prevail.desktop",
+    "~/Library/Preferences/sh.prevail.desktop.plist",
+    "~/Library/Saved Application State/sh.prevail.desktop.savedState",
+    "~/Library/WebKit/sh.prevail.desktop",
+  ]
+end


### PR DESCRIPTION
Important: Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process.

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free (one exception, see note below).
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, for new casks:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not already refused (no matches in issues/PRs for `prevail`).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks).

Note on the audit: `brew audit --cask --online --new` passes except for the notability check (the repo is at 15 stars). Prevail launched publicly this week: it is an open-source (GPL-3.0), signed and notarized, local-first AI desktop app for macOS (Tauri 2), with an active release cadence (v0.2.167). Submitting in case an exception is acceptable; happy to close and resubmit once the repo crosses the notability bar if not.

Homepage: https://prevail.sh
Repo: https://github.com/fru-dev3/prevail-desktop