### PR TITLE
Add hermes-setup cask

### DIFF
--- a/Casks/h/hermes-setup.rb
+++ b/Casks/h/hermes-setup.rb
@@ -1,0 +1,26 @@
+cask "hermes-setup" do
+  version "2026.7.1"
+  sha256 :no_check
+
+  url "https://hermes-assets.nousresearch.com/Hermes-Setup.dmg"
+  name "Hermes"
+  desc "Self-improving AI agent desktop installer from Nous Research"
+  homepage "https://hermes-agent.nousresearch.com/"
+
+  livecheck do
+    url "https://github.com/NousResearch/hermes-agent/releases/latest"
+    strategy :github_latest
+  end
+
+  conflicts_with cask: "hermes"
+  depends_on arch: :arm64
+  depends_on macos: :big_sur
+
+  app "Hermes.app"
+
+  zap trash: [
+    "~/.hermes",
+    "~/Library/Preferences/com.nousresearch.hermes.setup.plist",
+    "~/Library/Saved Application State/com.nousresearch.hermes.setup.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary

Add `hermes-setup`, the official macOS bootstrap installer for [Hermes Agent](https://hermes-agent.nousresearch.com/) from Nous Research.

- Downloads the signed DMG from `hermes-assets.nousresearch.com` (same org domain as homepage).
- Installs `Hermes.app`, which provisions dependencies and the full desktop agent on first launch.
- Declares `conflicts_with cask: "hermes"` (deprecated Pandora player that also used `Hermes.app`).
- Restricts to Apple Silicon (`depends_on arch: :arm64`) matching the current public DMG.

The CLI is already available as the `hermes-agent` formula in homebrew-core; this cask covers the desktop installer path documented at https://hermes-agent.nousresearch.com/docs/getting-started/installation.

**Token note:** New casks cannot end in `-desktop` per strict audit rules; `hermes-setup` matches the distributed bootstrap binary (`Hermes-Setup`).

## Test plan

- [x] `brew audit --new --strict --online hermes-setup`
- [x] `brew style Casks/h/hermes-setup.rb`
- [x] `brew livecheck hermes-setup`
- [ ] `brew install --cask hermes-setup` (after tap/merge)
- [ ] Confirm `/Applications/Hermes.app` launches the bootstrap UI
- [ ] `brew uninstall --cask hermes-setup`
