### PR TITLE
itermcompanion 1.0 (new cask)

### DIFF
--- a/Casks/i/itermcompanion.rb
+++ b/Casks/i/itermcompanion.rb
@@ -1,0 +1,20 @@
+cask "itermcompanion" do
+  version "1.0"
+  sha256 "2a6cea5e99a75d53ae673476ea5042ced6e4b2cad3ccbdbf5e54c89065f6e748"
+
+  url "https://iterm2.com/downloads/companion-plugin/iTermCompanion-#{version}.zip"
+  name "iTerm2 Companion Plugin"
+  desc "Pairs iTerm2 with the iTerm2 Companion iPhone app"
+  homepage "https://iterm2.com/companion-plugin.html"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/iTermCompanion[._-](\d+(?:\.\d+)*)\.zip}i)
+  end
+
+  depends_on macos: :catalina
+
+  app "iTermCompanion.app"
+
+  zap trash: "~/Library/Containers/com.googlecode.iterm2.iTermCompanion"
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.6.

Official first-party companion plugin from the iTerm2 developer; sibling to the existing `itermai` and `itermbrowserplugin` casks.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI (Claude Code) drafted the cask by following the existing `itermai`/`itermbrowserplugin` patterns. I manually verified: the download URL and version from the official site, the `sha256` and the `iTermCompanion.app` bundle name from the downloaded artifact, and the `depends_on macos: :catalina` minimum from the app's `LSMinimumSystemVersion`. The `zap` path was verified against a real install on my Mac — the app is sandboxed and its only footprint outside `/Applications` is `~/Library/Containers/com.googlecode.iterm2.iTermCompanion` (no `sfl`/prefs/caches outside the container). Install/uninstall were tested locally.
