### PR TITLE
otty 1.2.3 (new cask)

### DIFF
--- a/Casks/o/otty.rb
+++ b/Casks/o/otty.rb
@@ -12,7 +12,6 @@ cask "otty" do
   homepage "https://otty.sh/"
 
   livecheck do
-    url "https://docs.otty.sh/changelog"
     url "https://otty.sh/releases/macos-#{livecheck_arch}.json"
     strategy :json do |json|
       json["version"]

--- a/Casks/o/otty.rb
+++ b/Casks/o/otty.rb
@@ -1,0 +1,38 @@
+cask "otty" do
+  arch arm: "arm64", intel: "x86_64"
+  livecheck_arch = on_arch_conditional arm: "arm", intel: "intel"
+
+  version "1.2.3"
+  sha256 arm:   "7d94053cf0aaf5ee8a5a1b2591659f87fddc27381e311b0a027183e77d8e6345",
+         intel: "c7bbf448de4cdda000feccec581302bc7e899219a5ecadb004aac1ca4e889347"
+
+  url "https://downloads.otty.sh/macos/Otty-#{version}-#{arch}.zip"
+  name "Otty"
+  desc "Terminal emulator built for code agents"
+  homepage "https://otty.sh/"
+
+  livecheck do
+    url "https://docs.otty.sh/changelog"
+    url "https://otty.sh/releases/macos-#{livecheck_arch}.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  depends_on macos: :sonoma
+
+  app "Otty.app"
+  binary "#{appdir}/Otty.app/Contents/MacOS/otty-cli", target: "otty"
+
+  generate_completions_from_executable "#{HOMEBREW_PREFIX}/bin/otty", "completions",
+                                       shells: [:bash, :zsh, :fish]
+
+  zap trash: [
+    "~/.config/otty",
+    "~/Library/Application Support/io.appmakes.otty",
+    "~/Library/Caches/io.appmakes.otty",
+    "~/Library/HTTPStorages/io.appmakes.otty",
+    "~/Library/Preferences/io.appmakes.otty.plist",
+    "~/Library/WebKit/io.appmakes.otty",
+  ]
+end


### PR DESCRIPTION
Replaces https://github.com/Homebrew/homebrew-cask/pull/273544, which was accidentally closed when the head fork was deleted.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
