### PR TITLE
dbx: add livecheck

### DIFF
--- a/Casks/d/dbx.rb
+++ b/Casks/d/dbx.rb
@@ -20,6 +20,11 @@ cask "dbx" do
   desc "Database management tool"
   homepage "https://dbxio.com/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   on_macos do
     auto_updates true
     depends_on macos: :big_sur


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

By default, livecheck checks the Git tags for `dbx` and returns 0.5.49 as newest but this version is marked as "pre-release" on GitHub. This adds a `livecheck` block that uses the `GithubLatest` strategy, which correctly returns 0.5.48 as latest.

Upstream also creates releases for tags like `agents-v0.2.47` and `agents-latest` but hopefully they don't mark those releases as "latest". If this becomes an issue in the future, we will have to use the `GithubReleases` strategy to check multiple releases and identify releases that use a tag format like `v1.2.3` and aren't marked as pre-release.