### PR TITLE
Add Peeku cask

### DIFF
--- a/Casks/p/peeku.rb
+++ b/Casks/p/peeku.rb
@@ -1,0 +1,32 @@
+cask "peeku" do
+  version "1.7"
+  sha256 "fab7e88214255885a0ae7ca62017d31219b843044e39dd3bb75a9b60495403c6"
+
+  url "https://peeku.app/downloads/Peeku-#{version}.dmg"
+  name "Peeku"
+  desc "Private walk-away lock and desk break coach"
+  homepage "https://peeku.app/"
+
+  livecheck do
+    url "https://peeku.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "Peeku.app"
+
+  uninstall quit: "app.peeku.Peeku"
+
+  zap trash: [
+    "~/.config/proximity-lock",
+    "~/Library/Group Containers/AVGA7YK5X2.app.peeku.Peeku",
+    "~/Library/HTTPStorages/app.peeku.Peeku",
+    "~/Library/Logs/peeku-health.log",
+    "~/Library/Logs/peeku-lock-events.log",
+    "~/Library/Preferences/app.peeku.Peeku.plist",
+    "~/Library/Saved Application State/app.peeku.Peeku.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance: Codex prepared the cask file and PR body. Manual/current-state verification performed before opening the PR:

- Downloaded `https://peeku.app/downloads/Peeku-1.7.dmg` and verified SHA-256 `fab7e88214255885a0ae7ca62017d31219b843044e39dd3bb75a9b60495403c6`.
- Mounted the DMG and confirmed it contains `Peeku.app`.
- Read `Peeku.app/Contents/Info.plist` to confirm `CFBundleIdentifier` `app.peeku.Peeku`, `CFBundleShortVersionString` `1.7`, `CFBundleVersion` `107`, `LSMinimumSystemVersion` `14.0`, `LSUIElement` true, and Sparkle feed URL `https://peeku.app/appcast.xml`.
- Confirmed `https://peeku.app/appcast.xml` is a Sparkle feed with short version `1.7`, build `107`, minimum macOS `14.0`, and hardware requirement `arm64`.
- Checked local Ruby syntax with `ruby -c Casks/p/peeku.rb`.
- Checked there were no existing `peeku` entries in `Homebrew/homebrew-cask` and no existing/closed PRs for Peeku.
- Derived zap paths from the app bundle ID, app-group identifier, source references to `~/.config/proximity-lock`, and documented Peeku log files (`~/Library/Logs/peeku-health.log`, `~/Library/Logs/peeku-lock-events.log`).

I could not run the local `brew audit`, `brew style`, install, or uninstall checks because this machine does not have Homebrew installed. I opened this as a draft so CI and maintainers can report required style or install fixes.

-----
