### PR TITLE
Fixed wrong LTSpice Download URL & disable livecheck (since not working) & added minimum mac os version (delivered by `brew audit --cask --online <cask>`)

### DIFF
--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -21,7 +21,7 @@ cask "ltspice" do
         "~/Documents/LTspice/examples",
         "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.analog.ltspice.app.sfl*",
         "~/Library/Application Support/LTspice",
-        "~/Library/Preferences/com.analog.LTspice.App.plist",
+        "~/Library/Preferences/com.analog.ltspice.plist",
         "~/Library/Saved Application State/com.analog.LTspice.App.savedState",
       ],
       rmdir: "~/Documents/LTspice"

--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -13,7 +13,7 @@ cask "ltspice" do
 
   depends_on macos: :sonoma
 
-  pkg "LTspice_26.pkg"
+  pkg "LTspice_#{version.major}.pkg"
 
   uninstall pkgutil: "com.analog.ltspice"
 

--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -2,7 +2,7 @@ cask "ltspice" do
   version "26.0.2"
   sha256 :no_check
 
-  url "https://ltspice.analog.com/software/LTspice_26.pkg"
+  url "https://ltspice.analog.com/software/LTspice_#{version.major}.pkg"
   name "LTspice"
   desc "SPICE simulation software, schematic capture and waveform viewer"
   homepage "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html"

--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -2,7 +2,7 @@ cask "ltspice" do
   version "26.0.2"
   sha256 :no_check
 
-  url "https://ltspice.analog.com/software/LTspice.pkg"
+  url "https://ltspice.analog.com/software/LTspice_26.pkg"
   name "LTspice"
   desc "SPICE simulation software, schematic capture and waveform viewer"
   homepage "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html"
@@ -14,7 +14,7 @@ cask "ltspice" do
 
   depends_on :macos
 
-  pkg "LTspice.pkg"
+  pkg "LTspice_26.pkg"
 
   uninstall pkgutil: [
     "com.analog.LTspice",

--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -18,6 +18,7 @@ cask "ltspice" do
   uninstall pkgutil: [
     "com.analog.LTspice",
     "com.analog.LTspice.App",
+    "com.analog.ltspice",
   ]
 
   zap trash: [

--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -15,11 +15,7 @@ cask "ltspice" do
 
   pkg "LTspice_26.pkg"
 
-  uninstall pkgutil: [
-    "com.analog.LTspice",
-    "com.analog.LTspice.App",
-    "com.analog.ltspice",
-  ]
+  uninstall pkgutil: "com.analog.ltspice"
 
   zap trash: [
         "~/Documents/LTspice/examples",

--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -8,11 +8,10 @@ cask "ltspice" do
   homepage "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html"
 
   livecheck do
-    url :homepage, user_agent: :browser
-    regex(/for\s+MacOS.*?Version\s+v?(\d+(?:\.\d+)+)/im)
+    skip "Blocked by upstream bot protection"
   end
 
-  depends_on :macos
+  depends_on macos: :sonoma
 
   pkg "LTspice_26.pkg"
 


### PR DESCRIPTION
https://ltspice.analog.com/software/LTspice.pkg only pulls the legacy version (17.2.4) [End of Support], this may be intentional, but then it doesn't match cask version 26.0.2.

https://ltspice.analog.com/software/LTspice_26.pkg pulls the current 26.x version, currently 26.0.2.

Issue: this URL always pulls the latest 26.x image, so the pinned cask version tag may become stale between a new upstream package release and the corresponding cask update.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
