### PR TITLE
zen: add os stanza to fix Linux install

### DIFF
--- a/Casks/z/zen.rb
+++ b/Casks/z/zen.rb
@@ -1,5 +1,6 @@
 cask "zen" do
   arch arm: "aarch64", intel: "x86_64"
+  os macos: "macos", linux: "linux"
 
   version "1.21.5b"
 


### PR DESCRIPTION
The cask API JSON is generated on macOS, so the on_linux block (with the Linux sha256) never runs. Without a top-level `os` stanza, to_hash_with_ variations skips all Linux variations, the published JSON has empty `variations`, and Linux falls back to the macOS app artifact -> "This cask requires macOS". Adding `os` makes dsl!.os non-nil so the Linux AppImage variations are generated.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
