### PR TITLE
unity-hub: use versioned download URL and pin checksums

### DIFF
--- a/Casks/u/unity-hub.rb
+++ b/Casks/u/unity-hub.rb
@@ -2,9 +2,10 @@ cask "unity-hub" do
   arch arm: "arm64", intel: "x64"
 
   version "3.19.4"
-  sha256 :no_check
+  sha256 arm:   "8314a09f37a8ca1ac089c1561df20797c7dc871074a82d7cef69dbed4b42e59d",
+         intel: "d1ea4d52888813c66a3477f1378b5239aa60e854c0730ff26bfba0df424fa630"
 
-  url "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-#{arch}.dmg"
+  url "https://public-cdn.cloud.unity3d.com/hub/prod/#{version}/UnityHubSetup-#{version}-#{arch}.dmg"
   name "Unity Hub"
   desc "Management tool for Unity"
   homepage "https://unity3d.com/get-unity/download"


### PR DESCRIPTION
Updated the Unity Hub cask to use immutable/versioned download links. This fixes the current setup where Homebrew points at the latest download and the SHA256 has to be ignored to avoid mismtatches whenever binaries are updated.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.
  - AI was used to download and calculate the sha256s for the dmgs

-----
