### PR TITLE
dnclient-server 0.9.5,764f2278 (new cask)

### DIFF
--- a/Casks/d/dnclient-server.rb
+++ b/Casks/d/dnclient-server.rb
@@ -11,9 +11,9 @@ cask "dnclient-server" do
     url "https://api.defined.net/v1/downloads"
     regex(%r{/(\h+)/v?(\d+(?:\.\d+)+)/macos/DNClient-Server\.dmg}i)
     strategy :json do |json, regex|
-      json.dig("data", "dnclient")&.map do |_, release|
+      json.dig("data", "dnclient")&.filter_map do |_, release|
         match = release["macos-universal-server-dmg"]&.match(regex)
-        next if match.blank?
+        next unless match
 
         "#{match[2]},#{match[1]}"
       end

--- a/Casks/d/dnclient-server.rb
+++ b/Casks/d/dnclient-server.rb
@@ -28,15 +28,4 @@ cask "dnclient-server" do
     "/etc/defined",
     "/Library/LaunchDaemons/dnclient.plist",
   ]
-
-  caveats <<~EOS
-    To run dnclient as a system service and enroll this host:
-      sudo dnclient install
-      sudo dnclient start
-      sudo dnclient enroll -code <enrollment-code>
-
-    Before uninstalling this cask, remove the service:
-      sudo dnclient stop
-      sudo dnclient uninstall
-  EOS
 end

--- a/Casks/d/dnclient-server.rb
+++ b/Casks/d/dnclient-server.rb
@@ -1,0 +1,42 @@
+cask "dnclient-server" do
+  version "0.9.5,764f2278"
+  sha256 "fd7df9b98105c83fd1b7fe1c4d5a980b7127fe8f74c972b2b75d7c8dc8597692"
+
+  url "https://dl.defined.net/#{version.csv.second}/v#{version.csv.first}/macos/DNClient-Server.dmg"
+  name "DNClient Server"
+  desc "Peer-to-peer VPN client daemon for managed nebula networks"
+  homepage "https://www.defined.net/"
+
+  livecheck do
+    url "https://api.defined.net/v1/downloads"
+    regex(%r{/(\h+)/v?(\d+(?:\.\d+)+)/macos/DNClient-Server\.dmg}i)
+    strategy :json do |json, regex|
+      json.dig("data", "dnclient")&.map do |_, release|
+        match = release["macos-universal-server-dmg"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
+    end
+  end
+
+  depends_on macos: :ventura
+
+  binary "dnclient"
+
+  zap trash: [
+    "/etc/defined",
+    "/Library/LaunchDaemons/dnclient.plist",
+  ]
+
+  caveats <<~EOS
+    To run dnclient as a system service and enroll this host:
+      sudo dnclient install
+      sudo dnclient start
+      sudo dnclient enroll -code <enrollment-code>
+
+    Before uninstalling this cask, remove the service:
+      sudo dnclient stop
+      sudo dnclient uninstall
+  EOS
+end


### PR DESCRIPTION
Adds `dnclient-server` — the CLI daemon variant of DNClient, the client for Defined Networking's managed [nebula](https://github.com/slackhq/nebula) VPN networks. The existing `dnclient` cask ships the Desktop GUI app; this cask ships the standalone server/headless binary from the vendor's codesigned + notarized `DNClient-Server.dmg`. Closed-source prebuilt binary, so homebrew-core is not an option. I work for Defined Networking (the vendor).

Resubmission of #269225, which was closed while still WIP — reopening was blocked by GitHub, so this recreates it from the same branch per maintainer guidance. It is no longer WIP: the previously-linked companion rename (#269224) has been dropped on our side, so this cask stands alone and `dnclient` keeps its name.

Downloads are served from the vendor's official download site, [dl.defined.net](https://dl.defined.net) — it has a browsable index, so the DMG this cask fetches can be verified against the vendor's published artifacts directly. `livecheck` follows the same `api.defined.net/v1/downloads` JSON strategy as the existing `dnclient` cask, keyed on the `macos-universal-server-dmg` artifact. Verified locally: `brew livecheck` resolves `0.9.5,764f2278` (still the latest vendor release as of this resubmission), and `sudo dnclient install` writes its LaunchDaemon plist pointing at the stable `$(brew --prefix)/bin/dnclient` symlink, so upgrades don't orphan the service.

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field). The only prior closed PR for this token is #269225 — our own earlier WIP submission of this same cask, closed by us, not refused.
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

- [x] AI was used to generate or assist with generating this PR. _Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths_.

AI (Claude) drafted the cask file, the `livecheck` JSON strategy, and this PR body. Manual verification: `brew style` and `brew audit --cask --online --new dnclient-server` re-run clean on 2026-07-08 against the current template's exact invocations; `brew install --cask` / `brew uninstall --cask` performed locally on 2026-06-11 with this exact version and artifact; `brew livecheck` resolves `0.9.5,764f2278`, cross-checked against the vendor downloads API. The `zap` paths (`/etc/defined`, `/Library/LaunchDaemons/dnclient.plist`) were verified against a real `sudo dnclient install` daemon deployment on macOS — those are the paths the daemon actually creates outside the cask's own artifacts.

---
