### PR TITLE
amazon-workspaces: remove stale requires_rosetta caveat

### DIFF
--- a/Casks/a/amazon-workspaces.rb
+++ b/Casks/a/amazon-workspaces.rb
@@ -27,8 +27,4 @@ cask "amazon-workspaces" do
     "~/Library/Preferences/com.amazon.workspaces.plist",
     "~/Library/Saved Application State/com.amazon.workspaces.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
----- After making any changes to a cask, existing or new, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:
- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask\'s name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
-----
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with extracting the .pkg Payload and running `lipo -archs` on the binaries to verify architecture. The change (removing 3 lines) was manually verified. No changes to zap stanza paths.

**Verification:**
The WorkSpaces 5.33.0.6168 .pkg installs a universal (x86_64 + arm64) main binary. WorkSpacesClientUpdater is arm64-only. Rosetta is not required on Apple Silicon.

```
$ lipo -archs Contents/MacOS/WorkSpaces
x86_64 arm64
$ lipo -archs Contents/MacOS/WorkSpacesClientUpdater
arm64
```
-----