### PR TITLE
amazon-workspaces: remove stale requires_rosetta caveat

### DIFF
--- a/Casks/a/amazon-workspaces.rb
+++ b/Casks/a/amazon-workspaces.rb
@@ -27,8 +27,4 @@ cask "amazon-workspaces" do
     "~/Library/Preferences/com.amazon.workspaces.plist",
     "~/Library/Saved Application State/com.amazon.workspaces.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
----- After making any changes to a cask, existing or new, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online amazon-workspaces` is error-free.
- [x] `brew style --fix amazon-workspaces` reports no offenses.

Additionally, if adding a new cask:
- N/A (existing cask modification)

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with extracting the .pkg payload and running `lipo -archs` to verify the binary architecture. The 3-line deletion was manually verified. No changes to zap stanza.

**Context:**
The WorkSpaces 5.33.0.6168 .pkg installs a universal (x86_64 + arm64) main binary. WorkSpacesClientUpdater is arm64-only. Rosetta is not required.

```
$ lipo -archs Contents/MacOS/WorkSpaces
x86_64 arm64
$ lipo -archs Contents/MacOS/WorkSpacesClientUpdater
arm64
```
-----