### PR TITLE
Add Keyholdr 1.5.0

### DIFF
--- a/Casks/k/keyholdr.rb
+++ b/Casks/k/keyholdr.rb
@@ -1,0 +1,34 @@
+cask "keyholdr" do
+  version "1.5.0"
+  sha256 "6d740811551a0d0878a9ba2854700f143fd7d0b347b972d360f30eccf7ff7fe0"
+
+  url "https://github.com/OlixIgnacious/keyholdr/releases/download/v#{version}/Keyholdr-macOS-v#{version}.zip",
+      verified: "github.com/OlixIgnacious/keyholdr/"
+  name "Keyholdr"
+  desc "Menu bar vault for API keys with Touch ID unlock"
+  homepage "https://olixignacious.github.io/keyholdr-site/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+  depends_on arch: :arm64
+
+  app "Keyholdr.app"
+  binary "#{appdir}/Keyholdr.app/Contents/MacOS/keyholdr-cli", target: "keyholdr"
+
+  zap trash: "~/Library/Application Support/com.olixstudios.Keyholdr"
+
+  caveats <<~EOS
+    The `keyholdr` CLI is linked onto your PATH.
+
+    The first read of each key shows a one-time macOS Keychain consent —
+    choose "Always Allow".
+
+    Secrets live in the macOS Keychain and survive uninstalls by design;
+    `brew uninstall --zap keyholdr` removes the metadata file but not the
+    Keychain entries.
+  EOS
+end


### PR DESCRIPTION
-----

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online keyholdr` is error-free.
- [x] `brew style --fix keyholdr` reports no offenses.

Additionally, for this new cask:

- [x] Named the cask according to the token reference (`keyholdr`).
- [x] Checked the cask was not already refused.
- [ ] `brew audit --cask --new keyholdr` worked successfully — **note: fails the notability check** (10 stars currently; threshold is 75 stars / 30 forks / 30 watchers). The project is newly open-sourced and actively growing — happy to update this PR once the threshold is met.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask olixignacious/tap/keyholdr` worked successfully.
- [x] `brew uninstall --cask olixignacious/tap/keyholdr` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Claude (claude.ai) was used to generate the initial cask file. The cask was manually verified by running `brew audit`, `brew style`, install, and uninstall locally. SHA-256 was verified against the downloaded release zip. The app is signed and notarized with Developer ID Application.

-----