### PR TITLE
agentsview: enable auto_updates

### DIFF
--- a/Casks/a/agentsview.rb
+++ b/Casks/a/agentsview.rb
@@ -41,6 +41,8 @@ cask "agentsview" do
     end
   end
 
+  auto_updates true
+
   on_macos do
     app "AgentsView.app"
     binary "#{appdir}/AgentsView.app/Contents/MacOS/agentsview"


### PR DESCRIPTION
Adds `auto_updates true` to the `agentsview` cask.

AgentsView ships its own self-updater. It has already bumped the installed
app from 0.36.1 to 0.37.1 outside of Homebrew's knowledge, and the cask's
history shows a bump PR opened for nearly every release (0.34.0 through
0.37.2, ~13 PRs). Without `auto_updates`, `brew outdated --cask` keeps
reporting the cask as outdated by comparing the recorded Caskroom version
against the cask's pinned version, with no awareness that the app already
self-updated.

----- After making any changes to a cask, existing or new, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:
- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
-----
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) added the `auto_updates true` stanza and located its
required position via Homebrew's own `StanzaOrder` rubocop rule (must
follow `livecheck`, precede `depends_on`/`container`). I manually reviewed
the diff and ran `brew audit --cask --online agentsview` and
`brew style --fix agentsview` locally against a full tap checkout; audit is
clean aside from one pre-existing, unrelated finding (cask version `0.37.1`
vs. `0.37.2` from livecheck) already tracked by open PR #273997 and
untouched by this diff. No `zap` stanza was touched.

