### PR TITLE
audirvana-origin 2.6.6 (new cask)

### DIFF
--- a/Casks/a/audirvana-origin.rb
+++ b/Casks/a/audirvana-origin.rb
@@ -1,0 +1,34 @@
+cask "audirvana-origin" do
+  version "2.6.6"
+  sha256 "ee7993112e037364bb11a0fa0ac9908d9119cdd5827a29df2d65daf482838d6e"
+
+  url "https://audirvana.com/delivery/origin/mac/AudirvanaOrigin_#{version}.dmg"
+  name "Audirvana Origin"
+  desc "Audio playback software"
+  homepage "https://audirvana.com/"
+
+  livecheck do
+    url "https://audirvana.com/delivery/origin/mac/audirvana_origin_appcast.xml"
+    strategy :sparkle do |items|
+      items.filter_map do |item|
+        next unless item.channel.nil?
+
+        item.short_version
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :catalina
+
+  app "Audirvana Origin.app"
+
+  uninstall quit: "com.audirvana.Audirvana-Origin"
+
+  zap trash: [
+    "~/Library/Caches/com.audirvana.Audirvana-Origin",
+    "~/Library/HTTPStorages/com.audirvana.Audirvana-Origin",
+    "~/Library/Preferences/com.audirvana.Audirvana-Origin.plist",
+    "~/Library/Saved Application State/com.audirvana.Audirvana-Origin.savedState",
+  ]
+end


### PR DESCRIPTION
Adds Audirvana Origin as a separate cask from the existing Audirvana classic cask.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to draft the cask and run local verification commands. I manually verified the official download URL and appcast, checked that this is a separate product from the existing Audirvana cask, installed and uninstalled the cask locally, and reviewed the `zap` paths against the app bundle identifier.

-----
