### PR TITLE
appzapper 2.0.4

### DIFF
--- a/Casks/a/appzapper.rb
+++ b/Casks/a/appzapper.rb
@@ -1,22 +1,28 @@
 cask "appzapper" do
-  version "2.0.3"
-  sha256 "bb541a89fd513c4fa95eeefe46ebac6b985ac6498a46da4e4622089a15ef6bcd"
+  version "2.0.4"
+  sha256 "a03299821d55a83bd3072cb6e13f2badb9108d0ea5ef017004c0f6b762ceb80b"
 
   url "https://appzapper.com/downloads/appzapper#{version.no_dots}.zip"
   name "AppZapper"
   desc "Tool to uninstall unwanted applications and their support files"
-  homepage "https://www.appzapper.com/"
+  homepage "https://appzapper.com/"
 
+  # The upstream website doesn't provide any version information, so we have to
+  # naively add dots to the dotless version in the file name.
   livecheck do
-    url :homepage
-    regex(/href=.*?appzapper(\d+)(\d+)(\d+)\.zip/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}.#{match[1]}.#{match[2]}" }
+    url "https://appzapper.com/downloads/latest.zip"
+    regex(/appzapper[._-]?v?(\d+(?:\.\d+)*)\.zip/i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next unless match
+
+      ver = match[1]
+      ver.include?(".") ? ver : ver.chars.join(".")
     end
   end
 
   auto_updates true
-  depends_on :macos
+  depends_on macos: :big_sur
 
   app "AppZapper.app"
 
@@ -24,8 +30,4 @@ cask "appzapper" do
     "~/Library/Application Support/AppZapper",
     "~/Library/Preferences/com.appzapper.appzapper2.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`appzapper` is autobumped but the workflow failed to update to version 2.0.4 because the download link on the upstream website is an unversioned URL that redirects to the versioned zip file, so the `livecheck` block returns an "Unable to get versions" error. This updates the version and modifies the `livecheck` block to check the `Location` header from the redirecting link. We still have to naively add dots to the dotless version (and hope that upstream never uses a version part with more than one digit) but I've reworked the regex and `strategy` block logic to be able to also handle a version with dots. Besides that, version 2.0.4 is a universal binary, so this removes the Rosetta caveat.