### PR TITLE
assinador-serpro: update livecheck

### DIFF
--- a/Casks/a/assinador-serpro.rb
+++ b/Casks/a/assinador-serpro.rb
@@ -9,7 +9,7 @@ cask "assinador-serpro" do
 
   livecheck do
     url :homepage
-    regex(/href=.*?AssinadorSerpro[._-]v?(\d+(?:\.\d+)+)\.m?pkg/i)
+    regex(/href=.*?Assinador[._-]?Serpro[._-]v?(\d+(?:\.\d+)+)\.m?pkg/i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block for `assinador-serpro` is producing an "Unable to get versions" error because the pkg file name now includes a hyphen between "Assinador" and "Serpro", so the regex fails to match. This updates the regex to account for an optional delimiter, so the `livecheck` block correctly returns 4.4.0 as newest.

It's not possible to update to version 4.4.0 because the pkg file is busted (i.e., it's only ~606 KB but it should be ~60 MB). The 4.4.0 file is served from a different host but the 4.3.3 pkg file isn't available from the new host and the existing asset URL no longer works, so the cask will remain broken until upstream provides a working pkg file for 4.4.0 or later. There's a 4.5.0 RC version for ARM, so the cask will also need to be updated to account for that in the future.

In the interim time, I'm running this as syntax-only to fix the `livecheck` block, so we have a better chance of being able to see when a new version is available.