### PR TITLE
confirmo 1.0.96 (new cask)

### DIFF
--- a/Casks/c/confirmo.rb
+++ b/Casks/c/confirmo.rb
@@ -1,0 +1,33 @@
+cask "confirmo" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.0.96"
+  sha256 arm:   "03239cd21238de2ac706752103d2f776eecaecfa374b4dc4f90746f3e9d1a59f",
+         intel: "c8e22a5066d6052cd98ba7276ce1dccd9ef955711a644024606d83b13408f1da"
+
+  url "https://updates.confirmo.love/confirmo-#{version}-#{arch}.dmg"
+  name "Confirmo"
+  desc "AI coding companion"
+  homepage "https://confirmo.love/"
+
+  livecheck do
+    url "https://updates.confirmo.love/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "Confirmo.app"
+
+  uninstall quit: "com.confirmo.app"
+
+  zap trash: [
+    "~/Library/Application Support/Confirmo",
+    "~/Library/Caches/com.confirmo.app",
+    "~/Library/Caches/com.confirmo.app.ShipIt",
+    "~/Library/HTTPStorages/com.confirmo.app",
+    "~/Library/Preferences/com.confirmo.app.plist",
+    "~/Library/Saved Application State/com.confirmo.app.savedState",
+  ]
+end


### PR DESCRIPTION
Adds Confirmo, an AI coding companion desktop app.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to draft the cask and run local verification commands. I manually verified the official website and update feed, checked the app bundle identifier and minimum macOS version from `Info.plist`, verified Gatekeeper acceptance, installed and uninstalled the cask locally, and reviewed the `zap` paths against the bundle identifier.

-----
