### PR TITLE
siliconscope 3.1.5 (new cask)

### DIFF
--- a/Casks/s/siliconscope.rb
+++ b/Casks/s/siliconscope.rb
@@ -1,0 +1,24 @@
+cask "siliconscope" do
+  version "3.2.0"
+  sha256 "7ddb16f0e556d59be659671ae1db887a8d38f4f37285252781893b9f70b0f619"
+
+  url "https://github.com/kennss/SiliconScope/releases/download/v#{version}/SiliconScope-#{version}.dmg",
+      verified: "github.com/kennss/SiliconScope/"
+  name "SiliconScope"
+  desc "System monitor for Apple Silicon with ANE, Media Engine and bandwidth tracking"
+  homepage "https://siliconscope.calidalab.ai/"
+
+  auto_updates true
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "SiliconScope.app"
+
+  zap trash: [
+    "~/Library/Caches/ai.calidalab.SiliconScope",
+    "~/Library/HTTPStorages/ai.calidalab.SiliconScope",
+    "~/Library/HTTPStorages/ai.calidalab.SiliconScope.binarycookies",
+    "~/Library/Preferences/ai.calidalab.SiliconScope.plist",
+    "~/Library/Saved Application State/ai.calidalab.SiliconScope.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

This cask and PR were generated with help from Claude Code (Anthropic).

Generated by AI:
- The cask stanzas (version, sha256, url, name, desc, homepage, livecheck,
  depends_on, app, zap) for SiliconScope's latest stable release, v3.1.5.
- Computed sha256 from the release DMG via `shasum -a 256`.
- Ran `brew style siliconscope` (no offenses) and
  `brew audit --new --cask --online siliconscope` (error-free).

Manually verified by me (I'm the author/maintainer of SiliconScope,
https://github.com/kennss/SiliconScope):
- Mounted the v3.1.5 DMG and confirmed the artifact is `SiliconScope.app`
  with bundle id `ai.calidalab.SiliconScope` and LSMinimumSystemVersion 14.0
  (matches `depends_on macos: :sonoma`).
- Verified each zap path: the three bundle-id-scoped paths (Caches,
  HTTPStorages, Preferences) exist after normal use; Saved Application State
  is the standard macOS window-restoration path. I removed an earlier
  speculative `~/Library/Application Support/SiliconScope` entry after
  confirming the app never writes there (recordings are saved to
  `~/SiliconScope` via a save panel, intentionally left untouched).
- Installed and uninstalled the cask locally:
  `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask siliconscope` and
  `brew uninstall --cask siliconscope` both succeeded.
-----
