### PR TITLE
codex: use package tarball to install codex-code-mode-host

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -3,12 +3,12 @@ cask "codex" do
   os macos: "apple-darwin", linux: "unknown-linux-musl"
 
   version "0.144.0"
-  sha256 arm:          "10e062320b2462425178976ca138d55c6082173899de4723085ddc6066b49284",
-         intel:        "bd9748c1cf7a755fdd7b73a90ca944640f7b01113872181db8a5e278902d2331",
-         arm64_linux:  "c7c44a7950bdb555c743f5bb5f7ac3ec2ee7c311970effe92fd39e82eccc6b51",
-         x86_64_linux: "725883fc20ab4af3072829aaa0edf6d12c216238f9f7315a6656b950fb05c8bb"
+  sha256 arm:          "4584a243ff8a671250bc716f89c5a50ed59917a98390acfdffa3ecb6cfe5bb34",
+         intel:        "1056c80958863b13debd5daee5eb7b9bd6f86236a1171d21b009e2dceea8763e",
+         arm64_linux:  "d58be04e6ee804833c25b586869f1fa67f27f0bdc3f39105a2a9bacef167ae42",
+         x86_64_linux: "6b03d2d89910874fa5be27b617621d7638f906e891fd8cb40af3d2876a8a36fd"
 
-  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-#{arch}-#{os}.tar.gz"
+  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-package-#{arch}-#{os}.tar.gz"
   name "Codex"
   desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
@@ -21,9 +21,10 @@ cask "codex" do
 
   depends_on formula: "ripgrep"
 
-  binary "codex-#{arch}-#{os}", target: "codex"
+  binary "bin/codex"
+  binary "bin/codex-code-mode-host"
 
-  generate_completions_from_executable "codex-#{arch}-#{os}", "completion", base_name: "codex"
+  generate_completions_from_executable "bin/codex", "completion", base_name: "codex"
 
   zap rmdir: "~/.codex"
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same cask?
- [x] Have you built your cask with `brew audit --cask --online` and made sure that all warnings are addressed?
- [x] Have you checked style with `brew style`?
- [x] Have you verified the cask installs with `brew install --cask`?
- [x] Have you verified the cask uninstalls with `brew uninstall --cask`?

---

Fixes #274185.

Codex 0.144.0 introduced Code Mode, which requires a companion executable `codex-code-mode-host` resolved as a sibling of the `codex` binary. The current cask installs only the main binary from `codex-<arch>-<os>.tar.gz`, so every tool/shell invocation in 0.144.0 fails with:

```
failed to spawn code-mode host /opt/homebrew/bin/codex-code-mode-host: No such file or directory (os error 2)
```

Upstream tracking issue: openai/codex#31831 — an OpenAI collaborator fixed their standalone shell installer and [stated they are still working on a fix for Homebrew](https://github.com/openai/codex/issues/31831).

This PR switches the cask to the `codex-package-<arch>-<os>.tar.gz` release asset, which upstream publishes for all four platforms this cask supports and which contains both `bin/codex` and `bin/codex-code-mode-host`. Both are installed as binaries; the completions generator is updated to the new path.

Notes:
- The package tarball also bundles `codex-path/rg` and a `codex-resources/zsh`; I kept `depends_on formula: "ripgrep"` to minimize the diff, but maintainers may prefer to drop it.
- Tested on Apple Silicon (macOS/Darwin 25.5.0): `brew style` (no offenses), `brew audit --cask --online` (clean), install, uninstall, and a functional end-to-end check confirming `codex exec` executes commands again with no code-mode host errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
