### PR TITLE
codex 0.144.1

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -2,11 +2,11 @@ cask "codex" do
   arch arm: "aarch64", intel: "x86_64"
   os macos: "apple-darwin", linux: "unknown-linux-musl"
 
-  version "0.144.0"
-  sha256 arm:          "10e062320b2462425178976ca138d55c6082173899de4723085ddc6066b49284",
-         intel:        "bd9748c1cf7a755fdd7b73a90ca944640f7b01113872181db8a5e278902d2331",
-         arm64_linux:  "c7c44a7950bdb555c743f5bb5f7ac3ec2ee7c311970effe92fd39e82eccc6b51",
-         x86_64_linux: "725883fc20ab4af3072829aaa0edf6d12c216238f9f7315a6656b950fb05c8bb"
+  version "0.144.1"
+  sha256 arm:          "88e72ac8bd30815f7d18e62dac333dc20ce3ad1cba94be1649a1977dd9bfdbb8",
+         intel:        "0ea72d21c794504342d5fe0d5d057b0221c0a42f4bdf4a48b95af243af2b0c0e",
+         arm64_linux:  "b9f8ef5f98e46ced4dbbd3756a4223e3ee299a457ff488a3305bea455da8b5b8",
+         x86_64_linux: "84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28"
 
   url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-#{arch}-#{os}.tar.gz"
   name "Codex"


### PR DESCRIPTION
### What's included
* manually bump codex version to the [latest](https://github.com/openai/codex/releases/tag/rust-v0.144.1) and pick up fixes. 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

OpenAI Codex (GPT-5) was used to update the version and checksums and to prepare this draft PR. The four checksums were verified against the SHA-256 digests published with the OpenAI Codex 0.144.1 release. `brew lgtm --online` passed, including the strict online cask audit and style check. The cask was installed, the binary reported `codex-cli 0.144.1`, and the cask was then uninstalled successfully. The existing `zap` stanza is unchanged and removes `~/.codex`.

-----
