### PR TITLE
codex-app: deprecate

### DIFF
--- a/Casks/c/codex-app.rb
+++ b/Casks/c/codex-app.rb
@@ -1,6 +1,5 @@
 cask "codex-app" do
   arch arm: "arm64", intel: "x64"
-  livecheck_arch = on_arch_conditional intel: "-x64"
 
   version "26.623.141536"
   sha256 arm:   "d948dc36b8358f5a2924b033fbf08398eea7860dc9e97cb5ab9b354490283a0a",
@@ -13,9 +12,10 @@ cask "codex-app" do
   homepage "https://openai.com/codex"
 
   livecheck do
-    url "https://persistent.oaistatic.com/codex-app-prod/appcast#{livecheck_arch}.xml"
-    strategy :sparkle, &:short_version
+    skip "Upstream appcast now serves the renamed ChatGPT app"
   end
+
+  deprecate! date: "2026-07-09", because: "is now part of the ChatGPT app", replacement_cask: "chatgpt"
 
   auto_updates true
   depends_on macos: :monterey


### PR DESCRIPTION
OpenAI renamed the Codex desktop app to ChatGPT: since 26.707.30751, the Sparkle appcast at `persistent.oaistatic.com/codex-app-prod/` serves `ChatGPT-darwin-{arm64,x64}-<version>.zip` containing `ChatGPT.app` (bundle ID still `com.openai.codex`), so this cask can no longer be bumped, and installed copies have already self-updated into ChatGPT. The renamed app would also conflict with the existing `chatgpt` cask's `ChatGPT.app`, so deprecating with `replacement_cask: "chatgpt"` seems preferable to renaming. Happy to rework if you'd rather point this cask at the new URL pattern instead.

Built and tested locally on macOS 15.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) drafted the deprecation and verified the rename against the live appcast (enclosure URLs and the zip's `Info.plist`: `ChatGPT.app`, `CFBundleIdentifier com.openai.codex`). I reviewed the diff and ran `brew audit --cask --online codex-app` and `brew style` locally (both clean). No `zap` changes.
