### PR TITLE
codex: only install files in bin directory

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -24,6 +24,15 @@ cask "codex" do
   binary "bin/codex"
   binary "bin/codex-code-mode-host"
 
+  # The `codex-package` archive also contains binaries outside of the `/bin`
+  # directory that can cause problems (e.g., an adhoc-signed ripgrep binary), so
+  # we only install the `/bin` directory.
+  preflight do
+    staged_path.glob("*[!/bin/]*").each do |unwanted_path|
+      FileUtils.rm_r(unwanted_path)
+    end
+  end
+
   generate_completions_from_executable "bin/codex", "completion"
 
   zap rmdir: "~/.codex"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `codex-package...` archive that we recently switched the `codex` cask to also includes files outside of the `bin` directory that we don't need and can cause problems. Notably, there's an adhoc-signed ripgrep binary in `codex-path/rg` and `codex` will try to use that and predictably trigger a Gatekeeper warning.

As a workaround, this adds a `preflight` block that removes everything from the staged path other than the `bin` directory, so the cask only installs the `codex` and `codex-code-mode-host` binaries and nothing else.