### PR TITLE
codex: revert to standalone codex tarball

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -3,12 +3,12 @@ cask "codex" do
   os macos: "apple-darwin", linux: "unknown-linux-musl"
 
   version "0.144.1"
-  sha256 arm:          "326198829dfb4b68da59723cf605478a2e9bec89ff47feb645814a4c5eaf5f6c",
-         intel:        "1c797880977549b281eeb4ecd9dbd145542c4ce262a2835ea2847f19922ed30c",
-         arm64_linux:  "218ab48bdda98dde3e10df184cc0c4eb92c4372d9ca924ef1aa5fc81b4f6a38e",
-         x86_64_linux: "3fd50cf96809b1eea294bbfba0a5c3a576871b4876a1f0e91226e520c1923be1"
+  sha256 arm:          "88e72ac8bd30815f7d18e62dac333dc20ce3ad1cba94be1649a1977dd9bfdbb8",
+         intel:        "0ea72d21c794504342d5fe0d5d057b0221c0a42f4bdf4a48b95af243af2b0c0e",
+         arm64_linux:  "b9f8ef5f98e46ced4dbbd3756a4223e3ee299a457ff488a3305bea455da8b5b8",
+         x86_64_linux: "84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28"
 
-  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-package-#{arch}-#{os}.tar.gz"
+  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-#{arch}-#{os}.tar.gz"
   name "Codex"
   desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
@@ -21,19 +21,9 @@ cask "codex" do
 
   depends_on formula: "ripgrep"
 
-  binary "bin/codex"
-  binary "bin/codex-code-mode-host"
+  binary "codex-#{arch}-#{os}", target: "codex"
 
-  # The `codex-package` archive also contains binaries outside of the `/bin`
-  # directory that can cause problems (e.g., an adhoc-signed ripgrep binary), so
-  # we only install the `/bin` directory.
-  preflight do
-    staged_path.glob("*[!/bin/]*").each do |unwanted_path|
-      FileUtils.rm_r(unwanted_path)
-    end
-  end
-
-  generate_completions_from_executable "bin/codex", "completion"
+  generate_completions_from_executable "codex-#{arch}-#{os}", "completion", base_name: "codex"
 
   zap rmdir: "~/.codex"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

I previously modified the `codex` cask to also install a `codex-code-mode-host` binary from the `codex-package-...` tarball (as it provides both a `codex` and `codex-code-mode-host` binary) in response to user reports that the additional binary was needed. However, it was brought to my attention (in https://github.com/Homebrew/homebrew-cask/issues/274185) that this issue in version 0.144.0 was resolved in version 0.144.1, so we don't need to ship this additional binary and upstream recommends against it for now. This restores the cask to the previous setup using the tarball that only includes the `codex` binary until upstream suggests/requires a different approach.