### PR TITLE
chatgpt: repoint to new desktop app

### DIFF
--- a/Casks/c/chatgpt-classic.rb
+++ b/Casks/c/chatgpt-classic.rb
@@ -1,0 +1,45 @@
+cask "chatgpt-classic" do
+  version "1.2026.183,1783607847"
+  sha256 "49b33cadd2ec659b76352384f7ebd332a7ec7029663365a9f720f4a251d3b8d1"
+
+  url "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_#{version.csv.first}_#{version.csv.second}.dmg",
+      verified: "persistent.oaistatic.com/sidekick/public/"
+  name "ChatGPT Classic"
+  desc "OpenAI's previous ChatGPT desktop app"
+  homepage "https://chatgpt.com/"
+
+  # Some older items in the Sparkle feed have a more recent pubDate, so it's necessary to
+  # work with all of the items in the feed (not just the newest one).
+  livecheck do
+    url "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml"
+    strategy :sparkle do |items|
+      items.map(&:nice_version)
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "chatgpt"
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "ChatGPT.app"
+
+  uninstall quit: "com.openai.chat"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.openai.chat.Widgets",
+    "~/Library/Application Scripts/group.com.openai.chat",
+    "~/Library/Application Support/ChatGPT",
+    "~/Library/Application Support/com.openai.chat",
+    "~/Library/Caches/com.openai.chat",
+    "~/Library/Containers/com.openai.chat.Widgets",
+    "~/Library/Group Containers/group.com.openai.chat",
+    "~/Library/HTTPStorages/ChatGPTHelper.binarycookies",
+    "~/Library/HTTPStorages/com.openai.chat",
+    "~/Library/HTTPStorages/com.openai.chat.binarycookies",
+    "~/Library/Preferences/com.openai.chat.*.plist",
+    "~/Library/Preferences/com.openai.chat.plist",
+    "~/Library/Saved Application State/com.openai.chat.savedState",
+    "~/Library/WebKit/com.openai.chat",
+  ]
+end

--- a/Casks/c/chatgpt.rb
+++ b/Casks/c/chatgpt.rb
@@ -18,10 +18,7 @@ cask "chatgpt" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "chatgpt-classic",
-    "codex-app",
-  ]
+  conflicts_with cask: "codex-app"
   depends_on macos: :monterey
 
   app "ChatGPT.app"

--- a/Casks/c/chatgpt.rb
+++ b/Casks/c/chatgpt.rb
@@ -1,44 +1,42 @@
 cask "chatgpt" do
-  version "1.2026.183,1783607847"
-  sha256 "49b33cadd2ec659b76352384f7ebd332a7ec7029663365a9f720f4a251d3b8d1"
+  arch arm: "arm64", intel: "x64"
+  livecheck_arch = on_arch_conditional intel: "-x64"
 
-  url "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_#{version.csv.first}_#{version.csv.second}.dmg",
-      verified: "persistent.oaistatic.com/sidekick/public/"
+  version "26.707.31428"
+  sha256 arm:   "ffdc351a507105d55d7464e3340302c758b8a54b926711c4b15bf373ccb47d64",
+         intel: "bf24b45c83d86efc03155bcba5f6e6c1df87219e6ea8ee7c7059ff4d767afeac"
+
+  url "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-#{arch}-#{version}.zip",
+      verified: "persistent.oaistatic.com/codex-app-prod/"
   name "ChatGPT"
   desc "OpenAI's official ChatGPT desktop app"
   homepage "https://chatgpt.com/"
 
-  # Some older items in the Sparkle feed have a more recent pubDate, so it's necessary to
-  # work with all of the items in the feed (not just the newest one).
   livecheck do
-    url "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml"
-    strategy :sparkle do |items|
-      items.map(&:nice_version)
-    end
+    url "https://persistent.oaistatic.com/codex-app-prod/appcast#{livecheck_arch}.xml"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true
-  depends_on macos: :sonoma
-  depends_on arch: :arm64
+  conflicts_with cask: [
+    "chatgpt-classic",
+    "codex-app",
+  ]
+  depends_on macos: :monterey
 
   app "ChatGPT.app"
 
-  uninstall quit: "com.openai.chat"
+  uninstall quit: "com.openai.codex"
 
   zap trash: [
-    "~/Library/Application Scripts/com.openai.chat.Widgets",
-    "~/Library/Application Scripts/group.com.openai.chat",
-    "~/Library/Application Support/ChatGPT",
-    "~/Library/Application Support/com.openai.chat",
-    "~/Library/Caches/com.openai.chat",
-    "~/Library/Containers/com.openai.chat.Widgets",
-    "~/Library/Group Containers/group.com.openai.chat",
-    "~/Library/HTTPStorages/ChatGPTHelper.binarycookies",
-    "~/Library/HTTPStorages/com.openai.chat",
-    "~/Library/HTTPStorages/com.openai.chat.binarycookies",
-    "~/Library/Preferences/com.openai.chat.*.plist",
-    "~/Library/Preferences/com.openai.chat.plist",
-    "~/Library/Saved Application State/com.openai.chat.savedState",
-    "~/Library/WebKit/com.openai.chat",
-  ]
+        "~/Library/Application Support/Codex",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.openai.codex.sfl*",
+        "~/Library/Caches/com.openai.codex",
+        "~/Library/HTTPStorages/com.openai.codex",
+        "~/Library/HTTPStorages/com.openai.codex.binarycookies",
+        "~/Library/Logs/com.openai.codex",
+        "~/Library/Preferences/com.openai.codex.plist",
+        "~/Library/Saved Application State/com.openai.codex.savedState",
+      ],
+      rmdir: "~/.codex"
 end


### PR DESCRIPTION
OpenAI released the new ChatGPT desktop app, which combines Chat, Work, and Codex and replaces the previous desktop app: https://help.openai.com/en/articles/20001276-moving-to-the-new-chatgpt-desktop-app

- `chatgpt` now tracks what OpenAI ships as "ChatGPT": the new app from the `codex-app-prod` Sparkle feed (`ChatGPT.app`, bundle ID `com.openai.codex`, arm64 + x64, macOS 12+).
- `chatgpt-classic` (new cask) keeps the previous native app (`ChatGPT.app`, bundle ID `com.openai.chat`, from the `sidekick/public` feed), which OpenAI now calls "ChatGPT Classic" and continues to update with no forced migration.
- `conflicts_with` on both, since both vendor bundles are currently named `ChatGPT.app`.

Note for existing `chatgpt` users: the cask has `auto_updates true`, so plain `brew upgrade` won't swap their installed app; only `--greedy` or a reinstall will.

Built and tested locally on macOS 15.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) drafted both casks and verified the feeds and binaries (appcast enclosures for both feeds, and each app's `Info.plist` bundle ID). I reviewed the diff and ran audit, style, install, and uninstall locally for both casks (all clean; install/uninstall via a temporary `--appdir`). `chatgpt-classic` zap paths are carried over unchanged from the current `chatgpt` cask; the repointed `chatgpt` zap paths are carried over from `codex-app`, which tracks the same binary lineage.
