### PR TITLE
lazycat 2.0.14

### DIFF
--- a/Casks/l/lazycat.rb
+++ b/Casks/l/lazycat.rb
@@ -1,17 +1,18 @@
 cask "lazycat" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.0.13"
-  sha256 arm:   "d23dbd516712657ebbbc035cfa3f559022bc76f6ea95dca686e655f6417dbdba",
-         intel: "c1375a5823e43d6d0e8147faec112052eeb4596e0b1ceb50f9aa074ceafeab99"
+  version "2.0.14"
+  sha256 arm:   "081357d95dc6fdc9c9c2a45d85894931fde27199e8da0bfed279eb98a983ba45",
+         intel: "e23d04df2ea2056e35ca386fa174a78620254f7813438f6d05534b5b17b18a64"
 
-  url "https://dl.lazycat.cloud/client/desktop/stable/lzc-client-desktop_v#{version}_#{arch}.dmg"
+  url "https://dl.lazycatmicroserver.com/client/desktop/stable/lzc-client-desktop_v#{version}_#{arch}.dmg",
+      verified: "dl.lazycatmicroserver.com/client/desktop/stable/"
   name "LazyCat"
   desc "Client for LazyCat hardware"
   homepage "https://lazycat.cloud/"
 
   livecheck do
-    url "https://dl.lazycat.cloud/client/desktop/lzc-client-desktop_#{arch}.dmg.metadata.json"
+    url "https://dl.lazycatmicroserver.com/client/desktop/lzc-client-desktop_#{arch}.dmg.metadata.json"
     strategy :json do |json|
       json["buildVersion"]&.delete_prefix("v")
     end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`lazycat` is autobumped but the workflow failed to update to version 2.0.14 because upstream is now using a different host for assets. This updates the version and adjusts related URLs accordingly.