### PR TITLE
koodo-reader 2.3.9: update url, desc, livecheck; add Linux AppImage

### DIFF
--- a/Casks/k/koodo-reader.rb
+++ b/Casks/k/koodo-reader.rb
@@ -1,31 +1,35 @@
 cask "koodo-reader" do
-  arch arm: "arm64", intel: "x64"
+  arch arm: "arm64", intel: on_system_conditional(macos: "x64", linux: "x86_64")
 
-  version "1.7.4"
-  sha256 arm:   "def811c8e477bda788ae1036a395da499556ecbd2ee624249d95c897576efc41",
-         intel: "6270ed3bf37965de4e9d430de4d72036f70df8d957f0220419424947081f324e"
+  version "2.3.9"
+  sha256 arm:          "7fff8eb2c04475d06783ab2a474e5ea9127b76191164095445aed6c3faf926e1",
+         intel:        "5301b15c203aba67737f6f0a6796ac93acd5fe95218a8aa802d00dace742034d",
+         arm64_linux:  "0513069ba1c6c82e2fe73a3c7742a0b85d81d734b3a75dbbe5792e34da6772c2",
+         x86_64_linux: "f650f061141c81bbf2af05e0d07fc8ab73e2118dc45e4ddc6e7a8828846c5e81"
 
-  url "https://dl.koodoreader.com/v#{version}/Koodo-Reader-#{version}-#{arch}.dmg"
+  url_end = on_system_conditional macos: "dmg", linux: "AppImage"
+
+  url "https://github.com/koodo-reader/koodo-reader/releases/download/v#{version}/Koodo-Reader-#{version}-#{arch}.#{url_end}",
+      verified: "github.com/koodo-reader/koodo-reader/"
   name "Koodo Reader"
-  desc "Open-source epub reader"
+  desc "Open-source e-book reader"
   homepage "https://www.koodoreader.com/en"
 
-  livecheck do
-    url "https://api.960960.xyz/api/update"
-    strategy :json do |json|
-      json.dig("log", "version")
-    end
+  on_macos do
+    disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+    depends_on macos: :big_sur
+
+    app "Koodo Reader.app"
+
+    zap trash: [
+      "~/Library/Application Support/koodo-reader",
+      "~/Library/Preferences/xyz.960960.koodo.plist",
+      "~/Library/Saved Application State/xyz.960960.koodo.savedState",
+    ]
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
-  depends_on :macos
-
-  app "Koodo Reader.app"
-
-  zap trash: [
-    "~/Library/Application Support/koodo-reader",
-    "~/Library/Preferences/xyz.960960.koodo.plist",
-    "~/Library/Saved Application State/xyz.960960.koodo.savedState",
-  ]
+  on_linux do
+    app_image "Koodo-Reader-#{version}-#{arch}.AppImage", target: "Koodo Reader.AppImage"
+  end
 end


### PR DESCRIPTION
The previous `livecheck` URL <https://api.960960.xyz/api/update> gives the outdated version 1.7.4, so `url` is updated to GitHub-based download URLs so that `livecheck` uses up-to-date GitHub releases instead.

`desc` is updated because the app can read many other e-book formats than EPUB.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
