### PR TITLE
switchy 1.1.4 (new cask)

### DIFF
--- a/Casks/s/switchy.rb
+++ b/Casks/s/switchy.rb
@@ -1,0 +1,26 @@
+cask "switchy" do
+  version "1.1.4,70"
+  sha256 "de151649e8c0d3fa52f5f2b31db168b7d67325e3ac40109d25f8db9f5e4089b2"
+
+  url "https://mangobuns.com/switchy/downloads/Switchy-#{version.csv.first}.#{version.csv.second}.dmg"
+  name "Switchy"
+  desc "Switch Magic Keyboard, Trackpad and Mouse between Macs"
+  homepage "https://mangobuns.com/switchy/"
+
+  livecheck do
+    url "https://mangobuns.com/switchy/appcast.xml"
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.nice_version
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Switchy.app"
+
+  zap trash: [
+    "~/Library/HTTPStorages/com.mangobuns.Switchy",
+    "~/Library/Preferences/com.mangobuns.Switchy.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with the cask draft, release preparation, and PR text. I manually verified: the published first-party DMG checksum (sha256 matches the cask), `brew style --fix` with no offenses, `brew audit --cask --new --online` error-free, `brew livecheck` resolving 1.1.4,70 from the Sparkle appcast, and a full `brew install --cask` / `brew uninstall --cask` cycle. For the `zap` stanza: I mounted the v1.1.4 build 70 DMG and confirmed the app's bundle identifier is `com.mangobuns.Switchy`, matching the zap paths (`~/Library/HTTPStorages/com.mangobuns.Switchy`, `~/Library/Preferences/com.mangobuns.Switchy.plist`), which are the files the app actually creates on a real install.

-----
