### PR TITLE
Create bettbox

### DIFF
--- a/Casks/b/bettbox.rb
+++ b/Casks/b/bettbox.rb
@@ -1,0 +1,37 @@
+cask "bettbox" do
+  version "1.18.5"
+
+  on_arm do
+    sha256 "cc702403586a1260dada41cd11a44455d795e0cd2e782eae0f3542757d5cada9"
+
+    url "https://github.com/appshubcc/Bettbox/releases/download/v#{version}/Bettbox-#{version}-macos-arm64.dmg"
+  end
+  on_intel do
+    if MacOS.version <= :big_sur
+      sha256 "a8828fd8dc1e050e114542b81172aa932c1a34fa82534f2ac72126347dee1413"
+
+      url "https://github.com/appshubcc/Bettbox/releases/download/v#{version}/Bettbox-#{version}-macos-amd64-compatible.dmg"
+    else
+      sha256 "ffefdd47f7ac339e3277291d233d39a27155cff75b6fb75f25618e9683bd71e2"
+
+      url "https://github.com/appshubcc/Bettbox/releases/download/v#{version}/Bettbox-#{version}-macos-amd64.dmg"
+    end
+  end
+
+  name "Bettbox"
+  desc "Multi-platform network debugging and traffic splitting client"
+  homepage "https://github.com/appshubcc/Bettbox"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Bettbox.app"
+
+  zap trash: [
+    "~/Library/Application Support/Bettbox",
+    "~/Library/Preferences/com.appshub.bettbox.plist",
+    "~/Library/Saved Application State/com.appshub.bettbox.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI was used to help compute the SHA-256 hashes of the v1.18.5 macOS DMG assets and structure the Cask file. 

For manual verification:
1. The DMG files for all three targets (arm64, amd64, and amd64-compatible) were downloaded and their SHA-256 hashes were calculated and cross-verified locally using `Get-FileHash`.
2. The `zap` paths were verified against the actual macOS project configuration (Bundle ID is `com.appshub.bettbox`).

-----
