### PR TITLE
quintile 0.1.6 (new cask)

### DIFF
--- a/Casks/q/quintile.rb
+++ b/Casks/q/quintile.rb
@@ -1,0 +1,23 @@
+cask "quintile" do
+  version "0.1.6"
+  sha256 "b500addcb2f7e7660c1964a2316a4f549fa23bb75d50a7e26460a4be7db71777"
+
+  url "https://github.com/stefanopineda/quintile/releases/download/v#{version}/Quintile.app.zip"
+  name "Quintile"
+  desc "Keyboard-only N×M grid window tiling"
+  homepage "https://github.com/stefanopineda/quintile"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Quintile.app"
+
+  zap trash: [
+    "~/Library/Application Support/Quintile",
+    "~/Library/Preferences/com.stefanopineda.quintile.plist",
+  ]
+end

--- a/Casks/q/quintile.rb
+++ b/Casks/q/quintile.rb
@@ -12,7 +12,7 @@ cask "quintile" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "Quintile.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with drafting the cask and opening this PR. Manually verified: v0.1.6 zip is Developer ID signed and Apple-notarized (`spctl -a -vv` → `accepted`, `source=Notarized Developer ID`), sha256 matches the GitHub release asset, install and uninstall succeed via a local tap of this cask, `zap` covers Application Support and Preferences for `com.stefanopineda.quintile`.

**Audit note:** `brew audit --cask --new` fails only on GitHub notability (`<30 forks, <30 watchers and <75 stars`). Happy to revisit once the project crosses that bar, or discuss if maintainers prefer holding.

## App
- Homepage: https://github.com/stefanopineda/quintile  
- Release: https://github.com/stefanopineda/quintile/releases/tag/v0.1.6  
- Team: U6P5GPUCJJ (Developer ID Application, notarized)