### PR TITLE
ibm-notifier: add binary entrypoint

### DIFF
--- a/Casks/i/ibm-notifier.rb
+++ b/Casks/i/ibm-notifier.rb
@@ -21,7 +21,7 @@ cask "ibm-notifier" do
   depends_on macos: :big_sur
 
   app "IBM Notifier.app"
-  binary "#{appdir}/IBM Notifier.app/Contents/MacOS/IBM Notifier"
+  binary "#{appdir}/IBM Notifier.app/Contents/MacOS/IBM Notifier", target: "ibm-notifier"
 
   zap trash: [
     "~/Library/Caches/com.ibm.cio.notifier",

--- a/Casks/i/ibm-notifier.rb
+++ b/Casks/i/ibm-notifier.rb
@@ -21,6 +21,7 @@ cask "ibm-notifier" do
   depends_on macos: :big_sur
 
   app "IBM Notifier.app"
+  binary "#{appdir}/IBM Notifier.app/Contents/MacOS/IBM Notifier"
 
   zap trash: [
     "~/Library/Caches/com.ibm.cio.notifier",


### PR DESCRIPTION
IBM Notifier is an app mainly designed to be called from the command line in order to show macOS Notifications, so it makes sense to expose the binary by itself.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
