### PR TITLE
macshot-offline 4.2.1 (new cask)

### DIFF
--- a/Casks/m/macshot-offline.rb
+++ b/Casks/m/macshot-offline.rb
@@ -1,0 +1,28 @@
+cask "macshot-offline" do
+  version "4.2.1"
+  sha256 "7ac2c3537dec1a3718fbbc51e9f26c95de9550fc07a430f0eef350cb86aaf9d7"
+
+  url "https://github.com/sw33tLie/macshot/releases/download/v#{version}/MacShot-Offline.dmg"
+  name "macshot Offline"
+  desc "Screenshot and screen recording tool without upload integrations"
+  homepage "https://github.com/sw33tLie/macshot"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/sw33tLie/macshot/main/appcast-offline.xml"
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.short_version
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "macshot Offline.app"
+
+  uninstall quit: "com.sw33tlie.macshot.offline"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.sw33tlie.macshot.offline",
+    "~/Library/Containers/com.sw33tlie.macshot.offline",
+  ]
+end


### PR DESCRIPTION
Adds a new cask for macshot Offline, the upload-free variant of macshot ([`macshot`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/m/macshot.rb) is already in homebrew-cask). It is a separate app published by the same upstream project from the same tagged releases: its own bundle identifier (`com.sw33tlie.macshot.offline`), app name (`macshot Offline.app`), DMG, and Sparkle feed, with all upload and cloud storage integrations compiled out. Both casks can be installed side by side.

The livecheck follows the variant's own Sparkle appcast and skips items on the beta channel, matching the existing `macshot` cask.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+macshot&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

An AI coding assistant drafted the cask file (modeled on the existing `macshot` cask) and this PR description. All checklist items above were verified by actually running them on a macOS machine: `brew style`, `brew audit --cask --new --online`, a real install from the built cask followed by `brew uninstall`. The `zap` paths were confirmed against the installed app: it is sandboxed, so its data lives in `~/Library/Containers/com.sw33tlie.macshot.offline` and `~/Library/Application Scripts/com.sw33tlie.macshot.offline` (bundle identifier verified via `codesign -d` on the installed app). I am the upstream developer of macshot and maintain both variants.
