### PR TITLE
vorssaint 3.1.12 (new cask)

### DIFF
--- a/Casks/v/vorssaint.rb
+++ b/Casks/v/vorssaint.rb
@@ -1,0 +1,30 @@
+cask "vorssaint" do
+  version "3.1.12"
+  sha256 "1b91cd31c40f68c0b305cb7a5f8c3b9f460735e77fe560ea60bd508c5cb7996f"
+
+  url "https://github.com/vorssaint/vorssaint-utils/releases/download/v#{version}/Vorssaint-#{version}.dmg"
+  name "Vorssaint"
+  desc "Menu bar toolkit with keep-awake, system monitor and volume mixer"
+  homepage "https://github.com/vorssaint/vorssaint-utils"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "Vorssaint.app"
+
+  uninstall quit: "com.vorssaint.utils"
+
+  zap trash: [
+    "~/Library/Application Support/com.vorssaint.utils",
+    "~/Library/Caches/com.vorssaint.utils",
+    "~/Library/HTTPStorages/com.vorssaint.utils",
+    "~/Library/Preferences/com.vorssaint.utils.plist",
+    "~/Library/Saved Application State/com.vorssaint.utils.savedState",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 27 (Tier 2).

Resubmission of #269712. The repository is now over 30 days old, and the previous audit blocker is resolved.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your casks name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with policy review and cask preparation. Verification covered the release URL and SHA-256, app name, bundle ID, architecture, signature, notarization, installation, uninstallation, and zap paths against the app source and local filesystem.

-----