### PR TITLE
gmacFTP 0.1.1 (new cask)

### DIFF
--- a/Casks/g/gmacftp.rb
+++ b/Casks/g/gmacftp.rb
@@ -1,15 +1,15 @@
 cask "gmacftp" do
-  version "0.0.13"
-  sha256 "10e3f55dfe237e3962571ff6e72967dacfd2cdb6fb84e72250a160f98e5276a3"
+  version "0.0.14"
+  sha256 "a386fa85fbd3afdbeb3bd9f9c65bdf3524d097e76da1a8629996684d64281f5d"
 
   url "https://github.com/GMAC-pl/gmacFTP/releases/download/v#{version}/gmacFTP-#{version}.dmg",
       verified: "github.com/GMAC-pl/gmacFTP/"
   name "gmacFTP"
-  desc "Dual-pane FTP/FTPS/SFTP client for macOS, written in Rust"
+  desc "Dual-pane FTP/FTPS/SFTP client"
   homepage "https://github.com/GMAC-pl/gmacFTP"
 
   livecheck do
-    url :url_latest
+    url :url
     strategy :github_latest
   end
 
@@ -18,8 +18,8 @@ cask "gmacftp" do
   app "gmacFTP.app"
 
   zap trash: [
-    "~/Library/Caches/com.gmac.gmacftp",
-    "~/Library/Preferences/com.gmac.gmacftp.plist",
-    "~/Library/Saved Application State/com.gmac.gmacftp.savedState",
+    "~/Library/Application Support/mackftp/client",
+    "~/Library/Mobile Documents/com~apple~CloudDocs/gmacFTP",
+    "~/Library/Saved Application State/app.mackftp.client.savedState",
   ]
 end

--- a/Casks/g/gmacftp.rb
+++ b/Casks/g/gmacftp.rb
@@ -1,0 +1,25 @@
+cask "gmacftp" do
+  version "0.0.13"
+  sha256 "10e3f55dfe237e3962571ff6e72967dacfd2cdb6fb84e72250a160f98e5276a3"
+
+  url "https://github.com/GMAC-pl/gmacFTP/releases/download/v#{version}/gmacFTP-#{version}.dmg",
+      verified: "github.com/GMAC-pl/gmacFTP/"
+  name "gmacFTP"
+  desc "Dual-pane FTP/FTPS/SFTP client for macOS, written in Rust"
+  homepage "https://github.com/GMAC-pl/gmacFTP"
+
+  livecheck do
+    url :url_latest
+    strategy :github_latest
+  end
+
+  depends_on macos: :big_sur
+
+  app "gmacFTP.app"
+
+  zap trash: [
+    "~/Library/Caches/com.gmac.gmacftp",
+    "~/Library/Preferences/com.gmac.gmacftp.plist",
+    "~/Library/Saved Application State/com.gmac.gmacftp.savedState",
+  ]
+end

--- a/Casks/g/gmacftp.rb
+++ b/Casks/g/gmacftp.rb
@@ -1,11 +1,11 @@
 cask "gmacftp" do
-  version "0.0.14"
-  sha256 "a386fa85fbd3afdbeb3bd9f9c65bdf3524d097e76da1a8629996684d64281f5d"
+  version "0.1.1"
+  sha256 "24bf2efb9c90911ad96bc727f81b5e7292e3cda383fff5fe12fa923fbae0a68a"
 
   url "https://github.com/GMAC-pl/gmacFTP/releases/download/v#{version}/gmacFTP-#{version}.dmg",
       verified: "github.com/GMAC-pl/gmacFTP/"
   name "gmacFTP"
-  desc "Dual-pane FTP/FTPS/SFTP client"
+  desc "Dual-pane FTP/FTPS/SFTP client for macOS, built in Rust"
   homepage "https://github.com/GMAC-pl/gmacFTP"
 
   livecheck do


### PR DESCRIPTION
Adds **gmacFTP** - a free, open-source (GPL-3.0) dual-pane FTP/FTPS/SFTP client for macOS (Apple Silicon), built entirely in Rust with a Slint GPU-accelerated UI.

- Homepage: https://github.com/GMAC-pl/gmacFTP
- License: GPL-3.0
- Artifact: `gmacFTP.app` (bundle id `app.mackftp.client`), ~7.5 MB DMG
- Signed with Apple Developer ID and notarized

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assistance was used to draft the cask stanzas and to derive the `zap` paths from the application's source code. The cask was manually reviewed against the Cask Cookbook. Version, SHA256, and the Apple Developer ID signature were verified against the published, notarized GitHub release.
