### PR TITLE
Add simplebanking

### DIFF
--- a/Casks/s/simplebanking.rb
+++ b/Casks/s/simplebanking.rb
@@ -1,0 +1,33 @@
+cask "simplebanking" do
+  version "1.6.1,20260615-120846"
+  sha256 "bbd1e2b4d33a0e8cbf6e8dfd41575e07cef60b4732ec95b3a2391953ddc77ec1"
+
+  url "https://github.com/klotzbrocken/simplebanking/releases/download/v#{version.csv.first}/simplebanking-#{version.csv.second}.dmg"
+  name "simplebanking"
+  desc "Shows your bank balance in the menu bar"
+  homepage "https://www.simplebanking.de/"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/klotzbrocken/simplebanking/main/appcast.xml"
+    regex(/simplebanking[._-](\d{8}-\d{6})\.dmg/i)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[1]}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "simplebanking.app"
+
+  zap trash: [
+    "~/Library/Application Support/simplebanking",
+    "~/Library/Caches/tech.yaxi.simplebanking",
+    "~/Library/HTTPStorages/tech.yaxi.simplebanking",
+    "~/Library/Preferences/tech.yaxi.simplebanking.plist",
+    "~/Library/Saved Application State/tech.yaxi.simplebanking.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance was used to draft the cask, locate upstream download and appcast metadata, inspect the downloaded app bundle, and prepare the PR. Manual verification included confirming the stable version from the upstream Sparkle appcast, inspecting `Info.plist` for `CFBundleIdentifier` (`tech.yaxi.simplebanking`) and `LSMinimumSystemVersion` (`14.0`), verifying `brew audit --cask --new --online simplebanking`, verifying `brew style --fix Casks/s/simplebanking.rb`, and test-installing/uninstalling the cask. The `zap` paths were based on the app name and bundle identifier.

-----
