### PR TITLE
Update OpenInTerminal casks: openinterminal 2.3.9, openinterminal-lite 1.2.8, openineditor-lite 1.2.8

### DIFF
--- a/Casks/o/openineditor-lite.rb
+++ b/Casks/o/openineditor-lite.rb
@@ -1,6 +1,6 @@
 cask "openineditor-lite" do
-  version "1.2.7"
-  sha256 "c079751dc86ac4a683840e62b05872acc4dfbb08d2c7019bb3c6b9d88a0c8017"
+  version "1.2.8"
+  sha256 "40db3a781bee2da0f24cc17a9da5a59162ec4ca1d6f17e0504874f41c326106f"
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/v#{version}/OpenInEditor-Lite.zip"
   name "OpenInEditor-Lite"

--- a/Casks/o/openinterminal-lite.rb
+++ b/Casks/o/openinterminal-lite.rb
@@ -1,6 +1,6 @@
 cask "openinterminal-lite" do
-  version "1.2.7"
-  sha256 "07c558faf0975fd0dca604be2eb793272be91a8f6422f74c8c075ed76775df84"
+  version "1.2.8"
+  sha256 "189842433aed140307a17f25e93cbbe496fc0d745b6e7c2e879cb5dab23250af"
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/v#{version}/OpenInTerminal-Lite.zip"
   name "OpenInTerminal-Lite"

--- a/Casks/o/openinterminal.rb
+++ b/Casks/o/openinterminal.rb
@@ -1,6 +1,6 @@
 cask "openinterminal" do
-  version "2.3.8"
-  sha256 "da9eeb6cdd5db3de963e6f6a49d9d3cbff11f72cd3d56eeb6a657c88fae0aa6f"
+  version "2.3.9"
+  sha256 "14df8720783492fb430237e221604ac332f1025b1d51019e230b796daa387765"
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/v#{version}/OpenInTerminal.zip"
   name "OpenInTerminal"


### PR DESCRIPTION
Version bumps for the OpenInTerminal family of casks, all from the same upstream repo ([Ji4n1ng/OpenInTerminal](https://github.com/Ji4n1ng/OpenInTerminal)):

| Cask | Old | New |
| --- | --- | --- |
| `openinterminal` | 2.3.8 | 2.3.9 |
| `openinterminal-lite` | 1.2.7 | 1.2.8 |
| `openineditor-lite` | 1.2.7 | 1.2.8 |

The 2.3.9 / 1.2.8 releases include a security fix (an AppleScript/command injection vulnerability), among other changes. Releases: [v2.3.9](https://github.com/Ji4n1ng/OpenInTerminal/releases/tag/v2.3.9) · [v1.2.8](https://github.com/Ji4n1ng/OpenInTerminal/releases/tag/v1.2.8)

**Re: notarization** ([earlier comment](https://github.com/Homebrew/homebrew-cask/pull/274726#issuecomment-4966892454) from @SMillerDev): the release artifacts have been rebuilt and **re-uploaded**. They are now **Developer ID signed and notarized by Apple** (`source=Notarized Developer ID` via `spctl -a -t exec -vv`, ticket stapled), replacing the earlier ad-hoc-signed builds. The `sha256` values in this PR have been updated to match the new notarized zips, and `brew audit --cask --online` now passes for all three casks.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

> Note: these are existing casks (version bumps only), so the "new cask" items above are not applicable.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

  Claude Code (Anthropic) was used to: bump `version` and `sha256` in the three cask files; download each release asset from its GitHub URL and confirm the `sha256` matches the uploaded artifact; and run `brew style` (no offenses) and `brew audit --cask --online` (now error-free — the new artifacts are Developer ID signed and notarized).

  Manual verification: each downloaded artifact was checked with `spctl -a -t exec -vv` and reports `accepted / source=Notarized Developer ID`, and `xcrun stapler validate` passes. The `zap` stanzas are unchanged from the existing casks — `openinterminal` trashes its Application Scripts / Group Containers / Containers / sharedfilelist / Logs / Preferences paths under `wang.jianing.app.OpenInTerminal*`; `openinterminal-lite` and `openineditor-lite` each trash their respective `~/Library/Preferences/wang.jianing.app.OpenInTerminal-Lite.plist` / `...OpenInEditor-Lite.plist`. No `zap` paths were added or modified in this PR.
