### PR TITLE
orbit 1.0.7 (new cask)

### DIFF
--- a/Casks/o/orbit.rb
+++ b/Casks/o/orbit.rb
@@ -1,0 +1,29 @@
+cask "orbit" do
+  version "1.0.7"
+  sha256 "3f0e6167d4f26edfa868c3a205d5d4523f7cd3bc9dce0c1bfde7dda27dd13612"
+
+  url "https://orbitformac.com/downloads/Orbit-#{version}.dmg"
+  name "Orbit for Mac"
+  desc "Multiple Google accounts in isolated sessions in one window"
+  homepage "https://orbitformac.com/"
+
+  livecheck do
+    url "https://orbitformac.com/appcast-v1.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :sonoma"
+
+  app "Orbit.app"
+
+  zap trash: [
+    "~/Library/Application Support/Orbit",
+    "~/Library/Caches/com.dearnode.orbit",
+    "~/Library/HTTPStorages/com.dearnode.orbit",
+    "~/Library/Preferences/com.dearnode.orbit.plist",
+    "~/Library/Saved Application State/com.dearnode.orbit.savedState",
+    "~/Library/WebKit/com.dearnode.orbit",
+  ]
+end


### PR DESCRIPTION
Add a new cask for [Orbit for Mac](https://orbitformac.com/), a native Swift app that runs each Google account in its own isolated WebKit session (separate cookie store per account) inside one window.

- Signed and notarized DMG (Developer ID: Dearnode, Inc.), served from the vendor's own domain at a versioned URL
- Sparkle auto-updates, hence `auto_updates true` and a `livecheck` against the vendor appcast
- Apple silicon only, macOS 14+, declared via `depends_on`
- `zap` paths were confirmed by installing the app, launching it, adding an account, and then listing what it actually created on disk

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I am the app's developer. I used an AI assistant to draft the cask file and this PR description. Everything below I ran and checked myself on an Apple silicon Mac:

- Ran `brew style --fix orbit` (no offenses), `brew audit --cask --online orbit` and `brew audit --cask --new orbit` (both error-free), then `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask orbit`, launched the app, and `brew uninstall --cask orbit`.
- Verified the `sha256` against the DMG published at the versioned URL, and confirmed the download is signed and notarized (`spctl -a -vv`).
- The `zap` paths are not guesses. I installed the app fresh, launched it, signed a Google account in, quit, and then checked what appeared under `~/Library`. Five of the six listed paths exist on a used install and I confirmed `zap` removes them: `Application Support/Orbit` (the SwiftData store and cached avatars), `WebKit/com.dearnode.orbit` (the per-account website data stores, which is where the bulk of the data lives), and the `Caches`, `HTTPStorages`, and `Preferences` entries for the bundle ID. The sixth, `Saved Application State`, had not been written on my machine; I have left it in because macOS creates it for apps that restore state and it costs nothing to clean up. Happy to drop that line if you would rather only list paths I have observed.

-----
