### PR TITLE
ego-lite 0.4.4.13 (new cask)

### DIFF
--- a/Casks/e/ego-lite.rb
+++ b/Casks/e/ego-lite.rb
@@ -1,7 +1,7 @@
 cask "ego-lite" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.4.4.13"
+  version "0.4.4.15"
   sha256 :no_check
 
   url "https://cdn.ego.app/channel/egobrowser_npx_referral/setup/macos/#{arch}/egolite.dmg"
@@ -10,10 +10,28 @@ cask "ego-lite" do
   homepage "https://lite.ego.app/"
 
   livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["com.citrolabs.ego.lite"]&.short_version
-    end
+    url "https://update.citrolabs.ai/service/update2", post_json: {
+      request: {
+        protocol:     "4.0",
+        acceptformat: "crx3,download,puff,run,xz,zucc",
+        arch:         arch,
+        os:           {
+          platform: "Mac OS X",
+          version:  "26.5.0",
+          arch:     arch,
+        },
+        apps:         [
+          {
+            appid:       "com.citrolabs.ego.lite",
+            version:     "0.0.0.0",
+            ap:          "lite",
+            updatecheck: {},
+          },
+        ],
+      },
+    }
+    regex(/"nextversion":"(\d+(?:\.\d+)+)"/i)
+    strategy :page_match
   end
 
   auto_updates true

--- a/Casks/e/ego-lite.rb
+++ b/Casks/e/ego-lite.rb
@@ -1,0 +1,37 @@
+cask "ego-lite" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.4.4.13"
+  sha256 :no_check
+
+  url "https://cdn.ego.app/channel/egobrowser_npx_referral/setup/macos/#{arch}/egolite.dmg"
+  name "ego lite"
+  desc "Browser for AI agents to run web automation"
+  homepage "https://lite.ego.app/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist do |items|
+      items["com.citrolabs.ego.lite"]&.short_version
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "ego lite.app"
+
+  uninstall quit: "com.citrolabs.ego.lite"
+
+  zap trash: [
+    "~/Library/Application Support/Citro Labs/ego lite",
+    "~/Library/Application Support/Citro/ego lite",
+    "~/Library/Caches/Citro Labs/ego lite",
+    "~/Library/Caches/Citro/ego lite",
+    "~/Library/Caches/com.citrolabs.ego.lite",
+    "~/Library/HTTPStorages/com.citrolabs.ego.lite",
+    "~/Library/Preferences/com.citrolabs.ego.lite.plist",
+    "~/Library/Saved Application State/com.citrolabs.ego.lite.savedState",
+    "~/Library/WebKit/com.citrolabs.ego.lite",
+  ]
+end

--- a/Casks/e/ego-lite.rb
+++ b/Casks/e/ego-lite.rb
@@ -13,21 +13,9 @@ cask "ego-lite" do
     url "https://update.citrolabs.ai/service/update2", post_json: {
       request: {
         protocol:     "4.0",
-        acceptformat: "crx3,download,puff,run,xz,zucc",
-        arch:         arch,
-        os:           {
-          platform: "Mac OS X",
-          version:  "26.5.0",
-          arch:     arch,
-        },
-        apps:         [
-          {
-            appid:       "com.citrolabs.ego.lite",
-            version:     "0.0.0.0",
-            ap:          "lite",
-            updatecheck: {},
-          },
-        ],
+        acceptformat: "download,run",
+        os:           { platform: "Mac OS X", arch: arch },
+        apps:         [{ appid: "com.citrolabs.ego.lite", updatecheck: {} }],
       },
     }
     regex(/"nextversion":"(\d+(?:\.\d+)+)"/i)


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with drafting the cask and validation workflow. I verified the bundle version, style, livecheck, audit, install/uninstall, and zap paths locally.

-----

Built and tested locally on macOS 26.5.

Adds ego lite, a browser for AI agents to run web automation.
