### PR TITLE
Add minimal-clock cask

### DIFF
--- a/Casks/m/minimal-clock.rb
+++ b/Casks/m/minimal-clock.rb
@@ -1,0 +1,22 @@
+cask "minimal-clock" do
+  version "1.0.0"
+  sha256 "a65067ecab2f31c4fda824f0e4b4666d9baf823fbf522120bc609b9c06be574a"
+
+  url "https://github.com/ImJustIvaan/Minimal-Clock-Desktop/releases/download/v#{version}/MinimalClock.dmg"
+  name "Minimal Clock"
+  desc "Minimalist clock, timer, and countdown app for the desktop"
+  homepage "https://time.ivaan.cc"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates false
+
+  app "Minimal Clock.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.minimumclock.minimalClockDesktop.plist",
+  ]
+end


### PR DESCRIPTION
### Description

Adds Minimal Clock, a minimalist clock/timer/countdown desktop app.

- Homepage: https://time.ivaan.cc
- Source: https://github.com/ImJustIvaan/Minimal-Clock-Desktop
- The DMG is built and published automatically via GitHub Actions from source.

Note: the app is not currently code-signed/notarized. Happy to notarize if that's a blocker for acceptance.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. I used an AI coding assistant (Claude) to draft the cask file and this PR from the app's own GitHub release assets. I manually verified: the SHA256 checksum against the actual `v1.0.0` release DMG, the app bundle name inside the DMG (`Minimal Clock.app`), and the `zap` stanza's plist path against the app's real bundle identifier (`com.minimumclock.minimalClockDesktop`) in source. I was unable to run `brew audit`/`brew style`/`brew install`/`brew uninstall` locally due to a broken Ruby toolchain in my sandbox (missing `sorbet-runtime` gem at a level below Homebrew's own tooling) - those checks are left unticked above rather than falsely marked, and I'd appreciate CI or a maintainer running them.

-----
