### PR TITLE
crest 4.6.0 (new cask)

### DIFF
--- a/Casks/c/crest.rb
+++ b/Casks/c/crest.rb
@@ -1,0 +1,27 @@
+cask "crest" do
+  version "4.6.0"
+  sha256 "9c4ba286ee6fc0859064969507b551f55d223950cf13bb8032b3fedfdcd877f6"
+
+  url "https://crestnotch.app/downloads/Crest-#{version}.dmg"
+  name "Crest"
+  desc "Notch panel with media controls, system stats, and a Claude co-pilot"
+  homepage "https://crestnotch.app/"
+
+  livecheck do
+    url "https://crestnotch.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Crest.app"
+
+  zap trash: [
+    "~/Library/Application Support/Crest",
+    "~/Library/Caches/com.zack40x.crest",
+    "~/Library/HTTPStorages/com.zack40x.crest",
+    "~/Library/Preferences/com.zack40x.crest.plist",
+    "~/Library/WebKit/com.zack40x.crest",
+  ]
+end


### PR DESCRIPTION
Adds [Crest](https://crestnotch.app), a notch panel app for macOS: media controls, system stats, calendar, and a built-in Claude co-pilot. Signed and notarized, distributes via a versioned DMG with Sparkle updates (livecheck resolves 4.6.0 from the appcast).

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+crest&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

This PR was prepared with AI assistance (Claude), operated by the app's developer. Verification performed on arm64 macOS 15: sha256 computed from the live artifact at the cask URL; `brew style --fix`, `brew audit --cask --online --new`, install, and uninstall all run locally (install used `--appdir` pointing at a scratch directory because a copy of the app was already present and running in `/Applications`); every `zap` path checked one by one against the `~/Library` folders of a real installation; `brew livecheck --cask crest` verified against the Sparkle appcast (resolves 4.6.0).
