### PR TITLE
crest 4.8.0 (new cask)

### DIFF
--- a/Casks/c/crest.rb
+++ b/Casks/c/crest.rb
@@ -1,0 +1,26 @@
+cask "crest" do
+  version "4.8.0"
+  sha256 "d2225caf255b410dabcea4b06533d77cd192e148ff2807c2bb7b4e6e439d29f6"
+
+  url "https://crestnotch.app/downloads/Crest-#{version}.dmg"
+  name "Crest"
+  desc "Notch companion with live modules, modes, and a Claude co-pilot"
+  homepage "https://crestnotch.app/"
+
+  livecheck do
+    url "https://crestnotch.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Crest.app"
+
+  zap trash: [
+    "~/Library/Application Support/Crest",
+    "~/Library/Caches/com.zack40x.crest",
+    "~/Library/HTTPStorages/com.zack40x.crest",
+    "~/Library/Preferences/com.zack40x.crest.plist",
+  ]
+end


### PR DESCRIPTION
Adds [Crest](https://crestnotch.app/), a notch companion for the Mac: live modules (music, calendar, a shelf with clipboard history, system stats), three switchable modes, a global quick-jot, and a Claude co-pilot with agent approvals from the notch. Signed and notarized Developer ID app distributed as a DMG with Sparkle auto-updates. Versioned download URLs are stable and release artifacts are never mutated after publishing. Similar shipped casks: notchnook, alcove, atoll.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI use: this cask and PR were prepared by an AI assistant (Claude, in Claude Code) operating this account with the maintainer's authorization; we publish Crest ourselves. Verification was performed for real on macOS 26 (arm64), not assumed: `brew style --fix` reports no offenses; `brew audit --cask --online --new` is error-free; `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask` from a local tap completed successfully (download, sha256 match, staging) followed by a successful `brew uninstall --cask`; the sha256 in the cask was computed from the live download URL; and every `zap` path was individually confirmed to exist on a machine with Crest in real use (`~/Library/Application Support/Crest`, `~/Library/Caches/com.zack40x.crest`, `~/Library/HTTPStorages/com.zack40x.crest`, `~/Library/Preferences/com.zack40x.crest.plist`).

-----