### PR TITLE
supremo 4.11.7.2990

### DIFF
--- a/Casks/s/supremo.rb
+++ b/Casks/s/supremo.rb
@@ -1,8 +1,8 @@
 cask "supremo" do
-  version "4.11.6.2934"
-  sha256 "4d7ca80358fc41de5e348d1476d2c21b536c6db4e9e857bbe499a81d1a9f0524"
+  version "4.11.7.2990"
+  sha256 "77ace7d4521b4198aa8a1c9663a3578ee44273b520c9e36c2f2924dd080480d7"
 
-  url "https://www.nanosystems.com/AutoUpdateS/macOS/stable/Supremo_#{version}.dmg",
+  url "https://assets.nanosystems.com/AutoUpdateS/macOS/standard/stable/Supremo_#{version}.dmg",
       verified: "nanosystems.com/"
   name "Supremo"
   desc "Remote desktop software"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online supremo` is error-free.
- [x] `brew style --fix supremo` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI helped identify the stale download URL and prepare the cask edit. I manually verified the stable Sparkle enclosure URL, SHA-256, DMG and app version, and the listed `zap` paths; online audit, style, install, and uninstall checks passed.

-----

Built and tested locally on macOS 26.5.1.

Uses the official Sparkle enclosure URL for 4.11.7.2990, addressing the `supremo` source failure reported in #172732.
