### PR TITLE
openclaw: update sha256

### DIFF
--- a/Casks/o/openclaw.rb
+++ b/Casks/o/openclaw.rb
@@ -1,6 +1,6 @@
 cask "openclaw" do
   version "2026.7.1"
-  sha256 "c04006cb9e0e9005feec7e4137bc3def47f9ea095780a4ef520c102a4c9eef0c"
+  sha256 "d5f02b7fecb8a6125fb1f0935226b5be7c605b264a5eee156e5539089304c930"
 
   url "https://github.com/openclaw/openclaw/releases/download/v#{version}/OpenClaw-#{version}.dmg",
       verified: "github.com/openclaw/openclaw/"

--- a/Casks/o/openclaw.rb
+++ b/Casks/o/openclaw.rb
@@ -1,6 +1,6 @@
 cask "openclaw" do
   version "2026.7.1"
-  sha256 "1497be3f52a9a597e037806877d16b3e9ef8c2e9c905392045c6e1b69b163e37"
+  sha256 "c04006cb9e0e9005feec7e4137bc3def47f9ea095780a4ef520c102a4c9eef0c"
 
   url "https://github.com/openclaw/openclaw/releases/download/v#{version}/OpenClaw-#{version}.dmg",
       verified: "github.com/openclaw/openclaw/"


### PR DESCRIPTION
The v2026.7.1 DMG was replaced after the automated cask bump, so the published checksum changed. This restores installs against the final signed and notarized artifact.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with the checksum-only update and review. I manually downloaded the current DMG, confirmed SHA-256 `d5f02b7fecb8a6125fb1f0935226b5be7c605b264a5eee156e5539089304c930`, verified the disk image, code signature, notarization, and Gatekeeper assessment, and completed audit, style, livecheck, fetch, install, and uninstall checks with a temporary app directory. The unchanged `zap` stanza was reviewed; no paths were added or modified.

-----
