### PR TITLE
termic 0.22.0 (new cask)

### DIFF
--- a/Casks/t/termic.rb
+++ b/Casks/t/termic.rb
@@ -1,0 +1,29 @@
+cask "termic" do
+  version "0.22.0"
+  sha256 "1551e976048002e9b40f93c310bab43271fc69bf3c8a1815bd8565fddc207455"
+
+  url "https://github.com/simion/termic/releases/download/v#{version}/Termic_#{version}_universal.dmg",
+      verified: "github.com/simion/termic/"
+  name "Termic"
+  desc "Run claude, gemini, and codex in parallel git worktrees"
+  homepage "https://termic.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Termic.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.simion.termic",
+    "~/Library/Application Support/termic",
+    "~/Library/Caches/com.simion.termic",
+    "~/Library/Preferences/com.simion.termic.plist",
+    "~/Library/Saved Application State/com.simion.termic.savedState",
+    "~/Library/WebKit/com.simion.termic",
+  ]
+end

--- a/Casks/t/termic.rb
+++ b/Casks/t/termic.rb
@@ -22,6 +22,8 @@ cask "termic" do
     "~/Library/Application Support/com.simion.termic",
     "~/Library/Application Support/termic",
     "~/Library/Caches/com.simion.termic",
+    "~/Library/Caches/termic",
+    "~/Library/HTTPStorages/com.simion.termic",
     "~/Library/Preferences/com.simion.termic.plist",
     "~/Library/Saved Application State/com.simion.termic.savedState",
     "~/Library/WebKit/com.simion.termic",


### PR DESCRIPTION
Termic runs claude, gemini, and codex in parallel git worktrees, each in its own embedded terminal, in one window.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

I maintain Termic, and I used Claude Code to draft the cask and this PR.

What I verified manually, on macOS 15 (arm64):

- `brew style --fix` reports no offenses, and `brew audit --new --cask --online termic` exits 0.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask termic` installs to `/Applications`, and `brew uninstall --cask termic` removes it. I ran both against this cask before the last commit, which only added `zap` paths.
- `zap` paths: I checked them against the directories Termic actually creates in `~/Library` on a machine that has run it, rather than guessing from the bundle id. That is how `~/Library/Caches/termic` and `~/Library/HTTPStorages/com.simion.termic` turned up missing from my first draft; both are now included. The bundle id is `com.simion.termic` and every path above is one Termic writes.
- The `.dmg` is a universal binary (arm64 + x86_64), Developer ID signed and notarized by Apple, app and disk image both, each with a stapled ticket. `spctl -a` reports `accepted / source=Notarized Developer ID` on a download carrying the quarantine bit, so the cask needs no Gatekeeper workaround and sets none.

Notability: 96 stars, AGPL-3.0, actively maintained. https://github.com/simion/termic

Termic currently ships from my own tap (`simion/homebrew-termic`), which I will deprecate if this lands.
