### PR TITLE
twelite-stage 202508,R2

### DIFF
--- a/Casks/t/twelite-stage.rb
+++ b/Casks/t/twelite-stage.rb
@@ -1,15 +1,19 @@
 cask "twelite-stage" do
-  version "2022_08_30"
-  sha256 "d848758cb89690200041ed910aacd2e7396148d86fbc30376af0e9b94a2af46f"
+  version "202508,R2"
+  sha256 "4643f6d2cef4a63f3cd07a72030dadf530c195a0f386b420a151dfb8900086dc"
 
-  url "https://mono-wireless.com/download/stage/MWSTAGE#{version}-mac.zip"
+  url "https://dist.twelite.net/sdk/MWSTAGE#{version.csv.first}_macOS_#{version.csv.second}.zip",
+      verified: "dist.twelite.net/sdk/"
   name "TWELITE STAGE SDK"
   desc "Evaluation & Development tools for TWELITE wireless modules"
-  homepage "https://mono-wireless.com/"
+  homepage "https://mono-wireless.com/jp/tools/stage/"
 
   livecheck do
-    url "https://mono-wireless.com/jp/products/stage/Readme-j.html"
-    regex(/MWSTAGEv?(\d+(?:[._]\d+)+)/i)
+    url "https://twelite.net/downloads.html"
+    regex(/href=.*?MWSTAGE(\d{6})_macOS_(R\d+)\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
   end
 
   depends_on :macos
@@ -17,7 +21,7 @@ cask "twelite-stage" do
   # It is an SDK with a shell-based application that
   # includes source code and other user resources.
   # It is neither an "app" nor a "suite".
-  artifact "MWSTAGE", target: "~/MWSTAGE"
+  artifact "MWSTAGE#{version.csv.first}_macOS_#{version.csv.second}", target: "~/MWSTAGE"
 
   zap trash: "~/MWSTAGE"
 end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI helped locate the current official download and update the cask. I manually verified the vendor's stable `202508_R2` release, SHA-256 and archive integrity, `brew audit`, `brew style`, livecheck, and install/uninstall on macOS 26.5.1. I also confirmed the `~/MWSTAGE` zap path did not exist before testing and was created and removed by Homebrew as expected.

-----

Updates the cask to the vendor's corrected `202508_R2` release and restores the livecheck. Addresses the `twelite-stage` source report in #172732.
