### PR TITLE
lemonade-server 11.5.1 (new cask)

### DIFF
--- a/Casks/l/lemonade-server.rb
+++ b/Casks/l/lemonade-server.rb
@@ -1,0 +1,31 @@
+cask "lemonade-server" do
+  version "11.5.1"
+  sha256 "103ccdbac67735a8c97177c6cc4af133e72dc48f1e927197042e9a3bb6a39635"
+
+  url "https://github.com/lemonade-sdk/lemonade/releases/download/v#{version}/Lemonade-#{version}-Darwin.pkg",
+      verified: "github.com/lemonade-sdk/lemonade/"
+  name "Lemonade Server"
+  desc "Local LLM server with GPU and NPU acceleration"
+  homepage "https://lemonade-server.ai/"
+
+  depends_on arch: :arm64
+  depends_on :macos
+
+  pkg "Lemonade-#{version}-Darwin.pkg"
+
+  uninstall launchctl: [
+              "com.lemonade.server",
+              "com.lemonade.tray",
+            ],
+            pkgutil:   "com.lemonade.server.*"
+
+  zap delete: [
+        "/Library/Application Support/Lemonade",
+        "/Users/Shared/lemonade-tray.err.log",
+        "/Users/Shared/lemonade-tray.out.log",
+        "/usr/local/etc/lemonade",
+        "/var/log/lemonade",
+      ],
+      trash:  "~/.cache/lemonade",
+      rmdir:  "/usr/local/share/lemonade-server"
+end


### PR DESCRIPTION
Lemonade Server is a local LLM server with GPU/NPU acceleration  (https://github.com/lemonade-sdk/lemonade , 4.9k stars / ~400 forks - well past the notability bar). It's actively maintained (v10.10.0 released this month, daily commits) and already packaged as `lemonade-server` on snap and deb, so it's a little surprising this cask was still missing - the token matches the vendor's existing package naming.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----