### PR TITLE
crest 4.9.0 (new cask)

### DIFF
--- a/Casks/c/crest.rb
+++ b/Casks/c/crest.rb
@@ -1,0 +1,26 @@
+cask "crest" do
+  version "4.8.1"
+  sha256 "982ec658b83906733dc697437319702a1e5b5ef587374ca6c963376dc0d94b23"
+
+  url "https://crestnotch.app/downloads/Crest-#{version}.dmg"
+  name "Crest"
+  desc "Notch companion with live modules, modes, and a Claude co-pilot"
+  homepage "https://crestnotch.app/"
+
+  livecheck do
+    url "https://crestnotch.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Crest.app"
+
+  zap trash: [
+    "~/Library/Application Support/Crest",
+    "~/Library/Caches/com.zack40x.crest",
+    "~/Library/HTTPStorages/com.zack40x.crest",
+    "~/Library/Preferences/com.zack40x.crest.plist",
+  ]
+end

--- a/Casks/c/crest.rb
+++ b/Casks/c/crest.rb
@@ -1,6 +1,6 @@
 cask "crest" do
-  version "4.8.1"
-  sha256 "982ec658b83906733dc697437319702a1e5b5ef587374ca6c963376dc0d94b23"
+  version "4.9.0"
+  sha256 "e9da0a362f0262531e93189ecbac7ed42d6e778dcf554295b01183ccd8a8a66a"
 
   url "https://crestnotch.app/downloads/Crest-#{version}.dmg"
   name "Crest"


### PR DESCRIPTION
Adds Crest (https://crestnotch.app/), a notch companion for macOS: live modules, three modes, a quick jot, and a built-in Claude co-pilot. Signed and notarized DMG with Sparkle auto-updates. I'm the developer of Crest and I'm submitting this myself. Similar casks already accepted: notchnook, alcove, atoll.
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
