### PR TITLE
Add Aphera 1.0.1

### DIFF
--- a/Casks/a/aphera.rb
+++ b/Casks/a/aphera.rb
@@ -1,0 +1,29 @@
+cask "aphera" do
+  version "1.0.1"
+  sha256 "738252cc00398d0f0fbe33549e21c22a48345be00e856e9661fe910ee7c7b962"
+
+  url "https://releases.aphera.app/Aphera.#{version}.dmg",
+      verified: "releases.aphera.app/"
+  name "Aphera"
+  desc "Raw photo editing software"
+  homepage "https://aphera.co/"
+
+  livecheck do
+    url "https://releases.aphera.app/latest"
+    strategy :header_match
+  end
+
+  depends_on macos: :sequoia
+
+  app "Aphera.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/co.latentco.Aphera",
+    "~/Library/Application Scripts/co.latentco.Aphera.QuickLook",
+    "~/Library/Application Support/Aphera",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.latentco.aphera.sfl*",
+    "~/Library/Containers/co.latentco.Aphera",
+    "~/Library/Containers/co.latentco.Aphera.QuickLook",
+    "~/Library/Preferences/co.latentco.Aphera.plist",
+  ]
+end


### PR DESCRIPTION
New photo editing software for macOS, for those of us who miss Aperture its the closest I've found. Been beta testing and they've finally had a stable release.

https://aphera.co

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
