### PR TITLE
willow-voice 2.3.1 (new cask)

### DIFF
--- a/Casks/w/willow-voice.rb
+++ b/Casks/w/willow-voice.rb
@@ -1,0 +1,22 @@
+cask "willow-voice" do
+  version "2.3.1"
+  sha256 "eed6e8510c641a56a2c61c97848be893c1a71b7f90d359e2887ca1f2639ea582"
+
+  url "https://github.com/LiuLawrence45/stt-sparkle-update/releases/download/v#{version}/Willow.Installer.dmg",
+      verified: "github.com/LiuLawrence45/stt-sparkle-update/"
+  name "Willow Voice"
+  desc "AI-powered voice dictation and writing assistant"
+  homepage "https://willowvoice.com/"
+
+  livecheck do
+    url "https://liulawrence45.github.io/stt-sparkle-update/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "Willow Voice.app"
+
+  uninstall quit: "com.seewillow.WillowMac"
+end

--- a/Casks/w/willow-voice.rb
+++ b/Casks/w/willow-voice.rb
@@ -19,4 +19,14 @@ cask "willow-voice" do
   app "Willow Voice.app"
 
   uninstall quit: "com.seewillow.WillowMac"
+
+  zap trash: [
+    "~/Library/Application Support/com.seewillow.WillowMac",
+    "~/Library/Application Support/CrashReporter/Willow Voice_*.plist",
+    "~/Library/Caches/com.seewillow.WillowMac",
+    "~/Library/Caches/SentryCrash/Willow Voice",
+    "~/Library/HTTPStorages/com.seewillow.WillowMac",
+    "~/Library/HTTPStorages/com.seewillow.WillowMac.binarycookies",
+    "~/Library/Preferences/com.seewillow.WillowMac.plist",
+  ]
 end


### PR DESCRIPTION
Adds Willow Voice, a signed and notarized macOS voice dictation and writing app. The cask installs the stable 2.3.1 DMG; Willow continues to self-update through Sparkle.

Built and tested locally on macOS 26.2.

`brew audit --cask --new --online willow-voice` reports only the GitHub notability threshold for the binary-only release repository. Willow has an established public product website, so this submission requests the documented popular-app/binary-host exception.

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. OpenAI Codex assisted with drafting and validating the cask. The release URL, checksum, Sparkle livecheck, bundle identifier, code signature, notarization, isolated install/uninstall, and zap paths were manually verified. Debug, Electron, and legacy bundle paths were excluded from the zap stanza.

-----
