### PR TITLE
vmlx 1.6.9

### DIFF
--- a/Casks/v/vmlx.rb
+++ b/Casks/v/vmlx.rb
@@ -1,9 +1,9 @@
 cask "vmlx" do
-  version "1.6.3"
-  sha256 "eda146140d76e6d19fd98b1d7143c34678ee0a3c4aefdbd97b615420436efeca"
+  version "1.6.9"
+  sha256 "16dced0093fe142554d0236ea21c0b9aed3ed5f36d02d5bceac83569df5d6f62"
 
-  url "https://github.com/jjang-ai/vmlx/releases/download/v#{version}/vMLX-#{version}-sequoia-arm64.dmg",
-      verified: "github.com/jjang-ai/vmlx/"
+  url "https://github.com/jjang-ai/mlxstudio/releases/download/v#{version}/vMLX-#{version}-sequoia-arm64.dmg",
+      verified: "github.com/jjang-ai/mlxstudio/"
   name "vMLX"
   desc "Run local AI models on Apple Silicon"
   homepage "https://mlx.studio/"


### PR DESCRIPTION
Update `vmlx` to `1.6.9`.

This also retargets the release URL from `jjang-ai/vmlx` to `jjang-ai/mlxstudio` because the current `jjang-ai/vmlx` `v1.6.9` release has no attached DMG assets, while `jjang-ai/mlxstudio` is the repository publishing the current Sequoia/Tahoe app DMGs.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assistance was used to gather current release/Homebrew state, prepare the cask edit, and organize the verification notes. I manually verified the public release state and cask behavior with:

- No open Homebrew PR for `vmlx 1.6.9`.
- Current `jjang-ai/mlxstudio` release asset exists: `vMLX-1.6.9-sequoia-arm64.dmg`.
- Downloaded the DMG from `jjang-ai/mlxstudio`.
- SHA256 matched upstream release notes: `16dced0093fe142554d0236ea21c0b9aed3ed5f36d02d5bceac83569df5d6f62`.
- Mounted DMG contains `vMLX.app`.
- `brew style --fix vmlx` passed.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --cask --online vmlx` passed and downloaded/extracted the candidate DMG.

This is an existing cask update, so I did not run the new-cask-only install/uninstall checklist. I also left the existing `zap` stanza unchanged.

-----
