### PR TITLE
koe 1.0.23 (new cask)

### DIFF
--- a/Casks/k/koe.rb
+++ b/Casks/k/koe.rb
@@ -1,0 +1,24 @@
+cask "koe" do
+  version "1.0.23"
+  sha256 "00fdd20292730a788c8d2bb9b9b79f0684bf74db8ba2990942c7a644925c7462"
+
+  url "https://github.com/missuo/koe/releases/download/v#{version}/Koe-macOS-arm64.zip"
+  name "Koe"
+  desc "Zero-GUI voice input tool"
+  homepage "https://github.com/missuo/koe"
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "Koe.app"
+  binary "#{appdir}/Koe.app/Contents/MacOS/koe-cli", target: "koe"
+
+  zap trash: [
+    "~/.koe",
+    "~/Library/Caches/nz.owo.koe",
+    "~/Library/HTTPStorages/nz.owo.koe",
+    "~/Library/HTTPStorages/nz.owo.koe.binarycookies",
+    "~/Library/Preferences/nz.owo.koe.plist",
+  ]
+end


### PR DESCRIPTION
Koe is a zero-GUI voice input tool for macOS ([missuo/koe](https://github.com/missuo/koe), 366 stars). The app is Developer ID signed and notarized, distributed via GitHub releases.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+koe&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Claude Code (by the app's author) was used to adapt the cask from our existing third-party tap and prepare this PR. All checklist items above were actually executed locally on an arm64 Sonoma+ machine: `brew audit --cask --new --online koe`, `brew style`, install, and uninstall all passed. The `zap` stanza covers `~/.koe` (the app's config/data directory) plus the standard `nz.owo.koe` Caches/HTTPStorages/Preferences paths flagged by `brew generate-zap`, all verified to exist on the author's machine.
