### PR TITLE
bosun 1.4.0 (new cask)

### DIFF
--- a/Casks/b/bosun.rb
+++ b/Casks/b/bosun.rb
@@ -1,0 +1,29 @@
+cask "bosun" do
+  version "1.4.0"
+  sha256 "cccf6078ec65b63b41cebbccc7ee0ce336e3188188adc6d5329500b477d7051e"
+
+  url "https://dl.bosun.dev/Bosun-#{version}.dmg"
+  name "Bosun"
+  desc "Menu bar network port, tunnel, VPN, and Docker visibility tool"
+  homepage "https://bosun.dev/"
+
+  livecheck do
+    url "https://dl.bosun.dev/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Bosun.app"
+
+  uninstall quit: "dev.cuprite.bosun"
+
+  zap trash: [
+    "~/Library/Application Support/Bosun",
+    "~/Library/Application Support/CrashReporter/Bosun_*.plist",
+    "~/Library/Caches/dev.cuprite.bosun",
+    "~/Library/HTTPStorages/dev.cuprite.bosun",
+    "~/Library/Preferences/dev.cuprite.bosun.plist",
+  ]
+end


### PR DESCRIPTION
Resubmission of #273146. That PR was auto-closed for an incomplete template; the real blocker was the `brew audit --cask --new` notability check against the separate release-hosting repo. It is now resolved — the `.dmg` and Sparkle appcast are served from the vendor's own domain (`dl.bosun.dev`), so the audit passes with no notability exception needed. Built and tested locally on macOS 26.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Claude Code assisted with preparing this cask: it bumped `version` to 1.4.0 and `sha256` to the notarized DMG's checksum, and set the livecheck to `strategy :sparkle, &:short_version` so it returns the appcast's short version (`1.4.0`) instead of `1.4.0,6`. All checks were run locally (Homebrew 6.0.8, macOS 26): `brew audit --cask --new`, `brew audit --cask --online`, and `brew style` pass with no offenses, and a `brew install`/`brew uninstall` cycle (into a temp `--appdir`) installed and removed Bosun.app 1.4.0 cleanly. As the app's developer I confirmed the download at `dl.bosun.dev` is my own Developer ID-signed, notarized and stapled build, and that the `zap` paths match the app's bundle identifier `dev.cuprite.bosun` and the directories it creates.

-----
