### PR TITLE
scroll-reverser: add auto_updates

### DIFF
--- a/Casks/s/scroll-reverser.rb
+++ b/Casks/s/scroll-reverser.rb
@@ -12,6 +12,7 @@ cask "scroll-reverser" do
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on macos: :ventura
 
   app "Scroll Reverser.app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Related to #170994.

Marks Scroll Reverser as self-updating. Its bundled Sparkle updater starts with the app and automatic checks use the cask's appcast; `brew livecheck --cask --autobump --json scroll-reverser` confirmed current/latest version 1.9.

AI assistance: OpenAI Codex was used for policy and upstream source review and to prepare this one-line change. I verified the official updater configuration, ran cask audit and style, installed the cask, inspected the installed 1.9 app's Sparkle framework and updater settings, and uninstalled it. The existing zap paths were reviewed against the installed bundle identifier `com.pilotmoon.scroll-reverser`.
