### PR TITLE
sol: add auto_updates

### DIFF
--- a/Casks/s/sol.rb
+++ b/Casks/s/sol.rb
@@ -12,6 +12,7 @@ cask "sol" do
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on macos: :sonoma
 
   app "Sol.app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Related to #170994.

Marks Sol as self-updating. Its source starts `SPUStandardUpdaterController` with the app, and the installed app bundles Sparkle 2.9.3 with the same `SUFeedURL` used by the cask plus a `SUPublicEDKey`. Livecheck confirmed current/latest version 2.1.346.

AI assistance: OpenAI Codex was used for policy and upstream source review and to prepare this one-line change. I ran cask audit, style, and livecheck; installed the cask; inspected the installed version, primary and login-helper bundle identifiers, Sparkle framework, feed URL, and public update key; and uninstalled it. The existing zap paths were reviewed against `com.ospfranco.sol`, `com.ospfranco.sol-LaunchAtLoginHelper`, and the corresponding support, HTTP storage, and preference locations.

Additional upstream-artifact observation: the official 2.1.346 asset matched its published SHA-256 and installed successfully, but `codesign --verify --strict` reports the original app bundle signature as modified for both arm64 and x86_64. This metadata-only PR does not alter that asset.
