### PR TITLE
Add agent-island 1.6.1

### DIFF
--- a/Casks/a/agent-island.rb
+++ b/Casks/a/agent-island.rb
@@ -1,0 +1,25 @@
+cask "agent-island" do
+  version "1.6.1"
+  sha256 "0b1738df96890b0d93a91587ad5393507e6fa32961f35c510a9f41c730572ec6"
+
+  url "https://github.com/tristan666666/agent-island/releases/download/v#{version}/AgentIsland-#{version}.dmg",
+      verified: "github.com/tristan666666/agent-island/"
+  name "Agent Island"
+  desc "Local status companion for Claude Code and Codex sessions"
+  homepage "https://agent-island.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "AgentIsland.app"
+
+  zap trash: [
+    "~/Library/Application Support/AgentIsland",
+    "~/Library/Caches/dev.agentisland.AgentIsland",
+    "~/Library/Preferences/dev.agentisland.AgentIsland.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you are editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with the initial cask and PR text. I manually verified the release URL and SHA-256, inspected the app bundle, confirmed the universal x86_64/arm64 binary, bundle identifier `dev.agentisland.AgentIsland`, and minimum macOS 13.0, then ran the style, audit, real install, and uninstall checks above. I also verified these zap paths against the application bundle and local behavior:

- `~/Library/Application Support/AgentIsland`
- `~/Library/Caches/dev.agentisland.AgentIsland`
- `~/Library/Preferences/dev.agentisland.AgentIsland.plist`

-----

Adds the Agent Island macOS cask from the signed and notarized v1.6.1 GitHub release.