### PR TITLE
prisma-access-browser 150.49.5.129 (new cask)

### DIFF
--- a/Casks/p/prisma-access-browser.rb
+++ b/Casks/p/prisma-access-browser.rb
@@ -48,7 +48,9 @@ cask "prisma-access-browser" do
       ],
       trash:  [
         "~/Library/Application Support/PAB",
+        "~/Library/Caches/com.paloaltonetworks.PrismaAccessBrowserUpdater",
         "~/Library/Caches/PAB",
+        "~/Library/HTTPStorages/com.paloaltonetworks.PrismaAccessBrowserUpdater",
         "~/Library/PAB",
       ]
 end

--- a/Casks/p/prisma-access-browser.rb
+++ b/Casks/p/prisma-access-browser.rb
@@ -8,15 +8,22 @@ cask "prisma-access-browser" do
   desc "Secure enterprise browser with built-in threat and data protection"
   homepage "https://get.pabrowser.com/welcome"
 
+  # The upstream appcast uses "stable" and "lts" channels, with older releases
+  # in the default channel as well. It's possible for a release to be in both
+  # the "stable" and "lts" channels, so this works with releases in the "stable"
+  # or default channels.
   livecheck do
     url "https://releases.talon-sec.com/api/v1/appcast.xml?appid=%7Bdfef2477-4f0e-454b-bc0d-03ce61074e4c%7D&platform=mac&architecture=universal&channel=packaged"
-    strategy :sparkle do |items|
-      item = items.find do |i|
-        i.channel != "lts" && i.url&.match?(/-\d+(?:\.\d+)+-\h+\.pkg/i)
+    regex(/[._-]v?(\d+(?:\.\d+)+)[._-](\h+)\.pkg/i)
+    strategy :sparkle do |items, regex|
+      item = items.find do |item|
+        (item_channel = item.channel) == "stable" || item_channel.nil?
       end
-      next if item.blank?
+      next unless item
 
-      match = item.url.match(/-(\d+(?:\.\d+)+)-(\h+)\.pkg/i)
+      match = item.url&.match(regex)
+      next unless match
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/p/prisma-access-browser.rb
+++ b/Casks/p/prisma-access-browser.rb
@@ -1,0 +1,47 @@
+cask "prisma-access-browser" do
+  version "150.49.5.129,6a8a165d"
+  sha256 "4bcf5d4532851a02a62cbcd84adcb3ca50cc1b2670102f16639e78f0a2672943"
+
+  url "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-#{version.csv.first}-#{version.csv.second}.pkg",
+      verified: "updates.talon-sec.com/"
+  name "Prisma Access Browser"
+  desc "Secure enterprise browser with built-in threat and data protection"
+  homepage "https://get.pabrowser.com/welcome"
+
+  livecheck do
+    url "https://releases.talon-sec.com/api/v1/appcast.xml?appid=%7Bdfef2477-4f0e-454b-bc0d-03ce61074e4c%7D&platform=mac&architecture=universal&channel=packaged"
+    strategy :sparkle do |items|
+      item = items.find do |i|
+        i.channel != "lts" && i.url&.match?(/-\d+(?:\.\d+)+-\h+\.pkg/i)
+      end
+      next if item.blank?
+
+      match = item.url.match(/-(\d+(?:\.\d+)+)-(\h+)\.pkg/i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  pkg "PrismaBrowser-universal.pkg"
+
+  uninstall launchctl: [
+              "com.paloaltonetworks.prismaaccessbrowserupdater.agent",
+              "com.paloaltonetworks.prismaaccessbrowserupdater.daemon",
+              "com.paloaltonetworks.PrismaAccessBrowserUpdater.wake.system",
+              "com.paloaltonetworks.prismaaccessbrowserupdater.xpcservice",
+            ],
+            quit:      "com.talon-sec.Work",
+            pkgutil:   "com.talon-sec.Work"
+
+  zap delete: [
+        "/Library/Application Support/PAB",
+        "/Library/PAB",
+      ],
+      trash:  [
+        "~/Library/Application Support/PAB",
+        "~/Library/Caches/PAB",
+        "~/Library/PAB",
+      ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `prisma-access-browser` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online prisma-access-browser` is error-free.
- [x] `brew style --fix prisma-access-browser` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new prisma-access-browser` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask prisma-access-browser` worked successfully.
- [x] `brew uninstall --cask prisma-access-browser` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

AI (Claude) assisted in creating this PR: it researched the download URL, version, bundle identifier, minimum macOS, and pkg receipt, and drafted the cask DSL. I reviewed the result, ran brew style --fix and brew audit --cask --strict --online --new with no offenses or errors, and installed, reinstalled, uninstalled, and zapped the cask locally on macOS to verify the artifact, a clean uninstall, an idempotent reinstall, and the zap stanza paths.
