### PR TITLE
amore: add amore CLI binary

### DIFF
--- a/Casks/a/amore.rb
+++ b/Casks/a/amore.rb
@@ -16,6 +16,7 @@ cask "amore" do
   depends_on macos: :sequoia
 
   app "Amore.app"
+  binary "#{appdir}/Amore.app/Contents/MacOS/AmoreCLI", target: "amore"
 
   zap trash: [
     "~/Library/Application Support/Amore",


### PR DESCRIPTION
Exposes the bundled `AmoreCLI` executable as the `amore` command.

I tested this locally by running:

`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask amore` followed by `amore status`, which worked as expected.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----