### PR TITLE
openwhispr 1.7.5 (new cask)

### DIFF
--- a/Casks/o/openwhispr.rb
+++ b/Casks/o/openwhispr.rb
@@ -1,0 +1,29 @@
+cask "openwhispr" do
+  arch arm: "-arm64", intel: ""
+
+  version "1.7.5"
+  sha256 arm:   "7a26163a30d2a368a8a4d4d6554aa5fd779cda17f01c412bcfaa653ed62d2c92",
+         intel: "af49a5454f512822e2f8b927aa9ff572cded1f735bd1fbc6c4c08a9ca62a594d"
+
+  url "https://github.com/OpenWhispr/openwhispr/releases/download/v#{version}/OpenWhispr-#{version}#{arch}.dmg"
+  name "OpenWhispr"
+  desc "Privacy-first voice-to-text dictation with AI agents"
+  homepage "https://github.com/OpenWhispr/openwhispr"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "OpenWhispr.app"
+
+  zap trash: [
+    "~/Library/Application Support/open-whispr",
+    "~/Library/HTTPStorages/com.gizmolabs.openwhispr",
+    "~/Library/Preferences/ByHost/com.gizmolabs.openwhispr.ShipIt.*.plist",
+    "~/Library/Preferences/com.gizmolabs.openwhispr.plist",
+  ]
+end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

**AI usage:** This cask (`openwhispr`) was drafted with the assistance of Claude (Anthropic), which also ran the verification commands below.

**Manual verification performed:**
- `brew style openwhispr` — no offenses. `brew audit --cask --new openwhispr` and `brew audit --cask --strict --online openwhispr` — both error-free.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask openwhispr` installs cleanly; the app is signed **and notarized** (Developer ID Application: Gizmo Labs Inc., Team `T832773L2J`) — `spctl -a -t install` returns *accepted / Notarized Developer ID*.
- `brew uninstall --cask openwhispr` removes cleanly.
- **`zap` paths verified against a real install (not guessed):** the app was launched, its on-disk artifacts enumerated under `~/Library`, and `brew uninstall --zap` confirmed to remove exactly these four and leave nothing behind:
  - `~/Library/Application Support/open-whispr` — Electron `userData` dir (confirmed via the running process's `--user-data-dir`; note the hyphenated name, not `OpenWhispr`)
  - `~/Library/HTTPStorages/com.gizmolabs.openwhispr`
  - `~/Library/Preferences/ByHost/com.gizmolabs.openwhispr.ShipIt.*.plist` — Squirrel auto-updater state
  - `~/Library/Preferences/com.gizmolabs.openwhispr.plist`

Notes: OpenWhispr is MIT-licensed with 4.5k+ stars. This supersedes #265797 (closed unmerged by its own author, not refused) and addresses the packaging request in OpenWhispr/openwhispr#681. It also replaces #275230, which the template bot auto-closed and then could not reopen because the branch had been force-pushed (GitHub 422) — this PR carries the completed template from the start.
