### PR TITLE
openwhispr 1.7.6 (new cask)

### DIFF
--- a/Casks/o/openwhispr.rb
+++ b/Casks/o/openwhispr.rb
@@ -1,0 +1,35 @@
+cask "openwhispr" do
+  arch arm: "-arm64", intel: ""
+
+  version "1.7.5"
+  sha256 arm:   "7a26163a30d2a368a8a4d4d6554aa5fd779cda17f01c412bcfaa653ed62d2c92",
+         intel: "af49a5454f512822e2f8b927aa9ff572cded1f735bd1fbc6c4c08a9ca62a594d"
+
+  url "https://github.com/OpenWhispr/openwhispr/releases/download/v#{version}/OpenWhispr-#{version}#{arch}.dmg"
+  name "OpenWhispr"
+  desc "Privacy-first voice-to-text dictation with AI agents"
+  homepage "https://github.com/OpenWhispr/openwhispr"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "OpenWhispr.app"
+
+  zap trash: [
+    "~/.cache/openwhispr",
+    "~/.openwhispr",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.gizmolabs.openwhispr.sfl*",
+    "~/Library/Application Support/open-whispr",
+    "~/Library/Caches/com.gizmolabs.openwhispr",
+    "~/Library/Caches/com.gizmolabs.openwhispr.ShipIt",
+    "~/Library/Caches/open-whispr-updater",
+    "~/Library/HTTPStorages/com.gizmolabs.openwhispr",
+    "~/Library/Preferences/ByHost/com.gizmolabs.openwhispr.ShipIt.*.plist",
+    "~/Library/Preferences/com.gizmolabs.openwhispr.plist",
+  ]
+end

--- a/Casks/o/openwhispr.rb
+++ b/Casks/o/openwhispr.rb
@@ -1,9 +1,9 @@
 cask "openwhispr" do
   arch arm: "-arm64", intel: ""
 
-  version "1.7.5"
-  sha256 arm:   "7a26163a30d2a368a8a4d4d6554aa5fd779cda17f01c412bcfaa653ed62d2c92",
-         intel: "af49a5454f512822e2f8b927aa9ff572cded1f735bd1fbc6c4c08a9ca62a594d"
+  version "1.7.6"
+  sha256 arm:   "c4114cb665c25a4e1e0a10b59272d5b2af0155f422a8c4550f23656474b648c2",
+         intel: "4585922bc52eab9a3dcfd456a52c0d2e34bf1edc54c4035df68cfac78b72969d"
 
   url "https://github.com/OpenWhispr/openwhispr/releases/download/v#{version}/OpenWhispr-#{version}#{arch}.dmg"
   name "OpenWhispr"

--- a/Casks/o/openwhispr.rb
+++ b/Casks/o/openwhispr.rb
@@ -10,11 +10,6 @@ cask "openwhispr" do
   desc "Privacy-first voice-to-text dictation with AI agents"
   homepage "https://github.com/OpenWhispr/openwhispr"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
   depends_on macos: :monterey
 
@@ -31,5 +26,6 @@ cask "openwhispr" do
     "~/Library/HTTPStorages/com.gizmolabs.openwhispr",
     "~/Library/Preferences/ByHost/com.gizmolabs.openwhispr.ShipIt.*.plist",
     "~/Library/Preferences/com.gizmolabs.openwhispr.plist",
+    "~/Library/Saved Application State/com.gizmolabs.openwhispr.savedState",
   ]
 end


### PR DESCRIPTION
This is a cask for the [OpenWhispr](https://openwhispr.com/) Mac application. I personally installed the application with `brew` per the guide, and ran the application, changing its settings and doing a speech-to-text conversion to check the proper functionality. I uninstalled the application, and manually investigated and verified the `zap` paths myself against a live install on Apple Silicon; worth mentioning, the app is also notarized.

The app spreads its data across several locations. Its models (Whisper/embedding) and a local Qdrant vector database live under `~/.cache/openwhispr`; its Electron user-data directory (SQLite databases, keys, logs) is at `~/Library/Application Support/open-whispr`; and it also creates a marker directory at `~/.openwhispr` plus a recent-documents shared-file-list entry. Because the app auto-updates, I additionally installed an older release and let it update in place to capture the updater's footprint: electron-updater downloads into `~/Library/Caches/open-whispr-updater` and hands off to Squirrel.Mac for the install, which creates `~/Library/Caches/com.gizmolabs.openwhispr`, `~/Library/Caches/com.gizmolabs.openwhispr.ShipIt`, `~/Library/HTTPStorages/com.gizmolabs.openwhispr`, and a per-machine `ShipIt` plist under `~/Library/Preferences/ByHost`. The `zap` stanza covers every path I observed the app create.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used Claude Code to help author the cask and to script the investigation of the app's on-disk footprint. However, I ran every command myself on my own Apple Silicon Mac and personally verified the results. In particular, I determined the `zap` paths empirically: I installed the app, launched it and used it, then installed an older release and drove the in-app auto-update to 1.7.5 to observe exactly which paths the updater creates (the Squirrel/`ShipIt`, `HTTPStorages`, and `open-whispr-updater` cache paths only appear during a real update, not a fresh install). I cross-checked the result against `brew generate-zap` and confirmed the stanza covers every path I observed the app create.

-----
