### PR TITLE
Update oscar.rb

### DIFF
--- a/Casks/o/oscar.rb
+++ b/Casks/o/oscar.rb
@@ -6,7 +6,7 @@ cask "oscar" do
          intel: "16d518bb04e32cf58d748cb4f05e5c703a36f3da654d70b77896cebd1683c5da"
 
   on_arm do
-    url "https://www.sleepfiles.com/OSCAR/#{version}/OSCAR-#{version}-#{arch}.dmg"
+    url "https://www.sleepfiles.com/OSCAR/#{version}/OSCAR#{version.major_minor.no_dots}-#{version}-#{arch}.dmg"
   end
   on_intel do
     url "https://www.sleepfiles.com/OSCAR/#{version}/OSCAR#{version.major_minor.no_dots}-#{version}-#{arch}.dmg"
@@ -20,8 +20,6 @@ cask "oscar" do
     url :homepage
     regex(%r{href=.*?/OSCAR.*?v?(\d+(?:\.\d+)+)(?:[._-]#{arch})?\.dmg}i)
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: :ventura
 

--- a/Casks/o/oscar.rb
+++ b/Casks/o/oscar.rb
@@ -2,8 +2,8 @@ cask "oscar" do
   arch arm: "ARM", intel: "Intel"
 
   version "2.0.1"
-  sha256 arm:   "c52994d58254242c58a9d532d03753bb597575272c1a6fe3129d79f686c05f86",
-         intel: "16d518bb04e32cf58d748cb4f05e5c703a36f3da654d70b77896cebd1683c5da"
+  sha256 arm:   "78cd674ba7755ddcf505dd870c6e1d366c6e658a57482d91593eb191e611c769",
+         intel: "b44aedb2855583457985fd9fc4467983254a24ce51bfb43134e72be64e12194e"
 
   on_arm do
     url "https://www.sleepfiles.com/OSCAR/#{version}/OSCAR#{version.major_minor.no_dots}-#{version}-#{arch}.dmg"


### PR DESCRIPTION
The OSCAR developer has notarized both the ARM and Intel builds.

Gatekeeper accepts both versions:

$ spctl --assess --verbose=4 /Applications/OSCAR20.app
/Applications/OSCAR20.app: accepted
source=Notarized Developer ID

The previous deprecation reason (`because: :unnotarized`) no longer applies.
This PR updates the cask to the current notarized version and removes the deprecate stanza.

"brew audit --cask --online oscar" will pass, once merged
 - Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!
Remove the deprecate/disable stanza or update the deprecate/disable reason.
oscar
  * Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!
    Remove the deprecate/disable stanza or update the deprecate/disable reason.
Error: 1 problem in 1 cask detected.

"brew style --fix oscar"
1 file inspected, no offenses detected

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
