### PR TITLE
shearwater-cloud: update checksum

### DIFF
--- a/Casks/s/shearwater-cloud.rb
+++ b/Casks/s/shearwater-cloud.rb
@@ -1,6 +1,6 @@
 cask "shearwater-cloud" do
   version "2.12.10"
-  sha256 "193d305b331eb1720b07fcca54af6b0fd1ec8d963ae268dccf027830e6e89a4b"
+  sha256 "f5c19f5f61db66a03cb9f71eaedae3a4a5f58c61a306c3403b61d05e868cb79e"
 
   url "https://downloads.shearwater.com/livedownloads/ShearwaterCloudInstaller_#{version}.dmg"
   name "Shearwater Cloud"


### PR DESCRIPTION
The vendor replaced the 2.12.10 DMG; this updates the checksum to match the current official artifact.

Built and tested locally on macOS 26.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online shearwater-cloud` is error-free.
- [x] `brew style --fix Casks/s/shearwater-cloud.rb` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new shearwater-cloud` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask shearwater-cloud` worked successfully.
- [ ] `brew uninstall --cask shearwater-cloud` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assisted with diagnosing the checksum mismatch and preparing the one-line update. I manually verified the official download's SHA-256, DMG integrity, app version, the unchanged zap path, and the audit, style, install, and uninstall results.

-----
