### PR TITLE
fing 4.0.3

### DIFF
--- a/Casks/f/fing.rb
+++ b/Casks/f/fing.rb
@@ -1,16 +1,29 @@
 cask "fing" do
-  version "3.10.1"
-  sha256 "f0ccdf3b1a57117dc08e4e6970aded3f453eae75d1e6d8b28aa7a590381eeacf"
+  on_arm do
+    version "4.0.3"
+    sha256 "a82600762d494916fe0caed28621123d26f56bf5e369c76b2460661919c3d1bb"
 
-  url "https://get.fing.com/fing-desktop-releases/mac/Fing-#{version}.dmg"
+    url "https://get.fing.com/fing-desktop-releases/mac/Fing-#{version}-mac.zip"
+
+    livecheck do
+      url "https://get.fing.com/fing-desktop-releases/mac/latest-mac.yml"
+      strategy :electron_builder
+    end
+  end
+  on_intel do
+    version "3.10.1"
+    sha256 "f0ccdf3b1a57117dc08e4e6970aded3f453eae75d1e6d8b28aa7a590381eeacf"
+
+    url "https://get.fing.com/fing-desktop-releases/mac/Fing-#{version}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+
   name "Fing Desktop"
   desc "Network scanner"
-  homepage "https://www.fing.com/products/fing-desktop"
-
-  livecheck do
-    url "https://get.fing.com/fing-desktop-releases/mac/latest-mac.yml"
-    strategy :electron_builder
-  end
+  homepage "https://www.fing.com/desktop/"
 
   depends_on :macos
 
@@ -24,8 +37,4 @@ cask "fing" do
     "~/Library/Preferences/com.fing.app.plist",
     "~/Library/Saved Application State/com.fing.app.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`fing` is autobumped but the workflow failed to update to version 4.0.3 because the URL for the v4 dmg file is unversioned. The YAML file in the `livecheck` block references a versioned zip file, so this updates the version and adjusts the asset `url`. Versions from 4.0 onward are ARM-only and upstream directs Intel users to the latest 3.10 version, so I've kept the previous version for Intel.