### PR TITLE
quicklook-video: Add v2 for older macOS

### DIFF
--- a/Casks/q/quicklook-video.rb
+++ b/Casks/q/quicklook-video.rb
@@ -1,23 +1,41 @@
 cask "quicklook-video" do
-  version "3.10"
-  sha256 "42fb3382292ecec65971a7e3cc09a86e2d95ca814a2fe03f8170cfd9b505c541"
+  on_sequoia :or_newer do
+    version "3.10"
+    sha256 "42fb3382292ecec65971a7e3cc09a86e2d95ca814a2fe03f8170cfd9b505c541"
+
+    # The version in the tag and asset file name doesn't include dots, so we match
+    # the version from the release title (e.g. "Release 1.23").
+    livecheck do
+      url :url
+      regex(/v?(\d+(?:\.\d+)+)/i)
+      strategy :github_latest do |json, regex|
+        json["name"]&.[](regex, 1)
+      end
+    end
+  end
+  on_sonoma :or_older do
+    version "2.24"
+    sha256 "56f007628967808f2b70fda9cd11ae678181ef22107903eb59e419c0f9143348"
+
+    # The version in the tag and asset file name doesn't include dots, so we match
+    # the version from the release title (e.g. "Release 1.23").
+    livecheck do
+      url :url
+      regex(/v?(2(?:\.\d+)+)/i)
+      strategy :github_releases do |json, regex|
+        json.map do |release|
+          release["name"]&.[](regex, 1)
+        end.flatten
+      end
+    end
+  end
 
   url "https://github.com/Marginal/QuickLookVideo/releases/download/rel-#{version.no_dots}/QLVideo_#{version.no_dots}.dmg"
   name "QuickLook Video"
   desc "Thumbnails, static previews, cover art and metadata for video files"
   homepage "https://github.com/Marginal/QuickLookVideo"
 
-  # The version in the tag and asset file name doesn't include dots, so we match
-  # the version from the release title (e.g. "Release 1.23").
-  livecheck do
-    url :url
-    regex(/v?(\d+(?:\.\d+)+)/i)
-    strategy :github_latest do |json, regex|
-      json["name"]&.[](regex, 1)
-    end
-  end
-
-  depends_on macos: :tahoe
+  depends_on macos: :monterey
 
   app "QuickLook Video.app"
 


### PR DESCRIPTION
[v3](https://formulae.brew.sh/cask/quicklook-video) is supported on Sequoia (the latest release is an exception), but doesn't work in practice.

https://github.com/Marginal/QuickLookVideo/issues/201#issuecomment-4967671690:

> The APIs that 3.x uses to support thumbnails are supposed to work on macOS 15 but don't work in practice, so you're unlikely to see any thumbnails at all. Please use version 2.x.

Future (and previous) v3 releases will support Sequoia though, so add v2 to the cask for macOS versions between Monterey and Sonoma.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
