### PR TITLE
pixpin 3.3.5.7

### DIFF
--- a/Casks/p/pixpin.rb
+++ b/Casks/p/pixpin.rb
@@ -1,8 +1,8 @@
 cask "pixpin" do
-  version "3.2.3.1"
-  sha256 "e33db6e65fd967fa863dd4ca259366a7eab75e38a2c102584ce5373fff2614b4"
+  version "3.3.5.7"
+  sha256 "302cdbff56a68f7faf8957da3e9467a22ee49ea78fcc4e2bd88fb3341fad229e"
 
-  url "https://download.pixpin.cn/PixPin_cn_zh-cn_#{version}_uni.dmg"
+  url "https://down.pixpin.cn/PixPin_mac_#{version}_uni.dmg"
   name "PixPin"
   desc "Screenshot tool"
   homepage "https://pixpin.cn/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`pixpin` is autobumped but the workflow failed to update to version 3.3.5.7 because the file name format changed. This updates the version and adjusts the `url` accordingly. Upstream provides three different URLs for the dmg file and I've switched this to use the down.pixpin.cn URL (linked from the first-party download page), as the download.pixpin.cn URL was hanging locally in `brew audit`.