### PR TITLE
energia: disable

### DIFF
--- a/Casks/e/energia.rb
+++ b/Casks/e/energia.rb
@@ -8,10 +8,7 @@ cask "energia" do
   desc "Electronics prototyping platform"
   homepage "https://energia.nu/"
 
-  livecheck do
-    url "https://energia.nu/download/"
-    regex(/file=energia[._-]?v?(\d+(?:\.[\dE]+)+)[._-]macosx[._-]signed\.zip/i)
-  end
+  disable! date: "2026-07-16", because: :no_longer_available
 
   depends_on :macos
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Homebrew's scheduled online check reports that the Energia 1.8.10E23 macOS archive now returns HTTP 403. The first-party download page still links to the same inaccessible S3 object, and the upstream GitHub repository has no binary releases and was last pushed in 2022.

This disables the cask as `:no_longer_available` and removes the livecheck block, since there is no installable artifact left to discover.

Validation performed by the AI agent:

- `brew style --fix Casks/e/energia.rb` — one file inspected, no offenses
- `brew audit --cask energia` — passed
- `brew audit --cask --strict energia` — passed
- `git diff --check` — passed
- `brew audit --cask --online energia` — intentionally left unchecked; it reproduces the upstream archive's HTTP 403, which is the reason for this change
- Direct requests to both the cask URL and the first-party download-page redirect reproduce HTTP 403

The existing zap paths are unchanged:

- `~/Library/Energia15`
- `~/Library/Saved Application State/nu.energia.Energia.savedState`

Codex was used to identify the scheduled failure, read the contribution policy, research upstream availability, prepare the one-file change, and run the checks above. This PR is opened as a Draft because the account holder has not yet personally re-run the verification.
