### PR TITLE
paseo 0.1.109

### DIFF
--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -1,9 +1,9 @@
 cask "paseo" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.1.108"
-  sha256 arm:   "8550dd6b2dbad0338a77f0ad45138f1f391fd22863983f99791695c010cdb827",
-         intel: "6db50842942064a9694a177eae6ae036129f2913cf888c1b080f060c14e83746"
+  version "0.1.109"
+  sha256 arm:   "1c6c3c6a4882ae9761c138e286ce2d21a3e97b616cd04dd9847d94f76dbebd53",
+         intel: "7d6a262dace02b6cc6d70c30a6e1fa0a6b0dbb14bf1bf4e4b8fb3aa6d76c3f92"
 
   url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo-#{version}-#{arch}.dmg",
       verified: "github.com/getpaseo/paseo/"


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assisted with the version/checksum update and PR drafting. I manually verified both DMG checksums, mounted both architectures, confirmed version 0.1.109 and the expected native binaries, and verified code signatures and notarization. The unchanged `zap` paths were reviewed.

-----

Urgent hotfix bump: Paseo 0.1.108 broke the packaged desktop preload, leaving affected users stuck connecting and breaking native window controls. 0.1.109 restores the Electron bridge and built-in daemon startup ([upstream fix](https://github.com/getpaseo/paseo/pull/2111)).

Built and tested locally on macOS 15.6.1.