### PR TITLE
quicklook-video: update livecheck

### DIFF
--- a/Casks/q/quicklook-video.rb
+++ b/Casks/q/quicklook-video.rb
@@ -7,16 +7,13 @@ cask "quicklook-video" do
   desc "Thumbnails, static previews, cover art and metadata for video files"
   homepage "https://github.com/Marginal/QuickLookVideo"
 
+  # The version in the tag and asset file name doesn't include dots, so we match
+  # the version from the release title (e.g. "Release 1.23").
   livecheck do
     url :url
-    regex(/^QLVideo[._-]v?(\d+?)(\d+)\.dmg$/i)
+    regex(/v?(\d+(?:\.\d+)+)/i)
     strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["name"]&.match(regex)
-        next if match.blank?
-
-        "#{match[1]}.#{match[2]}"
-      end
+      json["name"]&.[](regex, 1)
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block for `quicklook-video` naively inserts dots into a dotless version but we only do this when there's no source that we can use to obtain a version with dots. In this case, upstream provides a version with dots in the GitHub release name (e.g., "Release 1.23"), so this updates the `livecheck` block to match the version from the release name instead.