### PR TITLE
jetbrains-toolbox: add uninstall quit

### DIFF
--- a/Casks/j/jetbrains-toolbox.rb
+++ b/Casks/j/jetbrains-toolbox.rb
@@ -29,6 +29,7 @@ cask "jetbrains-toolbox" do
   app "JetBrains Toolbox.app"
 
   uninstall launchctl: "com.jetbrains.toolbox",
+            quit:      "com.jetbrains.toolbox",
             signal:    ["TERM", "com.jetbrains.toolbox"]
 
   zap trash: [


### PR DESCRIPTION
Adds `uninstall quit:` to the JetBrains Toolbox cask — the same treatment as calendr (#269810), for the same reason.

The cask already tries to handle the resident menu-bar process, but with `signal:`, which `brew upgrade` deliberately skips (`UPGRADE_REINSTALL_SKIP_DIRECTIVES` in brew's `cask/artifact/uninstall.rb`). So an upgrade swaps the bundle on disk while the old process keeps running. On my machine, yesterday's 3.6.1 → 3.6.2 upgrade left a 3.6.1 process (running since 8 July) in the menu bar, offering "Download update" to the version already sitting on disk — and taking that offer would replace the brew-managed install with an unquarantined self-update. `quit:` runs during upgrades, and brew reopens the app on the new version afterwards.

The `signal:` directive stays: it still serves plain uninstalls as the escalation when quit isn't enough. The bundle id matches the existing `launchctl`/`signal` directives.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online jetbrains-toolbox` is error-free.
- [x] `brew style --fix jetbrains-toolbox` reports no offenses.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Diagnosed and written with AI assistance (Claude / Claude Code) under my direction and review. **How AI was used:** to trace why the resident Toolbox survived a brew upgrade (the verbose upgrade log shows the launchctl removal but no signalling line; the surviving process predates the upgrade by a week) and to locate the cause in brew's `UPGRADE_REINSTALL_SKIP_DIRECTIVES`. **Manual verification:** bundle id `com.jetbrains.toolbox` matches the cask's existing `launchctl` and `signal` directives (the `zap` stanza is unchanged); `brew style` clean and `brew audit --cask --online` error-free against the edited cask.

-----