### PR TITLE
emacs-app@pretest 31.0.90-2

### DIFF
--- a/Casks/e/emacs-app@pretest.rb
+++ b/Casks/e/emacs-app@pretest.rb
@@ -11,9 +11,11 @@ cask "emacs-app@pretest" do
 
   livecheck do
     url "https://emacsformacosx.com/atom/pretest"
-    regex(%r{\Atag:emacsformacosx\.com,2010:emacs-builds/Emacs-pretest-(.+)-universal\.dmg\Z}i)
+    regex(/Emacs-pretest-(\d+\.\d+(?:\.\d+|-rc\d+)(?:-\d+)?)-universal\.dmg/i)
     strategy :xml do |xml, regex|
-      xml.get_elements("/feed/entry/id").map { |item| item.text[regex, 1] }
+      xml.get_elements("/feed/entry/link").filter_map do |item|
+        item.attributes["href"]&.[](regex, 1)
+      end
     end
   end
 

--- a/Casks/e/emacs-app@pretest.rb
+++ b/Casks/e/emacs-app@pretest.rb
@@ -1,12 +1,12 @@
 cask "emacs-app@pretest" do
-  arch arm: "arm64-11", intel: "x86_64-10_12"
+  arch arm: "arm64-11", intel: "x86_64-11"
 
-  version "30.1.90"
-  sha256 "e41b6b4dfbaf7ed1f0b4377546b48a0dc29fd20c948126b4847018069fb4a4a3"
+  version "31.0.90-2"
+  sha256 "827eaf1fc043648601d7654f0be7c9d999c96b4bb8aae40e1592e80561ea92f4"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   name "Emacs"
-  desc "Text editor"
+  desc "GNU Emacs text editor"
   homepage "https://emacsformacosx.com/"
 
   livecheck do
@@ -18,15 +18,13 @@ cask "emacs-app@pretest" do
     "emacs-app",
     "emacs-app@nightly",
   ]
-  depends_on :macos
+  depends_on macos: :big_sur
 
   app "Emacs.app"
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: "emacs"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin-#{arch}/ctags"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin-#{arch}/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin-#{arch}/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin-#{arch}/etags"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ctags.1.gz"
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1.gz"
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1.gz"
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1.gz"

--- a/Casks/e/emacs-app@pretest.rb
+++ b/Casks/e/emacs-app@pretest.rb
@@ -11,7 +11,10 @@ cask "emacs-app@pretest" do
 
   livecheck do
     url "https://emacsformacosx.com/atom/pretest"
-    regex(/Emacs[._-]pretest[._-]v?(\d+(?:\.\d+)+)[._-]universal\.dmg/i)
+    regex(%r[\Atag:emacsformacosx\.com,2010:emacs-builds/Emacs-pretest-(.+)-universal\.dmg\Z]i)
+    strategy :xml do |xml, regex|
+      xml.get_elements("/feed/entry/id").map { |item| item.text[regex, 1] }
+    end
   end
 
   conflicts_with cask: [

--- a/Casks/e/emacs-app@pretest.rb
+++ b/Casks/e/emacs-app@pretest.rb
@@ -11,7 +11,7 @@ cask "emacs-app@pretest" do
 
   livecheck do
     url "https://emacsformacosx.com/atom/pretest"
-    regex(/Emacs-pretest-(\d+\.\d+(?:\.\d+|-rc\d+)(?:-\d+)?)-universal\.dmg/i)
+    regex(/Emacs[._-]pretest[._-]v?(\d+(?:[.-]\d+)+.*?)[._-]universal\.dmg/i)
     strategy :xml do |xml, regex|
       xml.get_elements("/feed/entry/link").filter_map do |item|
         item.attributes["href"]&.[](regex, 1)

--- a/Casks/e/emacs-app@pretest.rb
+++ b/Casks/e/emacs-app@pretest.rb
@@ -11,7 +11,7 @@ cask "emacs-app@pretest" do
 
   livecheck do
     url "https://emacsformacosx.com/atom/pretest"
-    regex(%r[\Atag:emacsformacosx\.com,2010:emacs-builds/Emacs-pretest-(.+)-universal\.dmg\Z]i)
+    regex(%r{\Atag:emacsformacosx\.com,2010:emacs-builds/Emacs-pretest-(.+)-universal\.dmg\Z}i)
     strategy :xml do |xml, regex|
       xml.get_elements("/feed/entry/id").map { |item| item.text[regex, 1] }
     end


### PR DESCRIPTION
Additional notes:
- The main thing that needed to be fixed for these pretests was the removal of ctags. The nightly builds cask had already done this.
- There is an older x86-64 build that doesn't require Big Sur, but standardizing on Big Sur ensures both versions have the same feature set.
- The livecheck update isn't required but is more precise. I'm happy to remove it or if you like it, move it to the other Emacs casks.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
