### PR TITLE
logseq-og 1.0.0 (new cask)

### DIFF
--- a/Casks/l/logseq-og.rb
+++ b/Casks/l/logseq-og.rb
@@ -1,0 +1,28 @@
+cask "logseq-og" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.0.0"
+  sha256 arm:   "82af43917c0aa0ce2e12949f741c527b8eaf71522223981317751c51487d7797",
+         intel: "f1480c81a0ef12efc5de1b46d59ed2adb5b17b4c32061bab29779b1e84b9c1e5"
+
+  url "https://github.com/logseq/og/releases/download/#{version}/Logseq-OG-darwin-#{arch}-#{version}.dmg"
+  name "Logseq OG"
+  desc "Privacy-first, open-source platform for knowledge sharing and management"
+  homepage "https://github.com/logseq/og"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Logseq-OG.app"
+
+  zap trash: [
+    "~/Library/Caches/com.logseq.logseq-og*",
+    "~/Library/HTTPStorages/com.logseq.logseq-og",
+    "~/Library/Preferences/com.logseq.logseq-og.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `logseq` cask was recently updated to version 2.0.1, which upstream describes as an "early beta" and that there may be "rough edges". Notably, the app switches from a file-based approach to a database approach, which is a breaking change for users. Despite 2.0.1 being an unstable version, upstream is directing users to this version on the first-party download page, the in-app updater, etc., potentially in relation to the [2.0.1 release](https://github.com/logseq/logseq/releases/tag/2.0.1) being marked as "latest" on GitHub instead of "pre-release".

It was brought to my attention by a user that [upstream has created a Logseq OG product](https://logseq.io/page/b2ad9ce1-9cb7-4436-8083-54cb4516d324/df4dc09d-0a12-4c87-904e-22a9bf4c350a), which maintains the existing file-based approach from 0.10.15 and will be maintained alongside Logseq. This introduces a `logseq-og` cask, so affected users can use this as a workaround in the interim time (or indefinitely, if they prefer the file-based approach) while upstream works toward a stable 2.x version.

Unfortunately, we don't really have a choice with how we're handling the `logseq` cask, due to upstream treating unstable versions the same way as unstable versions (i.e., we effectively can't identify the latest stable version) but hopefully this helps some affected users.

Related to https://github.com/Homebrew/homebrew-cask/issues/275234.