### PR TITLE
dcp-o-matic-player: update checksum

### DIFF
--- a/Casks/d/dcp-o-matic-player.rb
+++ b/Casks/d/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask "dcp-o-matic-player" do
   version "2.18.44"
-  sha256 "65e6d01da90a704727ed41134580b85af95148083a34a7d4a80be19c5f0d5002"
+  sha256 "9c7ea69f820a19a13d9dee81949a7a49ca0afb146aa46f09f867acfa8a93e448"
 
   url "https://download.dcpomatic.com/dl.php?id=osx-10.10-player&version=#{version}"
   name "DCP-o-matic Player"


### PR DESCRIPTION
## Summary

Update the checksum for the existing stable `dcp-o-matic-player` 2.18.44 cask after the upstream download was refreshed without a version change. This addresses the `dcp-o-matic-player` checksum failure reported in #172732.

The replacement artifact is still the official 2.18.44 macOS download. Its SHA-256 is `9c7ea69f820a19a13d9dee81949a7a49ca0afb146aa46f09f867acfa8a93e448`.

## Verification

- Confirmed 2.18.44 is the current stable version on the upstream download page.
- Calculated the SHA-256 directly and matched it against the testbot result.
- Verified the DMG with `hdiutil verify`.
- Verified the app's Developer ID signature and Gatekeeper notarization.
- Ran `brew audit --cask --online dcp-o-matic-player` successfully.
- Ran `brew style --fix Casks/d/dcp-o-matic-player.rb` with no offenses.
- Ran `brew livecheck --cask dcp-o-matic-player` successfully.
- Ran `brew fetch --cask --force dcp-o-matic-player` successfully.
- Installed and uninstalled the cask successfully.

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Codex was used to research the reported checksum mismatch, prepare the one-line checksum update, and draft this description. Verification performed in this task included direct checksum calculation, DMG integrity checking, signature and notarization checks, Homebrew audit/style/livecheck/fetch commands, an install/uninstall smoke test, and review of the final one-file diff. The existing cask states that no `zap` stanza is required, and that area was not changed.

-----
