### PR TITLE
cleanmymac-cli 1.0.0 (new cask)

### DIFF
--- a/Casks/c/cleanmymac-cli.rb
+++ b/Casks/c/cleanmymac-cli.rb
@@ -1,0 +1,28 @@
+cask "cleanmymac-cli" do
+  version "1.0.0"
+  sha256 "f22dcf72e26a680e16e7d4deb0f36c0588f5beb0f7a892248e0ddacf68fb737a"
+
+  url "https://cli.cleanmymac.com/#{version}/CleanMyMac-CLI-#{version}.zip",
+      verified: "cli.cleanmymac.com/"
+  name "CleanMyMac CLI"
+  desc "Command-line interface for CleanMyMac"
+  homepage "https://github.com/MacPaw/cleanmymac-cli"
+
+  livecheck do
+    url "https://cli.cleanmymac.com/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  depends_on macos: :big_sur
+
+  app "CleanMyMac_5_CLI.app"
+  binary "CleanMyMac_5_CLI.app/Contents/MacOS/CleanMyMac_5_CLI", target: "cleanmymac"
+  binary "CleanMyMac_5_CLI.app/Contents/MacOS/CleanMyMac_5_CLI", target: "cmm"
+
+  zap trash: [
+    "~/Library/Application Scripts/S8EX82NJP6.com.macpaw.CleanMyMac5.CLI",
+    "~/Library/Group Containers/S8EX82NJP6.com.macpaw.CleanMyMac5.CLI",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. The AI agent helped draft the cask file; I verified the sha256 myself, ran `brew style`, `brew audit --cask --online`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask` and `brew uninstall --cask` locally, and confirmed the `zap` stanza paths against the directories the app actually creates at runtime.

-----

-----

`brew audit --cask --new` reports a single issue: "GitHub repository not notable enough". Context below.

**Notability:** CleanMyMac CLI is the official companion CLI to CleanMyMac by MacPaw (the `cleanmymac` cask has been maintained in homebrew-cask for years). The GitHub repository serves as the product's homepage and was made public only recently for the public beta, so repository metrics don't yet reflect the product's user base — see "Exceptions to the notability threshold" (1): a popular app whose developers use GitHub as its home. Downloads are served from MacPaw's own CDN (`cli.cleanmymac.com`), the same pattern as the existing `cleanmymac` cask (`updates.cleanmymac.com`).
