### PR TITLE
libation 13.5.1 (new cask)

### DIFF
--- a/Casks/l/libation.rb
+++ b/Casks/l/libation.rb
@@ -11,11 +11,6 @@ cask "libation" do
   desc "Audible audiobook manager and liberator"
   homepage "https://getlibation.com/"
 
-  livecheck do
-    url "https://github.com/rmcrackan/Libation"
-    strategy :github_latest
-  end
-
   depends_on macos: :ventura
 
   app "Libation.app"

--- a/Casks/l/libation.rb
+++ b/Casks/l/libation.rb
@@ -1,0 +1,27 @@
+cask "libation" do
+  arch arm: "arm64", intel: "x64"
+
+  version "13.5.1"
+  sha256 arm:   "c94d9267303b2b19e9cbfad232e08c90fbada2a84b48a04b60ef03897f4518b3",
+         intel: "da695fda92045f16c95c7d95c4fb6659f7f85c2944924c2c268d102bb326adb1"
+
+  url "https://github.com/rmcrackan/Libation/releases/download/v#{version}/Libation.#{version}-macOS-chardonnay-#{arch}.dmg",
+      verified: "github.com/rmcrackan/Libation/"
+  name "Libation"
+  desc "Audible audiobook manager and liberator"
+  homepage "https://getlibation.com/"
+
+  livecheck do
+    url "https://github.com/rmcrackan/Libation"
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "Libation.app"
+
+  zap trash: [
+    "~/Library/Application Support/Libation",
+    "~/Library/Preferences/org.libation.macos.plist",
+  ]
+end


### PR DESCRIPTION
Adds a cask for [Libation](https://getlibation.com/) ([rmcrackan/Libation](https://github.com/rmcrackan/Libation), ~5.9k stars), the open-source Audible audiobook manager. Signed and notarized macOS builds (Developer ID: team 5TUHF7W9P9) have shipped since v13.x.

**Why previous submissions failed, and why this one should not:** #244250, #247162 and #253848 were closed because the app failed the new-cask signing audit (`gktool scan`) on some macOS runners, despite the dmg being properly notarized. The root cause was in Libation's packaging, not its signing: the app bundle was missing `CFBundlePackageType` in Info.plist and the `Contents/PkgInfo` file, so Gatekeeper tooling could not classify it as an application (`spctl -a -t exec` → `rejected (the code is valid but does not seem to be an app)`). That was diagnosed and fixed upstream in rmcrackan/Libation#1889, released in **v13.5.1** — the version this cask ships. On the installed 13.5.1 bundle (macOS 26, arm64):

- `spctl -a -t exec` → `accepted, source=Notarized Developer ID`
- `gktool scan` → `Scan completed and software is allowed by system policy.`

Libation's maintainer has asked us to handle this submission (interactions on the Libation repo are temporarily restricted to collaborators, so he applied the packaging fix from our branch himself and requested "any submission stuff you can handle would be greatly appreciated").

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (the three prior closed PRs failed CI on the now-fixed upstream packaging bug; none was refused on policy grounds).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

Claude (via Claude Code) assisted with authoring the cask, diagnosing why the three previous Libation submissions failed the signing audit — the app bundle was missing `CFBundlePackageType` and `PkgInfo`, fixed upstream in rmcrackan/Libation#1889 and shipped in v13.5.1 — and drafting this PR. Verification was performed on a real machine (macOS 26, Apple Silicon) with each step's output reviewed: `brew style` and `brew audit --cask --new --online` pass clean; full install/uninstall cycles were run (from a personal tap containing this identical file, since the cask isn't installable from this repo pre-merge); `spctl -a -t exec` on the installed app reports `accepted, source=Notarized Developer ID`; `gktool scan` reports "allowed by system policy". Both zap paths were verified empirically: they exist on a live install and `brew uninstall --zap` was observed to remove them. A `Saved Application State` path was deliberately omitted after testing showed the app does not participate in macOS window restoration (no savedState folder is created even with `NSQuitAlwaysKeepsWindows` enabled).
