### PR TITLE
nvidia-geforce-now: Kill GeForceNOWContainer at uninstall

### DIFF
--- a/Casks/n/nvidia-geforce-now.rb
+++ b/Casks/n/nvidia-geforce-now.rb
@@ -19,6 +19,8 @@ cask "nvidia-geforce-now" do
 
   app "GeForceNOW.app"
 
+  uninstall signal: ["QUIT", "com.nvidia.nvcontainer"]
+
   zap trash: [
         "~/Library/Application Support/NVIDIA Corporation/MessageBus_GFN_session*.conf",
         "~/Library/Application Support/NVIDIA/GeForceNOW",


### PR DESCRIPTION
Uninstalling leaves this executable running:

```
/Applications/GeForceNOW.app/Contents/MacOS/GeForceNOWContainer.app/Contents/MacOS/GeForceNOWContainer
```

Using SIGQUIT as SIGTERM didn't work, I tested more than once.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
