### PR TITLE
markdown-preview 0.0.37

### DIFF
--- a/Casks/m/markdown-preview.rb
+++ b/Casks/m/markdown-preview.rb
@@ -17,7 +17,7 @@ cask "markdown-preview" do
   depends_on macos: :sequoia
 
   app "Markdown Preview.app"
-  binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "md-preview"
+  binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "mdp"
 
   zap trash: [
     "~/Library/Application Scripts/doc.md-preview",

--- a/Casks/m/markdown-preview.rb
+++ b/Casks/m/markdown-preview.rb
@@ -16,25 +16,8 @@ cask "markdown-preview" do
   auto_updates true
   depends_on macos: :sequoia
 
-  legacy_cli = HOMEBREW_PREFIX/"bin/md-preview"
-  legacy_aliases = [HOMEBREW_PREFIX/"bin/mdp", HOMEBREW_PREFIX/"bin/markdown-preview"]
-
   app "Markdown Preview.app"
-  binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "mdp"
   binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "md-preview"
-  binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "markdown-preview"
-
-  preflight do
-    managed_legacy_cli = legacy_cli.file? && !legacy_cli.symlink? &&
-                         legacy_cli.read.include?("# Managed by Markdown Preview CLI")
-
-    if managed_legacy_cli
-      legacy_aliases.each do |path|
-        Utils.gain_permissions_remove(path) if path.symlink? && path.readlink.to_s == "md-preview"
-      end
-      Utils.gain_permissions_remove(legacy_cli)
-    end
-  end
 
   zap trash: [
     "~/Library/Application Scripts/doc.md-preview",

--- a/Casks/m/markdown-preview.rb
+++ b/Casks/m/markdown-preview.rb
@@ -1,6 +1,6 @@
 cask "markdown-preview" do
-  version "0.0.36"
-  sha256 "46726a07654adb66f661b57b0b8ca8d7d1518a0de5661327b0e4c3cac87233ba"
+  version "0.0.37"
+  sha256 "4abefdfc5fead9ce47f1d4dcbc9c30cbb773db7891ad6abb29831be3bfe9c0d4"
 
   url "https://github.com/pluk-inc/markdown-preview/releases/download/v#{version}/Markdown-Preview.dmg",
       verified: "github.com/pluk-inc/markdown-preview/"
@@ -16,7 +16,25 @@ cask "markdown-preview" do
   auto_updates true
   depends_on macos: :sequoia
 
+  legacy_cli = HOMEBREW_PREFIX/"bin/md-preview"
+  legacy_aliases = [HOMEBREW_PREFIX/"bin/mdp", HOMEBREW_PREFIX/"bin/markdown-preview"]
+
   app "Markdown Preview.app"
+  binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "mdp"
+  binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "md-preview"
+  binary "#{appdir}/Markdown Preview.app/Contents/Resources/bin/markdown-preview", target: "markdown-preview"
+
+  preflight do
+    managed_legacy_cli = legacy_cli.file? && !legacy_cli.symlink? &&
+                         legacy_cli.read.include?("# Managed by Markdown Preview CLI")
+
+    if managed_legacy_cli
+      legacy_aliases.each do |path|
+        Utils.gain_permissions_remove(path) if path.symlink? && path.readlink.to_s == "md-preview"
+      end
+      Utils.gain_permissions_remove(legacy_cli)
+    end
+  end
 
   zap trash: [
     "~/Library/Application Scripts/doc.md-preview",


### PR DESCRIPTION
Updates Markdown Preview to 0.0.37 and exposes the bundled launcher as the upstream primary command, `mdp`.

Closes pluk-inc/markdown-preview#200

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI helped draft the cask update. I manually verified the release SHA-256, ran `brew style --fix` and the online audit, reinstalled the cask, confirmed `mdp` links to the bundled executable, and verified the installed 0.0.37 app with `codesign` and `spctl`. The existing zap paths are unchanged and were reviewed.

-----
