### PR TITLE
codexbar: fix sha256

### DIFF
--- a/Casks/c/codexbar.rb
+++ b/Casks/c/codexbar.rb
@@ -1,6 +1,6 @@
 cask "codexbar" do
   version "0.45.0"
-  sha256 "624172121dd792bf63e6074795e339dec83acf07792d463c28ca612f76c85217"
+  sha256 "02d884074eed1f973fcb53d0fe82906e4eb25d9b96ac33cd07be7da540ebf81f"
 
   url "https://github.com/steipete/CodexBar/releases/download/v#{version}/CodexBar-macos-universal-#{version}.zip",
       verified: "github.com/steipete/CodexBar/"


### PR DESCRIPTION
The 0.45.0 release of CodexBar had a failed first publish: the release was created, its CLI asset workflow failed, and the automation cleaned up the release and tag. The autobump PR recorded the sha256 of that first (now-deleted) app zip. The release was re-published later the same day with rebuilt assets, so the current cask sha256 does not match the live artifact and every install fails with a checksum mismatch (reported at steipete/CodexBar#2297).

This PR updates only the sha256 to the live asset:

- old: 624172121dd792bf63e6074795e339dec83acf07792d463c28ca612f76c85217
- new: 02d884074eed1f973fcb53d0fe82906e4eb25d9b96ac33cd07be7da540ebf81f (shasum -a 256 of the current CodexBar-macos-universal-0.45.0.zip)

Version and URL are unchanged. I am the upstream maintainer of CodexBar.
