### PR TITLE
chatgpt-classic: update download URL

### DIFF
--- a/Casks/c/chatgpt-classic.rb
+++ b/Casks/c/chatgpt-classic.rb
@@ -1,9 +1,10 @@
 cask "chatgpt-classic" do
-  version "1.2026.183,1783607847"
-  sha256 "49b33cadd2ec659b76352384f7ebd332a7ec7029663365a9f720f4a251d3b8d1"
+  version "1.2026.184,1784145287"
+  sha256 "a94117fb34627229baafe3e8b7b45467c5aee7861b4cd795a5be8d547b1ff7b4"
 
-  url "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_#{version.csv.first}_#{version.csv.second}.dmg",
-      verified: "persistent.oaistatic.com/sidekick/public/"
+  # The version and build parameters only make Homebrew's cache key unique; they do not select the app version.
+  url "https://persistent.oaistatic.com/classic/public/ChatGPT_Classic.dmg?version=#{version.csv.first}&build=#{version.csv.second}",
+      verified: "persistent.oaistatic.com/classic/public/"
   name "ChatGPT Classic"
   desc "OpenAI's previous ChatGPT desktop app"
   homepage "https://chatgpt.com/"
@@ -21,21 +22,24 @@ cask "chatgpt-classic" do
   depends_on macos: :sonoma
   depends_on arch: :arm64
 
-  app "ChatGPT.app", target: "ChatGPT Classic.app"
+  app "ChatGPT Classic.app"
 
-  uninstall quit: "com.openai.chat"
+  uninstall launchctl: "com.openai.chat-helper",
+            quit:      "com.openai.chat"
 
   zap trash: [
     "~/Library/Application Scripts/com.openai.chat.Widgets",
     "~/Library/Application Scripts/group.com.openai.chat",
     "~/Library/Application Support/ChatGPT",
     "~/Library/Application Support/com.openai.chat",
+    "~/Library/Caches/ChatGPTHelper",
     "~/Library/Caches/com.openai.chat",
     "~/Library/Containers/com.openai.chat.Widgets",
     "~/Library/Group Containers/group.com.openai.chat",
     "~/Library/HTTPStorages/ChatGPTHelper.binarycookies",
     "~/Library/HTTPStorages/com.openai.chat",
     "~/Library/HTTPStorages/com.openai.chat.binarycookies",
+    "~/Library/Preferences/ChatGPTHelper.plist",
     "~/Library/Preferences/com.openai.chat.*.plist",
     "~/Library/Preferences/com.openai.chat.plist",
     "~/Library/Saved Application State/com.openai.chat.savedState",

--- a/Casks/c/chatgpt-classic.rb
+++ b/Casks/c/chatgpt-classic.rb
@@ -1,9 +1,8 @@
 cask "chatgpt-classic" do
   version "1.2026.184,1784145287"
-  sha256 "a94117fb34627229baafe3e8b7b45467c5aee7861b4cd795a5be8d547b1ff7b4"
+  sha256 :no_check
 
-  # The version and build parameters only make Homebrew's cache key unique; they do not select the app version.
-  url "https://persistent.oaistatic.com/classic/public/ChatGPT_Classic.dmg?version=#{version.csv.first}&build=#{version.csv.second}",
+  url "https://persistent.oaistatic.com/classic/public/ChatGPT_Classic.dmg",
       verified: "persistent.oaistatic.com/classic/public/"
   name "ChatGPT Classic"
   desc "OpenAI's previous ChatGPT desktop app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

Changes the ChatGPT Classic download URL to `https://persistent.oaistatic.com/classic/public/ChatGPT_Classic.dmg`, as listed on OpenAI's [download page](https://chatgpt.com/download/), and aligns the app, uninstall, and zap stanzas with the new download.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Codex was used to inspect the official DMG, identify the app bundle and helper service, update the cask, and run the required validation commands. I manually reviewed the resulting diff and verified the zap paths against the installed application.

-----
