### PR TITLE
tauritavern 2.2.0 (new cask)

### DIFF
--- a/Casks/t/tauritavern.rb
+++ b/Casks/t/tauritavern.rb
@@ -2,8 +2,8 @@ cask "tauritavern" do
   arch arm: "arm64", intel: "x64"
 
   version "2.2.0"
-  sha256 arm:   "f9616a391af266edd46576f81e0419c609c41d42e1e55d4980445a67b56c03b0",
-         intel: "e9397e4b2424ed4f14915303286e53e66a5576ab963d208a75a50891af0ccb7e"
+  sha256 arm:   "913756a0de19bb315d85204e026697aaff078d06d6f82d7ca5cff7bd70d0c6d2",
+         intel: "fbf3d80e4921f7abfbb3d56797db8645c14236e8338c96cec66997e5c1d81811"
 
   url "https://github.com/Darkatse/TauriTavern/releases/download/v#{version}/TauriTavern-#{version}-macos-#{arch}.dmg",
       verified: "github.com/Darkatse/TauriTavern/"
@@ -22,8 +22,13 @@ cask "tauritavern" do
 
   zap trash: [
     "~/Library/Application Support/com.tauritavern.client",
+    "~/Library/Application Support/CrashReporter/tauritavern_*.plist",
     "~/Library/Caches/com.tauritavern.client",
+    "~/Library/Caches/tauritavern",
+    "~/Library/HTTPStorages/tauritavern.binarycookies",
     "~/Library/Preferences/com.tauritavern.client.plist",
+    "~/Library/Preferences/tauritavern.plist",
     "~/Library/WebKit/com.tauritavern.client",
+    "~/Library/WebKit/tauritavern",
   ]
 end

--- a/Casks/t/tauritavern.rb
+++ b/Casks/t/tauritavern.rb
@@ -1,0 +1,29 @@
+cask "tauritavern" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.2.0"
+  sha256 arm:   "f9616a391af266edd46576f81e0419c609c41d42e1e55d4980445a67b56c03b0",
+         intel: "e9397e4b2424ed4f14915303286e53e66a5576ab963d208a75a50891af0ccb7e"
+
+  url "https://github.com/Darkatse/TauriTavern/releases/download/v#{version}/TauriTavern-#{version}-macos-#{arch}.dmg",
+      verified: "github.com/Darkatse/TauriTavern/"
+  name "TauriTavern"
+  desc "SillyTavern-compatible native client"
+  homepage "https://tauritavern.github.io/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on :macos
+
+  app "TauriTavern.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.tauritavern.client",
+    "~/Library/Caches/com.tauritavern.client",
+    "~/Library/Preferences/com.tauritavern.client.plist",
+    "~/Library/WebKit/com.tauritavern.client",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Codex assisted with drafting the cask and running the verification workflow. I manually verified both release checksums, architectures, bundle version and identifier, Developer ID signature, and Apple notarization ticket. The cask installs and uninstalls successfully from an isolated `--appdir`; `brew style` passes, `livecheck` resolves 2.2.0, and `brew audit --new --except signing` passes for both ARM and Intel.

The local signing audit was affected by a macOS 26.5 `syspolicyd` `EMFILE` failure; a quarantined copy of Visual Studio Code failed the same `gktool` control test. Clean Homebrew CI subsequently passed the complete macOS 14, 15, and 26 matrix on both ARM and Intel.

The `zap` paths were observed on a running installation and are limited to bundle-identifier-specific Application Support, Caches, Preferences, and WebKit data.

-----
