### PR TITLE
whooing 0.1.1 (new cask)

### DIFF
--- a/Casks/w/whooing.rb
+++ b/Casks/w/whooing.rb
@@ -1,0 +1,27 @@
+cask "whooing" do
+  version "0.1.1"
+  sha256 "2c5be3beca2024c85548171a86efe85fc49d2abd125957d27ae96beccb42eb3f"
+
+  url "https://github.com/zidell/whooing-desktop/releases/download/v#{version}/Whooing_#{version}_universal.dmg",
+      verified: "github.com/zidell/whooing-desktop/"
+  name "Whooing"
+  desc "Desktop app for the Whooing double-entry bookkeeping service"
+  homepage "https://whooing.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on :macos
+
+  app "Whooing.app"
+
+  zap trash: [
+    "~/Library/Caches/com.whooing.desktop",
+    "~/Library/HTTPStorages/com.whooing.desktop",
+    "~/Library/Preferences/com.whooing.desktop.plist",
+    "~/Library/Saved Application State/com.whooing.desktop.savedState",
+    "~/Library/WebKit/com.whooing.desktop",
+  ]
+end


### PR DESCRIPTION
## Description

Adds a cask for [Whooing](https://whooing.com), a live commercial double-entry bookkeeping SaaS. This packages its official desktop client, built with Tauri and distributed as a signed & notarized macOS universal binary via GitHub Releases.

The releases are hosted on the vendor's own [`zidell/whooing-desktop`](https://github.com/zidell/whooing-desktop) repository, which is used purely as a binary-hosting/CI repo (source lives there too, but it is not the product's homepage or primary community surface — that's [whooing.com](https://whooing.com)).

## Notability

`brew audit --new` flags `GitHub repository not notable enough`, since the release-hosting repo is new and has no forks/watchers/stars of its own (and self-submission thresholds are 3x higher). Per [Acceptable-Casks.md](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Casks.md), I believe this qualifies for the documented exception:

> A popular app that has its own website but the developers use GitHub for hosting the binaries.

Whooing is an established, actively used bookkeeping service (live since well before this cask); GitHub is only the binary CDN here, not the project's home. This is the **only** finding from `brew audit --cask --online --new whooing`; there are no other errors.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

As the vendor/maintainer of the upstream `whooing-desktop` project, I used Claude Code (an AI coding agent) to rewrite this PR description after the previous submission was auto-closed for using an outdated/incomplete template — the cask itself (URL, sha256, stanzas) is unchanged from the original submission. Under my direction, and with me reviewing the output, Claude Code re-ran the checklist commands above on my machine before this re-submission: `brew style --fix whooing` (clean), `brew audit --cask --online --new whooing` (only the documented notability finding discussed above), and a full `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask whooing` / `brew uninstall --cask whooing` cycle, confirming the installed app is the signed & notarized universal binary at the expected version and that uninstall removes it cleanly. The `zap` stanza paths were cross-checked against the app's actual bundle identifier (`com.whooing.desktop`, as declared in the app's own `tauri.conf.json`) rather than guessed.

-----
