### PR TITLE
neon-vision-editor 0.8.9

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,0 +1,22 @@
+cask "neon-vision-editor" do
+  version "0.8.9"
+  sha256 "6af41fb7c8d894035d36cd3308f14533c7620934951cf48e916370c1d8e80958"
+
+  url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
+  name "Neon Vision Editor"
+  desc "Native text editor for macOS"
+  homepage "https://github.com/h3pdesign/Neon-Vision-Editor"
+
+  auto_updates true
+  depends_on macos: :sequoia
+
+  app "Neon Vision Editor.app"
+
+  zap trash: [
+    "~/Library/Application Support/NeonVisionEditor",
+    "~/Library/Caches/h3p.Neon-Vision-Editor",
+    "~/Library/Containers/h3p.Neon-Vision-Editor",
+    "~/Library/Logs/NeonVisionEditorUpdater.log",
+    "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
+  ]
+end


### PR DESCRIPTION
Adds the Neon Vision Editor cask.\n\n- Uses the upstream GitHub release ZIP for v0.8.9.\n- SHA-256 verified against the published asset.\n- Declares macOS Sequoia as the minimum supported release and the app's built-in updater.