### PR TITLE
neon-vision-editor 0.9.1 (new cask)

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,0 +1,22 @@
+cask "neon-vision-editor" do
+  version "0.9.1"
+  sha256 "743518978cd0fa7174540508b7be18f12ba0c144448feb8abb8857d3e0e030b9"
+
+  url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
+  name "Neon Vision Editor"
+  desc "Native code and text editor"
+  homepage "https://github.com/h3pdesign/Neon-Vision-Editor"
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Neon Vision Editor.app"
+
+  zap trash: [
+    "~/Library/Application Support/NeonVisionEditor",
+    "~/Library/Caches/h3p.Neon-Vision-Editor",
+    "~/Library/Containers/h3p.Neon-Vision-Editor",
+    "~/Library/Logs/NeonVisionEditorUpdater.log",
+    "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. AI assisted with drafting the cask. I manually verified the upstream release URL and SHA-256 against the downloaded v0.8.9 archive, confirmed the macOS 15 minimum from the Xcode project, reviewed the updater's local storage paths for the `zap` stanza, and reviewed the final cask. Homebrew CI has validated installation on Intel macOS 15 and Apple Silicon macOS 26.

-----
