### PR TITLE
capcut 9.0.0.4346

### DIFF
--- a/Casks/c/capcut.rb
+++ b/Casks/c/capcut.rb
@@ -1,18 +1,18 @@
 cask "capcut" do
-  version "3.3.0.1159"
-  sha256 "26c253719a61eae679a2923121a83d0a39b98d920a5c57f3e00d66224986c867"
+  version "9.0.0.4346"
+  sha256 "e1015de3ec46022f7797eee2144f3eb4853d92a6b88e0bee408a38fa9dcfb07f"
 
-  url "https://lf16-capcut.faceulv.com/obj/capcutpc-packages-us/packages/CapCut_#{version.dots_to_underscores}_capcutpc_0_creatortool.dmg",
-      verified: "lf16-capcut.faceulv.com/obj/capcutpc-packages-us/packages/"
+  url "https://sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/CapCut_#{version.dots_to_underscores}_capcutpc_0_creatortool.dmg",
+      verified: "sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/"
   name "CapCut"
-  desc "Video editing and image design platform"
+  desc "All-in-one video editor and maker"
   homepage "https://www.capcut.com/"
 
   livecheck do
-    url "https://editor-api.capcutapi.com/service/settings/v3/?aid=359289&from_aid=359289&device_platform=mac&from_channel=capcutpc_0"
+    url "https://editor-api-sg.capcutapi.com/service/settings/v3/?aid=359289&device_platform=mac&channel=capcutpc_0&version_code=1&os_version=26.4&region=GB&traffic_type=release"
     regex(/CapCut[._-]v?(\d+(?:[._]\d+)+).+?\.dmg/i)
     strategy :json do |json, regex|
-      url = json.dig("data", "settings", "installer_downloader_config", "url")
+      url = json.dig("data", "settings", "update_reminder", "lastest_stable_url")
       next if url.blank?
 
       match = url.match(regex)
@@ -30,6 +30,5 @@ cask "capcut" do
     "~/Library/Application Scripts/com.lemon.lvoverseas",
     "~/Library/Containers/com.lemon.lvoverseas",
     "~/Library/Group Containers/22MMUN2RN5.lv",
-    "~/Library/Group Containers/22MMUN2RN5.ve",
   ]
 end

--- a/Casks/c/capcut.rb
+++ b/Casks/c/capcut.rb
@@ -5,7 +5,7 @@ cask "capcut" do
   url "https://sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/CapCut_#{version.dots_to_underscores}_capcutpc_0_creatortool.dmg",
       verified: "sf16-web-tos-buz.capcutstatic.com/obj/capcut-web-buz-sg/packages/"
   name "CapCut"
-  desc "All-in-one video editor and maker"
+  desc "Video editing and image design platform"
   homepage "https://www.capcut.com/"
 
   livecheck do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

To help diagnose and fix this cask. Reverse-engineered the new settings endpoint by capturing the in-app updater's traffic (proxy in a disposable macOS VM) to find the JSON field (`update_reminder.lastest_stable_url`) and the minimal request params that reliably return the current stable release.

Manual verification I performed:
- Downloaded the 9.0.0.4346 dmg, computed the sha256, and confirmed `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask capcut` fetches and checksum-verifies it cleanly.
- Installed and **launched** the app, created a project to force it to write data, confirming the dmg is functional (not just byte-valid).
- Ran `brew audit --cask --online --strict`, `brew style`, and `brew livecheck --cask capcut --autobump` (resolves `9.0.0.4346` from the new endpoint) — all under `HOMEBREW_NO_INSTALL_FROM_API=1`.
- **`zap` paths verified against a real install:** used `lsof` on the running process and `find ~/Library -iname '*lvoverseas*'` to locate exactly what CapCut writes. The app is sandboxed, so the zap trashes its three real locations — `~/Library/Containers/com.lemon.lvoverseas`, `~/Library/Application Scripts/com.lemon.lvoverseas`, and `~/Library/Group Containers/22MMUN2RN5.lv` — each confirmed to exist on disk. Bundle id `com.lemon.lvoverseas` confirmed via `osascript` and `defaults read`.

1. **`version_code=1` in the livecheck URL is deliberate.** The endpoint only includes the `update_reminder` block when it judges the reported version to be outdated — it's effectively a "should this client update?" decision. Passing a deliberately-low `version_code` guarantees the server always considers the request behind and returns the current stable release URL, making the livecheck self-correcting as new versions ship. Verified it needs no device identity (works with no `device_id`/`did`/`iid`).

2. **`lastest_stable_url` is spelled that way upstream.** It's an upstream typo ("lastest", not "latest") and must be preserved verbatim in the `dig` path — "correcting" the spelling makes the lookup return `nil` and silently breaks livecheck.
-----