### PR TITLE
Migrate cask removals (1/8)

### DIFF
--- a/Casks/g/gpg-suite-no-mail.rb
+++ b/Casks/g/gpg-suite-no-mail.rb
@@ -118,10 +118,9 @@ cask "gpg-suite-no-mail" do
         },
       ]
 
-  uninstall_postflight do
-    ["gpg", "gpg2", "gpg-agent"].map { |exec_name| Pathname("/usr/local/bin")/exec_name }.each do |exec|
-      exec.unlink if exec.exist? && exec.readlink.to_s.include?("MacGPG2")
-    end
+  uninstall_postflight_steps do
+    remove ["/usr/local/bin/gpg", "/usr/local/bin/gpg2", "/usr/local/bin/gpg-agent"],
+           symlink_target_contains: "MacGPG2"
   end
 
   uninstall launchctl: [

--- a/Casks/g/gpg-suite-pinentry.rb
+++ b/Casks/g/gpg-suite-pinentry.rb
@@ -118,10 +118,9 @@ cask "gpg-suite-pinentry" do
         },
       ]
 
-  uninstall_postflight do
-    ["gpg", "gpg2", "gpg-agent"].map { |exec_name| Pathname("/usr/local/bin")/exec_name }.each do |exec|
-      exec.unlink if exec.exist? && exec.readlink.to_s.include?("MacGPG2")
-    end
+  uninstall_postflight_steps do
+    remove ["/usr/local/bin/gpg", "/usr/local/bin/gpg2", "/usr/local/bin/gpg-agent"],
+           symlink_target_contains: "MacGPG2"
   end
 
   uninstall launchctl: [

--- a/Casks/g/gpg-suite.rb
+++ b/Casks/g/gpg-suite.rb
@@ -22,10 +22,9 @@ cask "gpg-suite" do
 
   pkg "Install.pkg"
 
-  uninstall_postflight do
-    ["gpg", "gpg2", "gpg-agent"].map { |exec_name| Pathname("/usr/local/bin")/exec_name }.each do |exec|
-      exec.unlink if exec.exist? && exec.readlink.to_s.include?("MacGPG2")
-    end
+  uninstall_postflight_steps do
+    remove ["/usr/local/bin/gpg", "/usr/local/bin/gpg2", "/usr/local/bin/gpg-agent"],
+           symlink_target_contains: "MacGPG2"
   end
 
   uninstall launchctl: [

--- a/Casks/g/gpg-suite@nightly.rb
+++ b/Casks/g/gpg-suite@nightly.rb
@@ -22,10 +22,9 @@ cask "gpg-suite@nightly" do
 
   pkg "Install.pkg"
 
-  uninstall_postflight do
-    ["gpg", "gpg2", "gpg-agent"].map { |exec_name| Pathname("/usr/local/bin")/exec_name }.each do |exec|
-      exec.unlink if exec.exist? && exec.readlink.to_s.include?("MacGPG2")
-    end
+  uninstall_postflight_steps do
+    remove ["/usr/local/bin/gpg", "/usr/local/bin/gpg2", "/usr/local/bin/gpg-agent"],
+           symlink_target_contains: "MacGPG2"
   end
 
   uninstall launchctl: [

--- a/Casks/i/intellij-idea@eap.rb
+++ b/Casks/i/intellij-idea@eap.rb
@@ -33,13 +33,9 @@ cask "intellij-idea@eap" do
   app "IntelliJ IDEA.app"
   binary "#{appdir}/IntelliJ IDEA.app/Contents/MacOS/idea"
 
-  uninstall_postflight do
-    ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "idea") }.each do |path|
-      if File.readable?(path) &&
-         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
-        File.delete(path)
-      end
-    end
+  uninstall_postflight_steps do
+    remove "idea", base:             :search_path,
+                   content_contains: "# see com.intellij.idea.SocketLock for the server side of this interface"
   end
 
   zap trash: [

--- a/Casks/m/miniconda.rb
+++ b/Casks/m/miniconda.rb
@@ -40,16 +40,16 @@ cask "miniconda" do
   }
   binary "#{caskroom_path}/base/condabin/conda"
 
-  postflight do
-    if Dir.exist? "#{HOMEBREW_TEMP}/#{token}-envs"
-      FileUtils.rm_r "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{HOMEBREW_TEMP}/#{token}-envs", "#{caskroom_path}/base/envs"
+  postflight_steps do
+    if_path_exists "{{temp}}/#{token}-envs" do
+      remove "base/envs", base: :caskroom_path, recursive: true
+      move "{{temp}}/#{token}-envs", "base/envs", target_base: :caskroom_path
     end
   end
 
-  uninstall_preflight do
-    if Dir.exist? "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{caskroom_path}/base/envs", "#{HOMEBREW_TEMP}/#{token}-envs"
+  uninstall_preflight_steps do
+    if_path_exists "{{caskroom_path}}/base/envs" do
+      move "base/envs", "{{temp}}/#{token}-envs", source_base: :caskroom_path
     end
   end
 

--- a/Casks/m/miniforge.rb
+++ b/Casks/m/miniforge.rb
@@ -28,16 +28,16 @@ cask "miniforge" do
   binary "#{caskroom_path}/base/condabin/conda"
   binary "#{caskroom_path}/base/condabin/mamba"
 
-  postflight do
-    if Dir.exist? "#{HOMEBREW_TEMP}/#{token}-envs"
-      FileUtils.rm_r "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{HOMEBREW_TEMP}/#{token}-envs", "#{caskroom_path}/base/envs"
+  postflight_steps do
+    if_path_exists "{{temp}}/#{token}-envs" do
+      remove "base/envs", base: :caskroom_path, recursive: true
+      move "{{temp}}/#{token}-envs", "base/envs", target_base: :caskroom_path
     end
   end
 
-  uninstall_preflight do
-    if Dir.exist? "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{caskroom_path}/base/envs", "#{HOMEBREW_TEMP}/#{token}-envs"
+  uninstall_preflight_steps do
+    if_path_exists "{{caskroom_path}}/base/envs" do
+      move "base/envs", "{{temp}}/#{token}-envs", source_base: :caskroom_path
     end
   end
 

--- a/Casks/p/playdate-simulator.rb
+++ b/Casks/p/playdate-simulator.rb
@@ -17,10 +17,8 @@ cask "playdate-simulator" do
 
   pkg "PlaydateSDK.pkg"
 
-  uninstall_preflight do
-    Pathname("/usr/local/bin").glob("arm-*").each do |exec|
-      Utils.gain_permissions_remove(exec) if exec.exist? && exec.readlink.to_s.include?("playdate")
-    end
+  uninstall_preflight_steps do
+    remove "/usr/local/bin/arm-*", symlink_target_contains: "playdate", sudo: true
   end
 
   uninstall pkgutil: "date.play.sdk",

--- a/Casks/p/pycharm-edu.rb
+++ b/Casks/p/pycharm-edu.rb
@@ -19,13 +19,9 @@ cask "pycharm-edu" do
 
   app "PyCharm Edu.app"
 
-  uninstall_postflight do
-    ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "charm") }.each do |path|
-      if File.readable?(path) &&
-         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
-        File.delete(path)
-      end
-    end
+  uninstall_postflight_steps do
+    remove "charm", base:             :search_path,
+                    content_contains: "# see com.intellij.idea.SocketLock for the server side of this interface"
   end
 
   zap trash: [

--- a/Casks/w/wezterm@nightly.rb
+++ b/Casks/w/wezterm@nightly.rb
@@ -25,13 +25,10 @@ cask "wezterm@nightly" do
   fish_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish", target: "wezterm.fish"
   zsh_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh", target: "_wezterm"
 
-  preflight do
+  preflight_steps do
     # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder
-    staged_subfolder = staged_path.glob(["WezTerm-*", "wezterm-*"]).first
-    if staged_subfolder
-      FileUtils.mv(staged_subfolder/"WezTerm.app", staged_path)
-      FileUtils.rm_r(staged_subfolder)
-    end
+    move "{WezTerm-*,wezterm-*}/WezTerm.app", ".", source_glob: true
+    remove ["WezTerm-*", "wezterm-*"], recursive: true
   end
 
   zap trash: "~/Library/Saved Application State/com.github.wez.wezterm.savedState"


### PR DESCRIPTION
Ten casks remove owned files, links or generated directories during
structured flight phases.

- replace Ruby removal code with scoped declarative steps
- preserve recursive, globbed and ownership-filtered behaviour
- retain matching uninstall semantics for GPG Suite and Python tools
- depend on Homebrew/brew's matching
  `Add install step removals` change

Needs https://github.com/Homebrew/brew/pull/23181

