### PR TITLE
Migrate cask inreplace calls (2/8)

### DIFF
--- a/Casks/j/j.rb
+++ b/Casks/j/j.rb
@@ -46,18 +46,19 @@ cask "j" do
     binary "j#{version.major_minor}/bin/#{b}.command", target: b
   end
 
-  postflight do
+  postflight_steps do
     # Use `readlink` to get full path of symlinked commands.
-    commands.each do |c|
-      command = "#{staged_path}/j#{version.major_minor}/bin/#{c}.command"
-      File.write command, File.read(command).gsub("$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")')
-    end
+    inreplace "j#{version.major_minor}/bin/jbrk.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
+    inreplace "j#{version.major_minor}/bin/jhs.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
+    inreplace "j#{version.major_minor}/bin/jqt.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
 
     # Fix relative paths inside App bundles.
-    apps.each do |a|
-      apprun = "#{appdir}/#{a}.app/Contents/MacOS/apprun"
-      File.write apprun, File.read(apprun).gsub(%r{`dirname "\$0"`.*?/bin}, "#{staged_path}/j#{version.major_minor}/bin")
-    end
+    inreplace "jbrk.app/Contents/MacOS/apprun", %r{`dirname "\$0"`.*?/bin},
+              "{{staged_path}}/j#{version.major_minor}/bin", base: :appdir
+    inreplace "jcon.app/Contents/MacOS/apprun", %r{`dirname "\$0"`.*?/bin},
+              "{{staged_path}}/j#{version.major_minor}/bin", base: :appdir
+    inreplace "jqt.app/Contents/MacOS/apprun", %r{`dirname "\$0"`.*?/bin},
+              "{{staged_path}}/j#{version.major_minor}/bin", base: :appdir
   end
 
   # Not actually necessary, since it would be deleted anyway.


### PR DESCRIPTION
The J cask only rewrites fixed launcher content after staging and does
not require arbitrary Ruby.

- use the shared `inreplace` spelling and option behaviour
- serialise the guarded literal replacement
- preserve the staged payload and uninstall behaviour
- depend on Homebrew/brew's matching
  `Add install step inreplace` change

Needs https://github.com/Homebrew/brew/pull/23182

