### PR TITLE
Migrate cask command wrappers (3/8)

### DIFF
--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -1,23 +1,9 @@
 cask "affine" do
   arch arm: "arm64", intel: "x64"
   os macos: "macos", linux: "linux"
-
-  version "0.27.3"
-
   url_end = on_system_conditional macos: ".zip", linux: ".appimage"
 
-  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-#{os}-#{arch}#{url_end}",
-      verified: "github.com/toeverything/AFFiNE/"
-  name "AFFiNE"
-  desc "Note editor and whiteboard"
-  homepage "https://affine.pro/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  auto_updates true
+  version "0.27.3"
 
   on_macos do
     sha256 arm:   "bdeaa87ae8f200d63c738dfcdc3a8435fd8386e82cb28ef8b1ac5cc975207264",
@@ -34,7 +20,6 @@ cask "affine" do
       "~/Library/Saved Application State/pro.affine.app.savedState",
     ]
   end
-
   on_linux do
     sha256 "bc132e3f8dea5a05c3943da79822d92ed7f3218456eb051bd81d11d4f0580114"
 
@@ -42,4 +27,17 @@ cask "affine" do
 
     app_image "affine-#{version}-stable-linux-#{arch}.appimage", target: "AFFiNE.AppImage"
   end
+
+  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-#{os}-#{arch}#{url_end}",
+      verified: "github.com/toeverything/AFFiNE/"
+  name "AFFiNE"
+  desc "Note editor and whiteboard"
+  homepage "https://affine.pro/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
 end

--- a/Casks/a/alex313031-thorium.rb
+++ b/Casks/a/alex313031-thorium.rb
@@ -22,16 +22,8 @@ cask "alex313031-thorium" do
   depends_on macos: :big_sur
 
   app "Thorium.app", target: "Thorium Browser.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/thorium.wrapper.sh"
-  binary shimscript, target: "thorium"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/Thorium Browser.app/Contents/MacOS/Thorium' "$@"
-    EOS
-  end
+  command_wrapper "thorium",
+                  executable: "#{appdir}/Thorium Browser.app/Contents/MacOS/Thorium"
 
   zap trash: [
     "~/Library/Application Support/Thorium",

--- a/Casks/a/android-ndk.rb
+++ b/Casks/a/android-ndk.rb
@@ -15,28 +15,16 @@ cask "android-ndk" do
 
   depends_on :macos
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/ndk_exec.sh"
-  preflight do
-    Pathname.new("#{HOMEBREW_PREFIX}/share").mkpath
+  command_wrapper "ndk-build", executable: "#{HOMEBREW_PREFIX}/share/android-ndk/ndk-build"
+  command_wrapper "ndk-depends", executable: "#{HOMEBREW_PREFIX}/share/android-ndk/ndk-depends"
+  command_wrapper "ndk-gdb", executable: "#{HOMEBREW_PREFIX}/share/android-ndk/ndk-gdb"
+  command_wrapper "ndk-stack", executable: "#{HOMEBREW_PREFIX}/share/android-ndk/ndk-stack"
+  command_wrapper "ndk-which", executable: "#{HOMEBREW_PREFIX}/share/android-ndk/ndk-which"
 
-    build = File.read("#{staged_path}/source.properties").match(/(?<=Pkg.Revision\s=\s\d\d.\d.)\d+/)
-    FileUtils.ln_sf("#{staged_path}/AndroidNDK#{build}.app/Contents/NDK", "#{HOMEBREW_PREFIX}/share/android-ndk")
-
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      readonly executable="#{staged_path}/AndroidNDK#{build}.app/Contents/NDK/$(basename ${0})"
-      test -f "${executable}" && exec "${executable}" "${@}"
-    EOS
+  preflight_steps do
+    symlink "AndroidNDK*.app/Contents/NDK", "share/android-ndk",
+            target_base: :homebrew_prefix, source_glob: true, force: true
   end
-
-  %w[
-    ndk-build
-    ndk-depends
-    ndk-gdb
-    ndk-stack
-    ndk-which
-  ].each { |link_name| binary shimscript, target: link_name }
 
   uninstall delete: "#{HOMEBREW_PREFIX}/share/android-ndk"
 

--- a/Casks/b/bandage.rb
+++ b/Casks/b/bandage.rb
@@ -16,16 +16,8 @@ cask "bandage" do
   depends_on macos: :big_sur
 
   app "Bandage.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/bandage.wrapper.sh"
-  binary shimscript, target: "bandage"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/Bandage.app/Contents/MacOS/Bandage' "$@"
-    EOS
-  end
+  command_wrapper "bandage",
+                  executable: "#{appdir}/Bandage.app/Contents/MacOS/Bandage"
 
   zap trash: [
     "~/Library/Preferences/com.rrwick.Bandage.plist",

--- a/Casks/b/betterdisplay.rb
+++ b/Casks/b/betterdisplay.rb
@@ -37,16 +37,8 @@ cask "betterdisplay" do
   depends_on :macos
 
   app "BetterDisplay.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/betterdisplay.wrapper.sh"
-  binary shimscript, target: "betterdisplaycli"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/BetterDisplay.app/Contents/MacOS/BetterDisplay' "$@"
-    EOS
-  end
+  command_wrapper "betterdisplaycli",
+                  executable: "#{appdir}/BetterDisplay.app/Contents/MacOS/BetterDisplay"
 
   uninstall quit:       "pro.betterdisplay.BetterDisplay",
             login_item: "BetterDisplay"

--- a/Casks/b/blender.rb
+++ b/Casks/b/blender.rb
@@ -55,18 +55,11 @@ cask "blender" do
   depends_on macos: :big_sur
 
   app "Blender.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/blender.wrapper.sh"
-  binary shimscript, target: "blender"
+  command_wrapper "blender",
+                  executable: "#{appdir}/Blender.app/Contents/MacOS/Blender"
 
-  preflight do
-    # make __pycache__ directories writable, otherwise uninstall fails
-    FileUtils.chmod "u+w", Dir.glob("#{staged_path}/*.app/**/__pycache__")
-
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
-    EOS
+  preflight_steps do
+    set_permissions "*.app/**/__pycache__", "u+w", recursive: false
   end
 
   zap trash: [

--- a/Casks/b/blender@lts.rb
+++ b/Casks/b/blender@lts.rb
@@ -22,18 +22,11 @@ cask "blender@lts" do
   depends_on macos: :big_sur
 
   app "Blender.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/blender.wrapper.sh"
-  binary shimscript, target: "blender"
+  command_wrapper "blender",
+                  executable: "#{appdir}/Blender.app/Contents/MacOS/Blender"
 
-  preflight do
-    # make __pycache__ directories writable, otherwise uninstall fails
-    FileUtils.chmod "u+w", Dir.glob("#{staged_path}/*.app/**/__pycache__")
-
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
-    EOS
+  preflight_steps do
+    set_permissions "*.app/**/__pycache__", "u+w", recursive: false
   end
 
   zap trash: [

--- a/Casks/c/chromium.rb
+++ b/Casks/c/chromium.rb
@@ -16,16 +16,8 @@ cask "chromium" do
   depends_on macos: :monterey
 
   app "chrome-mac/Chromium.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/chromium.wrapper.sh"
-  binary shimscript, target: "chromium"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
-    EOS
-  end
+  command_wrapper "chromium",
+                  executable: "#{appdir}/Chromium.app/Contents/MacOS/Chromium"
 
   zap trash: [
     "~/Library/Application Support/Chromium",

--- a/Casks/c/clion.rb
+++ b/Casks/c/clion.rb
@@ -27,16 +27,8 @@ cask "clion" do
   depends_on macos: :monterey
 
   app "CLion.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/clion.wrapper.sh"
-  binary shimscript, target: "clion"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/CLion.app/Contents/MacOS/clion' "$@"
-    EOS
-  end
+  command_wrapper "clion",
+                  executable: "#{appdir}/CLion.app/Contents/MacOS/clion"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/CLion#{version.major_minor}",

--- a/Casks/c/cutter.rb
+++ b/Casks/c/cutter.rb
@@ -19,16 +19,8 @@ cask "cutter" do
   depends_on macos: :big_sur
 
   app "Cutter.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/cutter.wrapper.sh"
-  binary shimscript, target: "cutter"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      '#{appdir}/Cutter.app/Contents/MacOS/Cutter' "$@"
-    EOS
-  end
+  command_wrapper "cutter",
+                  executable: "#{appdir}/Cutter.app/Contents/MacOS/Cutter"
 
   zap trash: [
     "~/.config/rizin",

--- a/Casks/d/datagrip.rb
+++ b/Casks/d/datagrip.rb
@@ -27,16 +27,8 @@ cask "datagrip" do
   depends_on :macos
 
   app "DataGrip.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/datagrip.wrapper.sh"
-  binary shimscript, target: "datagrip"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/DataGrip.app/Contents/MacOS/datagrip' "$@"
-    EOS
-  end
+  command_wrapper "datagrip",
+                  executable: "#{appdir}/DataGrip.app/Contents/MacOS/datagrip"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/DataGrip*",

--- a/Casks/d/dataspell.rb
+++ b/Casks/d/dataspell.rb
@@ -31,16 +31,8 @@ cask "dataspell" do
   depends_on :macos
 
   app "DataSpell.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/dataspell.wrapper.sh"
-  binary shimscript, target: "dataspell"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/DataSpell.app/Contents/MacOS/dataspell' "$@"
-    EOS
-  end
+  command_wrapper "dataspell",
+                  executable: "#{appdir}/DataSpell.app/Contents/MacOS/dataspell"
 
   zap trash: [
     "~/Library/Application Support/DataSpell*",

--- a/Casks/d/drawio.rb
+++ b/Casks/d/drawio.rb
@@ -20,16 +20,8 @@ cask "drawio" do
   depends_on macos: :monterey
 
   app "draw.io.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/drawio.wrapper.sh"
-  binary shimscript, target: "drawio"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/draw.io.app/Contents/MacOS/draw.io' "$@"
-    EOS
-  end
+  command_wrapper "drawio",
+                  executable: "#{appdir}/draw.io.app/Contents/MacOS/draw.io"
 
   zap trash: [
     "~/Library/Application Support/draw.io",

--- a/Casks/d/dynamodb-local.rb
+++ b/Casks/d/dynamodb-local.rb
@@ -21,17 +21,13 @@ cask "dynamodb-local" do
     end
   end
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/dynamodb-local.wrapper.sh"
-  binary shimscript, target: "dynamodb-local"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      cd "$(dirname "$(readlink -n "${0}")")" && \
-        exec java -Djava.library.path='./DynamoDBLocal_lib' -jar 'DynamoDBLocal.jar' "$@"
-    EOS
-  end
+  command_wrapper "dynamodb-local",
+                  executable: "java",
+                  args:       [
+                    "-Djava.library.path=#{staged_path}/DynamoDBLocal_lib",
+                    "-jar",
+                    "#{staged_path}/DynamoDBLocal.jar",
+                  ]
 
   # No zap stanza required
 

--- a/Casks/f/firefox.rb
+++ b/Casks/f/firefox.rb
@@ -436,16 +436,8 @@ cask "firefox" do
   depends_on :macos
 
   app "Firefox.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/firefox.wrapper.sh"
-  binary shimscript, target: "firefox"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/Firefox.app/Contents/MacOS/firefox' "$@"
-    EOS
-  end
+  command_wrapper "firefox",
+                  executable: "#{appdir}/Firefox.app/Contents/MacOS/firefox"
 
   uninstall quit: "org.mozilla.firefox"
 

--- a/Casks/g/gimp.rb
+++ b/Casks/g/gimp.rb
@@ -40,15 +40,8 @@ cask "gimp" do
   depends_on :macos
 
   app "GIMP.app"
-  shimscript = "#{staged_path}/gimp.wrapper.sh"
-  binary shimscript, target: "gimp"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      "#{appdir}/GIMP.app/Contents/MacOS/gimp" "$@"
-    EOS
-  end
+  command_wrapper "gimp",
+                  executable: "#{appdir}/GIMP.app/Contents/MacOS/gimp"
 
   zap trash: [
     "~/Library/Application Support/Gimp",

--- a/Casks/g/gimp@dev.rb
+++ b/Casks/g/gimp@dev.rb
@@ -28,15 +28,8 @@ cask "gimp@dev" do
   depends_on macos: :big_sur
 
   app "GIMP.app"
-  shimscript = "#{staged_path}/gimp.wrapper.sh"
-  binary shimscript, target: "gimp"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      "#{appdir}/GIMP.app/Contents/MacOS/gimp" "$@"
-    EOS
-  end
+  command_wrapper "gimp",
+                  executable: "#{appdir}/GIMP.app/Contents/MacOS/gimp"
 
   zap trash: [
     "~/Library/Application Support/Gimp",

--- a/Casks/g/gitfiend.rb
+++ b/Casks/g/gitfiend.rb
@@ -22,16 +22,8 @@ cask "gitfiend" do
   depends_on :macos
 
   app "GitFiend.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/gitfiend.wrapper.sh"
-  binary shimscript, target: "gitfiend"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/GitFiend.app/Contents/MacOS/GitFiend' "$@"
-    EOS
-  end
+  command_wrapper "gitfiend",
+                  executable: "#{appdir}/GitFiend.app/Contents/MacOS/GitFiend"
 
   zap trash: [
     "~/Library/Application Support/GitFiend",

--- a/Casks/g/godot-mono.rb
+++ b/Casks/g/godot-mono.rb
@@ -18,16 +18,8 @@ cask "godot-mono" do
   depends_on cask: "dotnet-sdk"
 
   app "Godot_mono.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/godot-mono.wrapper.sh"
-  binary shimscript, target: "godot-mono"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      '#{appdir}/Godot_mono.app/Contents/MacOS/Godot' "$@"
-    EOS
-  end
+  command_wrapper "godot-mono",
+                  executable: "#{appdir}/Godot_mono.app/Contents/MacOS/Godot"
 
   uninstall quit: "org.godotengine.godot"
 

--- a/Casks/g/gogs.rb
+++ b/Casks/g/gogs.rb
@@ -14,17 +14,11 @@ cask "gogs" do
   desc "Self-hosted Git service"
   homepage "https://gogs.io/"
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/gogs.wrapper.sh"
-
-  binary shimscript, target: "gogs"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      cd '#{staged_path}/gogs' && ./gogs "$@"
-    EOS
-  end
+  command_wrapper "gogs",
+                  content: <<~EOS
+                    #!/bin/sh
+                    cd '#{staged_path}/gogs' && ./gogs "$@"
+                  EOS
 
   # No zap stanza required
 end

--- a/Casks/g/goland.rb
+++ b/Casks/g/goland.rb
@@ -27,16 +27,9 @@ cask "goland" do
   depends_on :macos
 
   app "GoLand.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/goland.wrapper.sh"
-  binary shimscript, target: "goland"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      open -na "GoLand.app" --args "$@"
-    EOS
-  end
+  command_wrapper "goland",
+                  executable: "/usr/bin/open",
+                  args:       ["-na", "GoLand.app", "--args"]
 
   zap trash: [
     "~/Library/Application Support/JetBrains/GoLand",

--- a/Casks/g/goneovim.rb
+++ b/Casks/g/goneovim.rb
@@ -21,16 +21,8 @@ cask "goneovim" do
   depends_on macos: :big_sur
 
   app "goneovim-v#{version}-macos-#{arch}/goneovim.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/goneovim.wrapper.sh"
-  binary shimscript, target: "goneovim"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/goneovim.app/Contents/MacOS/goneovim' "$@"
-    EOS
-  end
+  command_wrapper "goneovim",
+                  executable: "#{appdir}/goneovim.app/Contents/MacOS/goneovim"
 
   zap trash: [
     "~/.goneovim",

--- a/Casks/g/gqrx.rb
+++ b/Casks/g/gqrx.rb
@@ -26,16 +26,8 @@ cask "gqrx" do
   depends_on macos: :ventura
 
   app "Gqrx.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/gqrx.wrapper.sh"
-  binary shimscript, target: "gqrx"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      '#{appdir}/Gqrx.app/Contents/MacOS/gqrx' "$@"
-    EOS
-  end
+  command_wrapper "gqrx",
+                  executable: "#{appdir}/Gqrx.app/Contents/MacOS/gqrx"
 
   zap trash: "~/.config/gqrx"
 end

--- a/Casks/i/inkscape.rb
+++ b/Casks/i/inkscape.rb
@@ -31,16 +31,8 @@ cask "inkscape" do
   depends_on macos: :big_sur
 
   app "Inkscape.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/inkscape.wrapper.sh"
-  binary shimscript, target: "inkscape"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{staged_path}/Inkscape.app/Contents/MacOS/inkscape' "$@"
-    EOS
-  end
+  command_wrapper "inkscape",
+                  executable: "#{staged_path}/Inkscape.app/Contents/MacOS/inkscape"
 
   zap trash: [
     "~/.config/inkscape",

--- a/Casks/i/intellij-idea-ce.rb
+++ b/Casks/i/intellij-idea-ce.rb
@@ -18,16 +18,8 @@ cask "intellij-idea-ce" do
   depends_on :macos
 
   app "IntelliJ IDEA CE.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/idea.wrapper.sh"
-  binary shimscript, target: "idea-ce"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/IntelliJ IDEA CE.app/Contents/MacOS/idea' "$@"
-    EOS
-  end
+  command_wrapper "idea-ce",
+                  executable: "#{appdir}/IntelliJ IDEA CE.app/Contents/MacOS/idea"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/IdeaIC#{version.major_minor}",

--- a/Casks/i/intellij-idea.rb
+++ b/Casks/i/intellij-idea.rb
@@ -28,16 +28,9 @@ cask "intellij-idea" do
   depends_on :macos
 
   app "IntelliJ IDEA.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/idea.wrapper.sh"
-  binary shimscript, target: "idea"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      open -na "IntelliJ IDEA.app" --args "$@"
-    EOS
-  end
+  command_wrapper "idea",
+                  executable: "/usr/bin/open",
+                  args:       ["-na", "IntelliJ IDEA.app", "--args"]
 
   zap trash: [
     "~/Library/Application Support/JetBrains/IntelliJIdea#{version.major_minor}",

--- a/Casks/k/kate.rb
+++ b/Casks/k/kate.rb
@@ -40,15 +40,8 @@ cask "kate" do
   depends_on macos: :ventura
 
   app "kate.app"
-  shimscript = "#{staged_path}/kate.wrapper.sh"
-  binary shimscript, target: "kate"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/Kate.app/Contents/MacOS/kate' "$@"
-    EOS
-  end
+  command_wrapper "kate",
+                  executable: "#{appdir}/Kate.app/Contents/MacOS/kate"
 
   zap trash: [
     "~/Library/Application Support/kate",

--- a/Casks/k/kdiff3.rb
+++ b/Casks/k/kdiff3.rb
@@ -19,15 +19,8 @@ cask "kdiff3" do
   depends_on macos: :ventura
 
   app "kdiff3.app"
-  shimscript = "#{staged_path}/kdiff3.wrapper.sh"
-  binary shimscript, target: "kdiff3"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      '#{appdir}/kdiff3.app/Contents/MacOS/kdiff3' "$@"
-    EOS
-  end
+  command_wrapper "kdiff3",
+                  executable: "#{appdir}/kdiff3.app/Contents/MacOS/kdiff3"
 
   zap trash: [
     "~/.kdiff3rc",

--- a/Casks/k/keka.rb
+++ b/Casks/k/keka.rb
@@ -18,16 +18,9 @@ cask "keka" do
   depends_on :macos
 
   app "Keka.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/keka.wrapper.sh"
-  binary shimscript, target: "keka"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/Keka.app/Contents/MacOS/Keka' '--cli' "$@"
-    EOS
-  end
+  command_wrapper "keka",
+                  executable: "#{appdir}/Keka.app/Contents/MacOS/Keka",
+                  args:       "--cli"
 
   zap trash: [
     "~/Library/Application Scripts/*.group.com.aone.keka",

--- a/Casks/k/kitty.rb
+++ b/Casks/k/kitty.rb
@@ -10,23 +10,10 @@ cask "kitty" do
     depends_on macos: :monterey
 
     app "kitty.app"
-    # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-    kitty_shimscript = "#{staged_path}/kitty.wrapper.sh"
-    binary kitty_shimscript, target: "kitty"
-    # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-    kitten_shimscript = "#{staged_path}/kitten.wrapper.sh"
-    binary kitten_shimscript, target: "kitten"
-
-    preflight do
-      File.write kitty_shimscript, <<~EOS
-        #!/bin/sh
-        exec '#{appdir}/kitty.app/Contents/MacOS/kitty' "$@"
-      EOS
-      File.write kitten_shimscript, <<~EOS
-        #!/bin/sh
-        exec '#{appdir}/kitty.app/Contents/MacOS/kitten' "$@"
-      EOS
-    end
+    command_wrapper "kitty",
+                    executable: "#{appdir}/kitty.app/Contents/MacOS/kitty"
+    command_wrapper "kitten",
+                    executable: "#{appdir}/kitty.app/Contents/MacOS/kitten"
   end
   on_linux do
     sha256 arm64_linux:  "6b0d8fe0af20ba03348e97e303f3c6084b5338bb4abd52737d8e2ffd2dba3d33",

--- a/Casks/k/kitty@nightly.rb
+++ b/Casks/k/kitty@nightly.rb
@@ -11,23 +11,10 @@ cask "kitty@nightly" do
   depends_on macos: :monterey
 
   app "kitty.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  kitty_shimscript = "#{staged_path}/kitty.wrapper.sh"
-  binary kitty_shimscript, target: "kitty"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  kitten_shimscript = "#{staged_path}/kitten.wrapper.sh"
-  binary kitten_shimscript, target: "kitten"
-
-  preflight do
-    File.write kitty_shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/kitty.app/Contents/MacOS/kitty' "$@"
-    EOS
-    File.write kitten_shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/kitty.app/Contents/MacOS/kitten' "$@"
-    EOS
-  end
+  command_wrapper "kitty",
+                  executable: "#{appdir}/kitty.app/Contents/MacOS/kitty"
+  command_wrapper "kitten",
+                  executable: "#{appdir}/kitty.app/Contents/MacOS/kitten"
 
   zap trash: [
     "~/.config/kitty",

--- a/Casks/k/klogg.rb
+++ b/Casks/k/klogg.rb
@@ -23,16 +23,8 @@ cask "klogg" do
   depends_on :macos
 
   app "klogg.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/klogg.wrapper.sh"
-  binary shimscript, target: "klogg"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/klogg.app/Contents/MacOS/klogg' "$@"
-    EOS
-  end
+  command_wrapper "klogg",
+                  executable: "#{appdir}/klogg.app/Contents/MacOS/klogg"
 
   zap trash: [
     "~/Library/Application Support/klogg",

--- a/Casks/l/lbry.rb
+++ b/Casks/l/lbry.rb
@@ -14,23 +14,10 @@ cask "lbry" do
   depends_on :macos
 
   app "LBRY.app"
-  # shim scripts (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shim_lbrynet = "#{staged_path}/lbrynet.wrapper.sh"
-  shim_lbryfirst = "#{staged_path}/libry-first.wrapper.sh"
-  binary shim_lbrynet, target: "lbrynet"
-  binary shim_lbryfirst, target: "lbry-first"
-
-  preflight do
-    File.write shim_lbrynet, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/LBRY.app/Contents/Resources/static/daemon/lbrynet' "$@"
-    EOS
-
-    File.write shim_lbryfirst, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/LBRY.app/Contents/Resources/static/lbry-first/lbry-first' "$@"
-    EOS
-  end
+  command_wrapper "lbrynet",
+                  executable: "#{appdir}/LBRY.app/Contents/Resources/static/daemon/lbrynet"
+  command_wrapper "lbry-first",
+                  executable: "#{appdir}/LBRY.app/Contents/Resources/static/lbry-first/lbry-first"
 
   zap trash: [
     "~/Library/Application Support/lbry",

--- a/Casks/l/libreoffice-still.rb
+++ b/Casks/l/libreoffice-still.rb
@@ -36,16 +36,8 @@ cask "libreoffice-still" do
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/unopkg"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/uri-encode"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/xpdfimport"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/soffice.wrapper.sh"
-  binary shimscript, target: "soffice"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      '#{appdir}/LibreOffice.app/Contents/MacOS/soffice' "$@"
-    EOS
-  end
+  command_wrapper "soffice",
+                  executable: "#{appdir}/LibreOffice.app/Contents/MacOS/soffice"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl*",

--- a/Casks/l/libreoffice.rb
+++ b/Casks/l/libreoffice.rb
@@ -41,16 +41,8 @@ cask "libreoffice" do
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/unopkg"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/uri-encode"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/xpdfimport"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/soffice.wrapper.sh"
-  binary shimscript, target: "soffice"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      '#{appdir}/LibreOffice.app/Contents/MacOS/soffice' "$@"
-    EOS
-  end
+  command_wrapper "soffice",
+                  executable: "#{appdir}/LibreOffice.app/Contents/MacOS/soffice"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.libreoffice.script.sfl*",

--- a/Casks/l/librewolf.rb
+++ b/Casks/l/librewolf.rb
@@ -12,16 +12,8 @@ cask "librewolf" do
     disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
     app "LibreWolf.app"
-    # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-    shimscript = "#{staged_path}/librewolf.wrapper.sh"
-    binary shimscript, target: "librewolf"
-
-    preflight do
-      File.write shimscript, <<~EOS
-        #!/bin/sh
-        exec '#{appdir}/LibreWolf.app/Contents/MacOS/librewolf' "$@"
-      EOS
-    end
+    command_wrapper "librewolf",
+                    executable: "#{appdir}/LibreWolf.app/Contents/MacOS/librewolf"
 
     zap trash: [
       "~/.librewolf",

--- a/Casks/m/meld.rb
+++ b/Casks/m/meld.rb
@@ -17,16 +17,8 @@ cask "meld" do
   depends_on :macos
 
   app "Meld.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/meld.wrapper.sh"
-  binary shimscript, target: "meld"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/Meld.app/Contents/MacOS/Meld' "$@"
-    EOS
-  end
+  command_wrapper "meld",
+                  executable: "#{appdir}/Meld.app/Contents/MacOS/Meld"
 
   zap trash: [
     "~/.local/share/meld",

--- a/Casks/m/mps.rb
+++ b/Casks/m/mps.rb
@@ -27,16 +27,8 @@ cask "mps" do
   depends_on :macos
 
   app "MPS.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/mps.wrapper.sh"
-  binary shimscript, target: "mps"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/MPS.app/Contents/MacOS/mps' "$@"
-    EOS
-  end
+  command_wrapper "mps",
+                  executable: "#{appdir}/MPS.app/Contents/MacOS/mps"
 
   zap trash: [
     "~/Library/Application Support/MPS#{version.csv.first.major_minor}",

--- a/Casks/m/musescore.rb
+++ b/Casks/m/musescore.rb
@@ -25,16 +25,8 @@ cask "musescore" do
   depends_on :macos
 
   app "MuseScore #{version.major}.app"
-  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/mscore.wrapper.sh"
-  binary shimscript, target: "mscore"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/MuseScore #{version.major}.app/Contents/MacOS/mscore' "$@"
-    EOS
-  end
+  command_wrapper "mscore",
+                  executable: "#{appdir}/MuseScore #{version.major}.app/Contents/MacOS/mscore"
 
   zap trash: [
     "~/Library/Application Support/MuseScore",

--- a/Casks/n/nudge.rb
+++ b/Casks/n/nudge.rb
@@ -15,16 +15,8 @@ cask "nudge" do
   depends_on macos: :monterey
 
   pkg "Nudge-#{version}.pkg"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/nudge.wrapper.sh"
-  binary shimscript, target: "nudge"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '/Applications/Utilities/Nudge.app/Contents/MacOS/Nudge' "$@"
-    EOS
-  end
+  command_wrapper "nudge",
+                  executable: "/Applications/Utilities/Nudge.app/Contents/MacOS/Nudge"
 
   uninstall pkgutil: "com.github.macadmins.Nudge"
 

--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -28,16 +28,8 @@ cask "obs" do
   depends_on macos: :monterey
 
   app "OBS.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/obs.wrapper.sh"
-  binary shimscript, target: "obs"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/OBS.app/Contents/MacOS/OBS' "$@"
-    EOS
-  end
+  command_wrapper "obs",
+                  executable: "#{appdir}/OBS.app/Contents/MacOS/OBS"
 
   uninstall delete: "/Library/CoreMediaIO/Plug-Ins/DAL/obs-mac-virtualcam.plugin"
 

--- a/Casks/o/obs@beta.rb
+++ b/Casks/o/obs@beta.rb
@@ -28,16 +28,8 @@ cask "obs@beta" do
   depends_on macos: :monterey
 
   app "OBS.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/obs.wrapper.sh"
-  binary shimscript, target: "obs"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/OBS.app/Contents/MacOS/OBS' "$@"
-    EOS
-  end
+  command_wrapper "obs",
+                  executable: "#{appdir}/OBS.app/Contents/MacOS/OBS"
 
   uninstall delete: "/Library/CoreMediaIO/Plug-Ins/DAL/obs-mac-virtualcam.plugin"
 

--- a/Casks/p/p4v.rb
+++ b/Casks/p/p4v.rb
@@ -22,25 +22,13 @@ cask "p4v" do
   app "p4v.app"
   app "p4admin.app"
   app "p4merge.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  p4_wrapper = "#{staged_path}/p4.wrapper.sh"
   binary "p4vc"
-  binary p4_wrapper, target: "p4v"
-  binary p4_wrapper, target: "p4admin"
-  binary p4_wrapper, target: "p4merge"
-
-  preflight do
-    File.write p4_wrapper, <<~EOS
-      #!/bin/bash
-      set -euo pipefail
-      COMMAND=$(basename "$0")
-      if [[ "$COMMAND" == "p4merge" ]]; then
-        exec "#{appdir}/${COMMAND}.app/Contents/Resources/launch${COMMAND}" "$@" 2> /dev/null
-      else
-        exec "#{appdir}/${COMMAND}.app/Contents/MacOS/${COMMAND}" "$@" 2> /dev/null
-      fi
-    EOS
-  end
+  command_wrapper "p4v",
+                  executable: "#{appdir}/p4v.app/Contents/MacOS/p4v"
+  command_wrapper "p4admin",
+                  executable: "#{appdir}/p4admin.app/Contents/MacOS/p4admin"
+  command_wrapper "p4merge",
+                  executable: "#{appdir}/p4merge.app/Contents/Resources/launchp4merge"
 
   zap trash: [
     "~/Library/Preferences/com.perforce.p4v",

--- a/Casks/p/phpstorm.rb
+++ b/Casks/p/phpstorm.rb
@@ -27,16 +27,8 @@ cask "phpstorm" do
   depends_on :macos
 
   app "PhpStorm.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/phpstorm.wrapper.sh"
-  binary shimscript, target: "phpstorm"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/PhpStorm.app/Contents/MacOS/phpstorm' "$@"
-    EOS
-  end
+  command_wrapper "phpstorm",
+                  executable: "#{appdir}/PhpStorm.app/Contents/MacOS/phpstorm"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/consentOptions",

--- a/Casks/p/prince.rb
+++ b/Casks/p/prince.rb
@@ -14,16 +14,9 @@ cask "prince" do
 
   depends_on :macos
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/prince-#{version}-macos/prince.wrapper.sh"
-  binary shimscript, target: "prince"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{staged_path}/prince-#{version}-macos/lib/prince/bin/prince' --prefix '#{staged_path}/prince-#{version}-macos/lib/prince' "$@"
-    EOS
-  end
+  command_wrapper "prince",
+                  executable: "#{staged_path}/prince-#{version}-macos/lib/prince/bin/prince",
+                  args:       ["--prefix", "#{staged_path}/prince-#{version}-macos/lib/prince"]
 
   # No zap stanza required
 end

--- a/Casks/p/pycharm-ce.rb
+++ b/Casks/p/pycharm-ce.rb
@@ -18,16 +18,8 @@ cask "pycharm-ce" do
   depends_on :macos
 
   app "PyCharm CE.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/pycharm.wrapper.sh"
-  binary shimscript, target: "pycharm-ce"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/PyCharm CE.app/Contents/MacOS/pycharm' "$@"
-    EOS
-  end
+  command_wrapper "pycharm-ce",
+                  executable: "#{appdir}/PyCharm CE.app/Contents/MacOS/pycharm"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/PyCharmCE#{version.major_minor}",

--- a/Casks/p/pycharm.rb
+++ b/Casks/p/pycharm.rb
@@ -28,16 +28,8 @@ cask "pycharm" do
   depends_on :macos
 
   app "PyCharm.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/pycharm.wrapper.sh"
-  binary shimscript, target: "pycharm"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/PyCharm.app/Contents/MacOS/pycharm' "$@"
-    EOS
-  end
+  command_wrapper "pycharm",
+                  executable: "#{appdir}/PyCharm.app/Contents/MacOS/pycharm"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/PyCharm#{version.major_minor}",

--- a/Casks/q/qutebrowser.rb
+++ b/Casks/q/qutebrowser.rb
@@ -15,17 +15,9 @@ cask "qutebrowser" do
 
   depends_on macos: :big_sur
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/qutebrowser.wrapper.sh"
   app "qutebrowser.app"
-  binary shimscript, target: "qutebrowser"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      '#{appdir}/qutebrowser.app/Contents/MacOS/qutebrowser' "$@"
-    EOS
-  end
+  command_wrapper "qutebrowser",
+                  executable: "#{appdir}/qutebrowser.app/Contents/MacOS/qutebrowser"
 
   zap trash: [
         "~/Library/Application Support/qutebrowser",

--- a/Casks/r/rider.rb
+++ b/Casks/r/rider.rb
@@ -27,16 +27,8 @@ cask "rider" do
   depends_on :macos
 
   app "Rider.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/rider.wrapper.sh"
-  binary shimscript, target: "rider"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/Rider.app/Contents/MacOS/rider' "$@"
-    EOS
-  end
+  command_wrapper "rider",
+                  executable: "#{appdir}/Rider.app/Contents/MacOS/rider"
 
   zap trash: [
     "~/Library/Application Support/Rider#{version.major_minor}",

--- a/Casks/r/rubymine.rb
+++ b/Casks/r/rubymine.rb
@@ -27,16 +27,9 @@ cask "rubymine" do
   depends_on :macos
 
   app "RubyMine.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/rubymine.wrapper.sh"
-  binary shimscript, target: "rubymine"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      open -na "RubyMine.app" --args "$@"
-    EOS
-  end
+  command_wrapper "rubymine",
+                  executable: "/usr/bin/open",
+                  args:       ["-na", "RubyMine.app", "--args"]
 
   zap trash: [
     "~/Library/Application Support/RubyMine#{version.major_minor}",

--- a/Casks/r/rustrover.rb
+++ b/Casks/r/rustrover.rb
@@ -27,16 +27,8 @@ cask "rustrover" do
   depends_on :macos
 
   app "RustRover.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/rustrover.wrapper.sh"
-  binary shimscript, target: "rustrover"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/RustRover.app/Contents/MacOS/rustrover' "$@"
-    EOS
-  end
+  command_wrapper "rustrover",
+                  executable: "#{appdir}/RustRover.app/Contents/MacOS/rustrover"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/RustRover#{version.major_minor}",

--- a/Casks/s/sioyek.rb
+++ b/Casks/s/sioyek.rb
@@ -19,16 +19,8 @@ cask "sioyek" do
   container nested: "build/sioyek.dmg"
 
   app "sioyek.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/sioyek.wrapper.sh"
-  binary shimscript, target: "sioyek"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/sioyek.app/Contents/MacOS/sioyek' "$@"
-    EOS
-  end
+  command_wrapper "sioyek",
+                  executable: "#{appdir}/sioyek.app/Contents/MacOS/sioyek"
 
   zap trash: [
     "~/Library/Application Support/sioyek",

--- a/Casks/s/starnet++.rb
+++ b/Casks/s/starnet++.rb
@@ -19,29 +19,25 @@ cask "starnet++" do
 
   bin_path = "#{staged_path}/StarNetv#{version.csv.first}CLI_MacOS"
 
-  shimscript = "#{staged_path}/starnet_wrapper.sh"
-  binary shimscript, target: "starnet++"
+  command_wrapper "starnet++",
+                  content: <<~EOS
+                    #!/bin/sh
 
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
+                    # delete the symlink on process exit
+                    cleanup() {
+                      rm -f starnet#{version.csv.first}_weights.pb
+                    }
+                    trap cleanup RETURN EXIT SIGINT SIGKILL
 
-      # delete the symlink on process exit
-      cleanup() {
-        rm -f starnet#{version.csv.first}_weights.pb
-      }
-      trap cleanup RETURN EXIT SIGINT SIGKILL
+                    # the binary hardcodes the weights path so we have to symlink it to the CWD
+                    ln -sf "#{bin_path}/starnet#{version.csv.first}_weights.pb" .
 
-      # the binary hardcodes the weights path so we have to symlink it to the CWD
-      ln -sf "#{bin_path}/starnet#{version.csv.first}_weights.pb" .
+                    # define a load path since the libs are not in the same dir as the bin
+                    DYLD_LIBRARY_PATH=#{bin_path} command #{bin_path}/starnet++ $@
+                  EOS
 
-      # define a load path since the libs are not in the same dir as the bin
-      DYLD_LIBRARY_PATH=#{bin_path} command #{bin_path}/starnet++ $@
-    EOS
-  end
-
-  postflight do
-    set_permissions "#{bin_path}/starnet++", "0755"
+  postflight_steps do
+    set_permissions "StarNetv*CLI_MacOS/starnet++", "0755"
   end
 
   # No zap stanza required

--- a/Casks/s/steamcmd.rb
+++ b/Casks/s/steamcmd.rb
@@ -16,22 +16,13 @@ cask "steamcmd" do
   auto_updates true
   depends_on :macos
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = staged_path/"steamcmd.wrapper.sh"
-  binary shimscript, target: "steamcmd"
+  command_wrapper "steamcmd",
+                  executable: "#{staged_path}/MacOS/steamcmd.sh"
 
-  preflight do
+  preflight_steps do
     # Running for the first time will create a Frameworks symlink in the parent
     # directory pointing to a MacOS directory, so move the files in a MacOS directory.
-    files = staged_path.glob("*")
-    macos_dir = staged_path/"MacOS"
-    macos_dir.mkpath
-    FileUtils.mv files, macos_dir
-
-    shimscript.write <<~SH
-      #!/bin/sh
-      exec '#{macos_dir}/steamcmd.sh' "$@"
-    SH
+    move_contents ".", "MacOS"
   end
 
   uninstall launchctl: "com.valvesoftware.steamclean"

--- a/Casks/s/subsync.rb
+++ b/Casks/s/subsync.rb
@@ -14,16 +14,9 @@ cask "subsync" do
   depends_on :macos
 
   app "subsync.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/subsync.wrapper.sh"
-  binary shimscript, target: "subsync"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/subsync.app/Contents/MacOS/subsync' --cli "$@"
-    EOS
-  end
+  command_wrapper "subsync",
+                  executable: "#{appdir}/subsync.app/Contents/MacOS/subsync",
+                  args:       "--cli"
 
   zap trash: "~/Library/Preferences/subsync"
 

--- a/Casks/t/tiled.rb
+++ b/Casks/t/tiled.rb
@@ -30,16 +30,8 @@ cask "tiled" do
   depends_on :macos
 
   app "Tiled.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/tiled.wrapper.sh"
-  binary shimscript, target: "tiled"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/Tiled.app/Contents/MacOS/Tiled' "$@"
-    EOS
-  end
+  command_wrapper "tiled",
+                  executable: "#{appdir}/Tiled.app/Contents/MacOS/Tiled"
 
   zap trash: [
     "~/Library/Application Support/Tiled",

--- a/Casks/u/uniflash.rb
+++ b/Casks/u/uniflash.rb
@@ -18,16 +18,8 @@ cask "uniflash" do
     executable: "uniflash_sl.#{version}.app/Contents/MacOS/installbuilder.sh",
     args:       ["--mode", "unattended", "--prefix", "/Applications/TI/UniFlash"],
   }
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/dslite"
-  binary shimscript
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '/Applications/TI/UniFlash/dslite.sh' "$@"
-    EOS
-  end
+  command_wrapper "dslite",
+                  executable: "/Applications/TI/UniFlash/dslite.sh"
 
   uninstall script: {
     executable: "/Applications/TI/UniFlash/uninstall.app/Contents/MacOS/installbuilder.sh",

--- a/Casks/v/vieb.rb
+++ b/Casks/v/vieb.rb
@@ -16,16 +16,8 @@ cask "vieb" do
   depends_on macos: :monterey
 
   app "Vieb.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/vieb.wrapper.sh"
-  binary shimscript, target: "vieb"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/Vieb.app/Contents/MacOS/Vieb' "$@"
-    EOS
-  end
+  command_wrapper "vieb",
+                  executable: "#{appdir}/Vieb.app/Contents/MacOS/Vieb"
 
   zap trash: [
     "~/Library/Application Support/Vieb",

--- a/Casks/v/vlc.rb
+++ b/Casks/v/vlc.rb
@@ -20,16 +20,8 @@ cask "vlc" do
   depends_on :macos
 
   app "VLC.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/vlc.wrapper.sh"
-  binary shimscript, target: "vlc"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/VLC.app/Contents/MacOS/VLC' "$@"
-    EOS
-  end
+  command_wrapper "vlc",
+                  executable: "#{appdir}/VLC.app/Contents/MacOS/VLC"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*",

--- a/Casks/v/vlc@nightly.rb
+++ b/Casks/v/vlc@nightly.rb
@@ -46,16 +46,8 @@ cask "vlc@nightly" do
   depends_on :macos
 
   app "VLC.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/vlc.wrapper.sh"
-  binary shimscript, target: "vlc"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/VLC.app/Contents/MacOS/VLC' "$@"
-    EOS
-  end
+  command_wrapper "vlc",
+                  executable: "#{appdir}/VLC.app/Contents/MacOS/VLC"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*",

--- a/Casks/w/waterfox.rb
+++ b/Casks/w/waterfox.rb
@@ -16,16 +16,8 @@ cask "waterfox" do
   depends_on :macos
 
   app "Waterfox.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/waterfox.wrapper.sh"
-  binary shimscript, target: "waterfox"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/Waterfox.app/Contents/MacOS/waterfox' "$@"
-    EOS
-  end
+  command_wrapper "waterfox",
+                  executable: "#{appdir}/Waterfox.app/Contents/MacOS/waterfox"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.waterfox.sfl*",

--- a/Casks/w/webstorm.rb
+++ b/Casks/w/webstorm.rb
@@ -27,16 +27,8 @@ cask "webstorm" do
   depends_on :macos
 
   app "WebStorm.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/webstorm.wrapper.sh"
-  binary shimscript, target: "webstorm"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/WebStorm.app/Contents/MacOS/webstorm' "$@"
-    EOS
-  end
+  command_wrapper "webstorm",
+                  executable: "#{appdir}/WebStorm.app/Contents/MacOS/webstorm"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/WebStorm#{version.major_minor}",

--- a/Casks/x/xld.rb
+++ b/Casks/x/xld.rb
@@ -20,16 +20,9 @@ cask "xld" do
   depends_on :macos
 
   app "XLD.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/xld.wrapper.sh"
-  binary shimscript, target: "xld"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/XLD.app/Contents/MacOS/XLD' "--cmdline" "$@"
-    EOS
-  end
+  command_wrapper "xld",
+                  executable: "#{appdir}/XLD.app/Contents/MacOS/XLD",
+                  args:       "--cmdline"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/jp.tmkk.xld.sfl*",


### PR DESCRIPTION
Sixty-two casks write fixed launchers and link them into the configured
binary directory.

- replace flight script generation with serialised wrapper artifacts
- preserve wrapper content, targets, linking and uninstall behaviour
- remove each matching Ruby flight block
- depend on Homebrew/brew's matching
  `Add cask command wrappers` change

Needs https://github.com/Homebrew/brew/pull/23183

