### PR TITLE
Migrate generated cask scripts (4/8)

### DIFF
--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -1,23 +1,9 @@
 cask "affine" do
   arch arm: "arm64", intel: "x64"
   os macos: "macos", linux: "linux"
-
-  version "0.27.3"
-
   url_end = on_system_conditional macos: ".zip", linux: ".appimage"
 
-  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-#{os}-#{arch}#{url_end}",
-      verified: "github.com/toeverything/AFFiNE/"
-  name "AFFiNE"
-  desc "Note editor and whiteboard"
-  homepage "https://affine.pro/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  auto_updates true
+  version "0.27.3"
 
   on_macos do
     sha256 arm:   "bdeaa87ae8f200d63c738dfcdc3a8435fd8386e82cb28ef8b1ac5cc975207264",
@@ -34,7 +20,6 @@ cask "affine" do
       "~/Library/Saved Application State/pro.affine.app.savedState",
     ]
   end
-
   on_linux do
     sha256 "bc132e3f8dea5a05c3943da79822d92ed7f3218456eb051bd81d11d4f0580114"
 
@@ -42,4 +27,17 @@ cask "affine" do
 
     app_image "affine-#{version}-stable-linux-#{arch}.appimage", target: "AFFiNE.AppImage"
   end
+
+  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-#{os}-#{arch}#{url_end}",
+      verified: "github.com/toeverything/AFFiNE/"
+  name "AFFiNE"
+  desc "Note editor and whiteboard"
+  homepage "https://affine.pro/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
 end

--- a/Casks/l/libreoffice-language-pack.rb
+++ b/Casks/l/libreoffice-language-pack.rb
@@ -508,46 +508,41 @@ cask "libreoffice-language-pack" do
   depends_on :macos
   depends_on cask: "libreoffice"
 
+  generated_script "SilentInstall.sh", content: <<~EOS
+    #!/bin/bash
+    pathOfApp=$(mdfind "kMDItemContentType == 'com.apple.application-bundle' && kMDItemFSName == 'LibreOffice.app'" -onlyin '#{appdir}')
+    if [[ $(mdls --raw --name kMDItemFSName --name kMDItemVersion "$pathOfApp" | xargs -0) == "LibreOffice.app #{version}"* ]]
+    then
+      #Test if the .app have quarantine attribute, or if they are already launched once.
+      if [[ $(xattr -l "$pathOfApp") != *'com.apple.quarantine'* || $(xattr -p com.apple.quarantine "$pathOfApp") != '0181;'* ]]
+      then
+        echo "Silent installation has started, you didn't need to use the .app"
+        echo "Add language pack support for $pathOfApp"
+        /usr/bin/tar -C "$pathOfApp" -xjf "#{staged_path}/LibreOffice Language Pack.app/Contents/Resources/tarball.tar.bz2" && touch "$pathOfApp"
+      else
+        echo "You need to run $pathOfApp once before you can silently install language pack"
+      fi
+    else
+      echo 'Silent installation cannot match the prerequisite'
+      echo "To complete the installation of Cask #{token}, you must also run the installer at:"
+      echo "#{staged_path}/LibreOffice Language Pack.app"
+    fi
+  EOS
   # Start the silent install
   installer script: {
     executable: "#{staged_path}/SilentInstall.sh",
     sudo:       true,
   }
 
-  preflight do
-    File.write "#{staged_path}/SilentInstall.sh", <<~EOS
-      #!/bin/bash
-      pathOfApp=$(mdfind "kMDItemContentType == 'com.apple.application-bundle' && kMDItemFSName == 'LibreOffice.app'" -onlyin '#{appdir}')
-      if [[ $(mdls --raw --name kMDItemFSName --name kMDItemVersion "$pathOfApp" | xargs -0) == "LibreOffice.app #{version}"* ]]
-      then
-        #Test if the .app have quarantine attribute, or if they are already launched once.
-        if [[ $(xattr -l "$pathOfApp") != *'com.apple.quarantine'* || $(xattr -p com.apple.quarantine "$pathOfApp") != '0181;'* ]]
-        then
-          echo "Silent installation has started, you didn't need to use the .app"
-          echo "Add language pack support for $pathOfApp"
-          /usr/bin/tar -C "$pathOfApp" -xjf "#{staged_path}/LibreOffice Language Pack.app/Contents/Resources/tarball.tar.bz2" && touch "$pathOfApp"
-        else
-          echo "You need to run $pathOfApp once before you can silently install language pack"
-        fi
-      else
-        echo 'Silent installation cannot match the prerequisite'
-        echo "To complete the installation of Cask #{token}, you must also run the installer at:"
-        echo "#{staged_path}/LibreOffice Language Pack.app"
-      fi
-    EOS
-    # Make the script executable
-    system_command "/bin/chmod",
-                   args: ["u+x", "#{staged_path}/SilentInstall.sh"]
+  postflight_steps do
+    remove "SilentInstall.sh"
   end
 
   # Not actually necessary, since it would be deleted anyway.
   # It is present to make clear an uninstall was not forgotten
   # and that for this cask it is indeed this simple.
   # See https://github.com/Homebrew/homebrew-cask/pull/52893
-  uninstall delete: [
-    "#{staged_path}/#{token}",
-    "#{staged_path}/SilentInstall.sh",
-  ]
+  uninstall delete: "#{staged_path}/#{token}"
 
   # No zap stanza required
 

--- a/Casks/l/libreoffice-still-language-pack.rb
+++ b/Casks/l/libreoffice-still-language-pack.rb
@@ -508,46 +508,41 @@ cask "libreoffice-still-language-pack" do
   depends_on :macos
   depends_on cask: "libreoffice-still"
 
+  generated_script "SilentInstall.sh", content: <<~EOS
+    #!/bin/bash
+    pathOfApp=$(mdfind "kMDItemContentType == 'com.apple.application-bundle' && kMDItemFSName == 'LibreOffice.app'")
+    if [[ $(mdls --raw --name kMDItemFSName --name kMDItemVersion "$pathOfApp" | xargs -0) == "LibreOffice.app #{version}"* ]]
+    then
+      #Test if the .app have quarantine attribute, or if they are already launched once.
+      if [[ $(xattr -l "$pathOfApp") != *'com.apple.quarantine'* || $(xattr -p com.apple.quarantine "$pathOfApp") != '0181;'* ]]
+      then
+        echo "Silent installation has started, you didn't need to use the .app"
+        echo "Add language pack support for $pathOfApp"
+        /usr/bin/tar -C "$pathOfApp" -xjf "#{staged_path}/LibreOffice Language Pack.app/Contents/Resources/tarball.tar.bz2" && touch "$pathOfApp"
+      else
+        echo "You need to run $pathOfApp once before you can silently install language pack"
+      fi
+    else
+      echo 'Silent installation cannot match the prerequisite'
+      echo "To complete the installation of Cask #{token}, you must also run the installer at:"
+      echo "#{staged_path}/LibreOffice Language Pack.app"
+    fi
+  EOS
   # Start the silent install
   installer script: {
     executable: "#{staged_path}/SilentInstall.sh",
     sudo:       true,
   }
 
-  preflight do
-    File.write "#{staged_path}/SilentInstall.sh", <<~EOS
-      #!/bin/bash
-      pathOfApp=$(mdfind "kMDItemContentType == 'com.apple.application-bundle' && kMDItemFSName == 'LibreOffice.app'")
-      if [[ $(mdls --raw --name kMDItemFSName --name kMDItemVersion "$pathOfApp" | xargs -0) == "LibreOffice.app #{version}"* ]]
-      then
-        #Test if the .app have quarantine attribute, or if they are already launched once.
-        if [[ $(xattr -l "$pathOfApp") != *'com.apple.quarantine'* || $(xattr -p com.apple.quarantine "$pathOfApp") != '0181;'* ]]
-        then
-          echo "Silent installation has started, you didn't need to use the .app"
-          echo "Add language pack support for $pathOfApp"
-          /usr/bin/tar -C "$pathOfApp" -xjf "#{staged_path}/LibreOffice Language Pack.app/Contents/Resources/tarball.tar.bz2" && touch "$pathOfApp"
-        else
-          echo "You need to run $pathOfApp once before you can silently install language pack"
-        fi
-      else
-        echo 'Silent installation cannot match the prerequisite'
-        echo "To complete the installation of Cask #{token}, you must also run the installer at:"
-        echo "#{staged_path}/LibreOffice Language Pack.app"
-      fi
-    EOS
-    # Make the script executable
-    system_command "/bin/chmod",
-                   args: ["u+x", "#{staged_path}/SilentInstall.sh"]
+  postflight_steps do
+    remove "SilentInstall.sh"
   end
 
   # Not actually necessary, since it would be deleted anyway.
   # It is present to make clear an uninstall was not forgotten
   # and that for this cask it is indeed this simple.
   # See https://github.com/Homebrew/homebrew-cask/pull/52893
-  uninstall delete: [
-    "#{staged_path}/#{token}",
-    "#{staged_path}/SilentInstall.sh",
-  ]
+  uninstall delete: "#{staged_path}/#{token}"
 
   # No zap stanza required
 

--- a/Casks/m/mailtrackerblocker.rb
+++ b/Casks/m/mailtrackerblocker.rb
@@ -14,14 +14,22 @@ cask "mailtrackerblocker" do
   depends_on maximum_macos: :ventura
 
   pkg "MailTrackerBlocker.pkg"
+  generated_script "warn-if-mail-running.sh", content: <<~SH
+    #!/bin/sh
+    if /bin/ps x | /usr/bin/grep -q 'Mail.app/Contents/MacOS/[M]ail'; then
+      echo 'Warning: Restart Mail.app to finish uninstalling mailtrackerblocker' >&2
+    fi
+  SH
 
-  uninstall_postflight do
-    if system_command("ps", args: ["x"]).stdout.match?("Mail.app/Contents/MacOS/Mail")
-      opoo "Restart Mail.app to finish uninstalling #{token}"
-    end
+  uninstall_postflight_steps do
+    remove "warn-if-mail-running.sh"
   end
 
-  uninstall pkgutil: "com.onefatgiraffe.mailtrackerblocker",
+  uninstall script:  {
+              executable:   "warn-if-mail-running.sh",
+              must_succeed: false,
+            },
+            pkgutil: "com.onefatgiraffe.mailtrackerblocker",
             delete:  "/Library/Mail/Bundles/MailTrackerBlocker.mailbundle"
 
   zap trash: "~/Library/Containers/com.apple.mail/Data/Library/Application Support/com.onefatgiraffe.mailtrackerblocker"

--- a/Casks/s/starnet2.rb
+++ b/Casks/s/starnet2.rb
@@ -18,53 +18,47 @@ cask "starnet2" do
   depends_on :macos
   depends_on arch: :arm64
 
-  bin_path = "#{staged_path}/StarNet2T_MacOS"
-  installer = "#{bin_path}/installer.sh"
-  shim = "#{bin_path}/shim.sh"
+  generated_script "StarNet2T_MacOS/installer.sh", content: <<~EOS
+    #!/bin/sh
 
+    chmod 0755 "$(dirname "$0")"/lib/*
+    mkdir -p /usr/local/lib
+    cp "$(dirname "$0")"/lib/* /usr/local/lib/
+  EOS
+  generated_script "StarNet2T_MacOS/uninstaller.sh", content: <<~EOS
+    #!/bin/sh
+
+    for lib in "$(dirname "$0")"/lib/*; do
+      test -e "${lib}" || continue
+      rm -f "/usr/local/lib/$(basename "${lib}")"
+    done
+  EOS
   installer script: {
-    executable: installer,
+    executable: "StarNet2T_MacOS/installer.sh",
     sudo:       true,
   }
-  binary shim, target: "starnet2"
+  command_wrapper "starnet2", content: <<~EOS
+    #!/bin/sh
 
-  preflight do
-    File.write installer, <<~EOS
-      #!/bin/sh
+    cleanup() {
+      rm -f StarNet2_weights.pt
+    }
+    trap cleanup RETURN EXIT SIGINT SIGKILL
 
-      chmod 0755 #{bin_path}/lib/*
-      mkdir -p /usr/local/lib
-      cp #{bin_path}/lib/* /usr/local/lib/
-    EOS
+    ln -sf "#{staged_path}/StarNet2T_MacOS/StarNet2_weights.pt" .
+    "#{staged_path}/StarNet2T_MacOS/starnet2" "$@"
+  EOS
 
-    File.write shim, <<~EOS
-      #!/bin/sh
-
-      # delete the symlink on process exit
-      cleanup() {
-        rm -f StarNet2_weights.pt
-      }
-      trap cleanup RETURN EXIT SIGINT SIGKILL
-
-      # the binary hardcodes the weights path so we have to symlink it to the CWD
-      ln -sf #{bin_path}/StarNet2_weights.pt .
-      #{bin_path}/starnet2 $@
-    EOS
+  postflight_steps do
+    remove "StarNet2T_MacOS/installer.sh"
   end
 
-  uninstaller = "#{bin_path}/uninstaller.sh"
-  uninstall_preflight do
-    script_dir = "#{caskroom_path}/#{version}/StarNet2T_MacOS/lib"
-    next unless Dir.exist?(script_dir)
-
-    libs = Dir.children(script_dir).map { |lib| "/usr/local/lib/#{lib}" }
-    File.write uninstaller, <<~EOS
-      rm #{libs.join(" ")}
-    EOS
+  uninstall_postflight_steps do
+    remove "StarNet2T_MacOS/uninstaller.sh"
   end
 
   uninstall script: {
-    executable: uninstaller,
+    executable: "StarNet2T_MacOS/uninstaller.sh",
     sudo:       true,
   }
 

--- a/Casks/x/xscreensaver.rb
+++ b/Casks/x/xscreensaver.rb
@@ -15,22 +15,26 @@ cask "xscreensaver" do
   depends_on :macos
 
   pkg "Install Everything.pkg"
+  generated_script "uninstall-xscreensaver.sh", content: <<~'SH'
+    #!/bin/bash
+    for plist in /Library/Screen\ Savers/*.saver/Contents/Info.plist; do
+      [[ -e "$plist" ]] || continue
+      bundle_id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")
+      [[ "$bundle_id" == org.jwz* ]] || continue
+      screensaver_name=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$plist")
+      /bin/rm -rf "/Library/Screen Savers/${screensaver_name// /}.saver"
+    done
+  SH
 
-  # There is no uninstall script for this Cask, so a manual uninstall is performed
-  # Loop through all screensaver plist files, looking for "org,jwz" in the bundle identifier
-  # Then remove the screensaver if the bundle identifier matches
-  uninstall_postflight do
-    Pathname.glob("/Library/Screen Savers/*.saver/Contents/Info.plist").each do |plist|
-      bundle_id = `/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "#{plist}"`
-      next unless bundle_id.start_with?("org.jwz")
-
-      screensaver_name = `/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "#{plist}"`.delete(" ").strip
-      screensaver = Pathname.new("/Library/Screen Savers/#{screensaver_name}.saver")
-      Utils.gain_permissions_remove(screensaver) if screensaver.directory?
-    end
+  uninstall_postflight_steps do
+    remove "uninstall-xscreensaver.sh"
   end
 
-  uninstall pkgutil: "org.jwz.xscreensaver",
+  uninstall script:  {
+              executable: "uninstall-xscreensaver.sh",
+              sudo:       true,
+            },
+            pkgutil: "org.jwz.xscreensaver",
             delete:  [
               "/Applications/Apple2.app",
               "/Applications/Phosphor.app",


### PR DESCRIPTION
Five casks materialise fixed helper scripts for installers or later
structured steps.

- replace flight file writes and chmod calls with serialised artifacts
- preserve staged paths, literal content and artifact ordering
- keep generated paths inside each staged cask
- depend on Homebrew/brew's matching
  `Add generated cask scripts` change

Needs https://github.com/Homebrew/brew/pull/23184

