### PR TITLE
Migrate cask flight commands (5/8)

### DIFF
--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -1,23 +1,9 @@
 cask "affine" do
   arch arm: "arm64", intel: "x64"
   os macos: "macos", linux: "linux"
-
-  version "0.27.3"
-
   url_end = on_system_conditional macos: ".zip", linux: ".appimage"
 
-  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-#{os}-#{arch}#{url_end}",
-      verified: "github.com/toeverything/AFFiNE/"
-  name "AFFiNE"
-  desc "Note editor and whiteboard"
-  homepage "https://affine.pro/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  auto_updates true
+  version "0.27.3"
 
   on_macos do
     sha256 arm:   "bdeaa87ae8f200d63c738dfcdc3a8435fd8386e82cb28ef8b1ac5cc975207264",
@@ -34,7 +20,6 @@ cask "affine" do
       "~/Library/Saved Application State/pro.affine.app.savedState",
     ]
   end
-
   on_linux do
     sha256 "bc132e3f8dea5a05c3943da79822d92ed7f3218456eb051bd81d11d4f0580114"
 
@@ -42,4 +27,17 @@ cask "affine" do
 
     app_image "affine-#{version}-stable-linux-#{arch}.appimage", target: "AFFiNE.AppImage"
   end
+
+  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-#{os}-#{arch}#{url_end}",
+      verified: "github.com/toeverything/AFFiNE/"
+  name "AFFiNE"
+  desc "Note editor and whiteboard"
+  homepage "https://affine.pro/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
 end

--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -54,38 +54,42 @@ cask "gcloud-cli" do
   bash_completion "google-cloud-sdk/completion.bash.inc", target: "google-cloud-sdk"
   zsh_completion "google-cloud-sdk/completion.zsh.inc", target: "_google_cloud_sdk"
 
-  preflight do
-    FileUtils.cp_r staged_path/"google-cloud-sdk/.", google_cloud_sdk_root, remove_destination: true
-    FileUtils.rm_r(staged_path/"google-cloud-sdk")
-    FileUtils.ln_s google_cloud_sdk_root, (staged_path/"google-cloud-sdk")
+  preflight_steps do
+    copy "google-cloud-sdk/.", "share/google-cloud-sdk", target_base: :homebrew_prefix, recursive: true
+    remove "google-cloud-sdk", recursive: true
+    symlink "{{HOMEBREW_PREFIX}}/share/google-cloud-sdk", "google-cloud-sdk"
   end
 
-  postflight do
+  postflight_steps do
     # HACK: Allow existing shell profiles to work by linking the current version to the `latest` directory.
-    unless (latest_path = staged_path.dirname/"latest").directory?
-      FileUtils.ln_s staged_path, latest_path, force: true
+    unless_path_exists "{{caskroom_path}}/latest" do
+      symlink "{{staged_path}}", "{{caskroom_path}}/latest", force: true
     end
 
-    if OS.mac?
-      ENV["CLOUDSDK_PYTHON"] = "#{HOMEBREW_PREFIX}/opt/python@3.14/libexec/bin/python"
-      # Install required external dependencies via virtualenv
-      if File.exist?(File.join(Dir.home, "/.config/gcloud/virtenv"))
-        puts "deleting existing virtual env before enabling virtual env with current Python version"
-        system_command "#{google_cloud_sdk_root}/bin/gcloud",
-                       args:      ["config", "virtualenv", "delete", "-q"],
-                       reset_uid: true
+    on_macos do
+      if_path_exists "~/.config/gcloud/virtenv" do
+        run "share/google-cloud-sdk/bin/gcloud", base: :homebrew_prefix,
+                                                 args: ["config", "virtualenv", "delete", "-q"],
+                                                 env:  {
+                                                   "CLOUDSDK_PYTHON" => "{{HOMEBREW_PREFIX}}/opt/" \
+                                                                        "python@3.14/libexec/bin/python",
+                                                 }
       end
-      system_command  "#{google_cloud_sdk_root}/bin/gcloud",
-                      args:      ["config", "virtualenv", "create", "--python-to-use",
-                                  "#{HOMEBREW_PREFIX}/opt/python@3.14/libexec/bin/python"],
-                      reset_uid: true
-      system_command  "#{google_cloud_sdk_root}/bin/gcloud",
-                      args:      ["config", "virtualenv", "enable"],
-                      reset_uid: true
-
-      system_command  "#{google_cloud_sdk_root}/bin/gcloud",
-                      args:      ["version"],
-                      reset_uid: true
+      run "share/google-cloud-sdk/bin/gcloud", base: :homebrew_prefix,
+                                               args: ["config", "virtualenv", "create", "--python-to-use",
+                                                      "{{HOMEBREW_PREFIX}}/opt/python@3.14/libexec/bin/python"],
+                                               env:  {
+                                                 "CLOUDSDK_PYTHON" => "{{HOMEBREW_PREFIX}}/opt/" \
+                                                                      "python@3.14/libexec/bin/python",
+                                               }
+      run "share/google-cloud-sdk/bin/gcloud", base: :homebrew_prefix,
+                                               args: ["config", "virtualenv", "enable"],
+                                               env:  {
+                                                 "CLOUDSDK_PYTHON" => "{{HOMEBREW_PREFIX}}/opt/" \
+                                                                      "python@3.14/libexec/bin/python",
+                                               }
+      run "share/google-cloud-sdk/bin/gcloud", args: ["version"], base: :homebrew_prefix,
+          env: { "CLOUDSDK_PYTHON" => "{{HOMEBREW_PREFIX}}/opt/python@3.14/libexec/bin/python" }
     end
   end
 

--- a/Casks/k/kaleidoscope.rb
+++ b/Casks/k/kaleidoscope.rb
@@ -21,10 +21,9 @@ cask "kaleidoscope" do
 
   app "Kaleidoscope.app"
 
-  postflight do
-    contents = "#{appdir}/Kaleidoscope.app/Contents"
-    system_command "#{contents}/Resources/Integration/scripts/install_ksdiff",
-                   args: ["#{contents}/MacOS", "#{HOMEBREW_PREFIX}/bin"]
+  postflight_steps do
+    run "Kaleidoscope.app/Contents/Resources/Integration/scripts/install_ksdiff",
+        args: ["{{appdir}}/Kaleidoscope.app/Contents/MacOS", "{{HOMEBREW_PREFIX}}/bin"], base: :appdir
   end
 
   uninstall quit:    "app.kaleidoscope.v#{version.major}",

--- a/Casks/k/kaleidoscope@3.rb
+++ b/Casks/k/kaleidoscope@3.rb
@@ -20,10 +20,9 @@ cask "kaleidoscope@3" do
 
   app "Kaleidoscope.app"
 
-  postflight do
-    contents = "#{appdir}/Kaleidoscope.app/Contents"
-    system_command "#{contents}/Resources/Integration/scripts/install_ksdiff",
-                   args: ["#{contents}/MacOS", "#{HOMEBREW_PREFIX}/bin"]
+  postflight_steps do
+    run "Kaleidoscope.app/Contents/Resources/Integration/scripts/install_ksdiff",
+        args: ["{{appdir}}/Kaleidoscope.app/Contents/MacOS", "{{HOMEBREW_PREFIX}}/bin"], base: :appdir
   end
 
   uninstall quit:    "app.kaleidoscope.v#{version.major}",

--- a/Casks/k/keybase.rb
+++ b/Casks/k/keybase.rb
@@ -27,9 +27,8 @@ cask "keybase" do
 
   app "Keybase.app"
 
-  postflight do
-    system_command "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
-                   args: ["install-auto"]
+  postflight_steps do
+    run "Keybase.app/Contents/SharedSupport/bin/keybase", args: ["install-auto"], base: :appdir
   end
 
   uninstall launchctl: "keybase.Helper",

--- a/Casks/l/lg-onscreen-control.rb
+++ b/Casks/l/lg-onscreen-control.rb
@@ -33,10 +33,8 @@ cask "lg-onscreen-control" do
 
   pkg "OSC_V#{version.csv.first}_signed.pkg"
 
-  postflight do
-    system_command "/bin/chmod",
-                   args: ["755", "/usr/local", "/usr/local/lmm"],
-                   sudo: true
+  postflight_steps do
+    run "/bin/chmod", args: ["755", "/usr/local", "/usr/local/lmm"], sudo: true
   end
 
   uninstall quit:       [

--- a/Casks/m/minecraft-server.rb
+++ b/Casks/m/minecraft-server.rb
@@ -45,32 +45,26 @@ cask "minecraft-server" do
 
   container type: :naked
 
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/minecraft-server.wrapper.sh"
-  binary shimscript, target: "minecraft-server"
-
   config_dir = HOMEBREW_PREFIX.join("etc", "minecraft-server")
 
-  preflight do
-    FileUtils.mkdir_p config_dir
+  command_wrapper "minecraft-server", content: <<~EOS
+    #!/bin/sh
+    cd '#{config_dir}' && \
+      exec /usr/bin/java ${@:--Xms1024M -Xmx1024M} -jar '#{staged_path}/server.jar' nogui
+  EOS
 
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      cd '#{config_dir}' && \
-        exec /usr/bin/java ${@:--Xms1024M -Xmx1024M} -jar '#{staged_path}/server.jar' nogui
-    EOS
+  preflight_steps do
+    mkdir_p "{{HOMEBREW_PREFIX}}/etc/minecraft-server"
   end
 
   eula_file = config_dir.join("eula.txt")
 
-  postflight do
-    system_command shimscript
-    File.write(eula_file, File.read(eula_file).sub("eula=false", "eula=TRUE"))
+  postflight_steps do
+    run "minecraft-server.wrapper.sh", base: :staged_path
+    inreplace "{{HOMEBREW_PREFIX}}/etc/minecraft-server/eula.txt", "eula=false", "eula=TRUE", audit_result: false
   end
 
-  uninstall_preflight do
-    FileUtils.rm(eula_file) if eula_file.exist?
-  end
+  uninstall delete: eula_file
 
   zap trash: config_dir
 

--- a/Casks/m/mplabx-ide.rb
+++ b/Casks/m/mplabx-ide.rb
@@ -34,22 +34,16 @@ cask "mplabx-ide" do
   # staged_path files are owned by root which prevents binaries from being moved
   # to appdir, as cp does not use sudo. This copies the binaries after the owner
   # is changed.
-  postflight do
-    set_ownership staged_path.to_s
-    system_command "mkdir",
-                   args: ["-p", "#{appdir}/microchip/mplabx/#{version}"],
-                   sudo: true
-
-    system_command "cp",
-                   args: [
-                     "-pR",
-                     "#{staged_path}/MPLAB IPE v#{version}.app",
-                     "#{staged_path}/MPLAB X IDE v#{version}.app",
-                     "#{appdir}/microchip/mplabx/#{version}/",
-                   ],
-                   sudo: true
-
-    set_ownership "/Applications/microchip/mplabx/#{version}"
+  postflight_steps do
+    set_ownership "."
+    run "/bin/mkdir", args: ["-p", "{{appdir}}/microchip/mplabx/#{version}"], sudo: true
+    run "/bin/cp", args: [
+      "-pR",
+      "{{staged_path}}/MPLAB IPE v#{version}.app",
+      "{{staged_path}}/MPLAB X IDE v#{version}.app",
+      "{{appdir}}/microchip/mplabx/#{version}/",
+    ], sudo: true
+    set_ownership "microchip/mplabx/#{version}", base: :appdir
   end
 
   uninstall script: {

--- a/Casks/n/ncar-ncl.rb
+++ b/Casks/n/ncar-ncl.rb
@@ -19,8 +19,8 @@ cask "ncar-ncl" do
   artifact "bin", target: "#{HOMEBREW_PREFIX}/ncl-#{version}/bin"
   artifact "lib", target: "#{HOMEBREW_PREFIX}/ncl-#{version}/lib"
 
-  preflight do
-    system_command "/bin/mkdir", args: ["-p", "#{HOMEBREW_PREFIX}/ncl-#{version}"], sudo: true
+  preflight_steps do
+    run "/bin/mkdir", args: ["-p", "{{HOMEBREW_PREFIX}}/ncl-#{version}"], sudo: true
   end
 
   uninstall delete: "#{HOMEBREW_PREFIX}/ncl-#{version}"

--- a/Casks/o/openzfs.rb
+++ b/Casks/o/openzfs.rb
@@ -65,8 +65,8 @@ cask "openzfs" do
     set_ownership "/usr/local/zfs"
   end
 
-  uninstall_preflight do
-    system "sudo", "/usr/local/zfs/bin/zpool", "export", "-af"
+  uninstall_preflight_steps do
+    run "/usr/local/zfs/bin/zpool", args: ["export", "-af"], sudo: true
   end
 
   uninstall launchctl: [

--- a/Casks/o/orbstack.rb
+++ b/Casks/o/orbstack.rb
@@ -28,9 +28,8 @@ cask "orbstack" do
   zsh_completion "#{appdir}/OrbStack.app/Contents/Resources/completions/zsh/_orb"
   zsh_completion "#{appdir}/OrbStack.app/Contents/Resources/completions/zsh/_orbctl"
 
-  postflight do
-    system_command "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl",
-                   args: ["_internal", "brew-postflight"]
+  postflight_steps do
+    run "OrbStack.app/Contents/MacOS/bin/orbctl", args: ["_internal", "brew-postflight"], base: :appdir
   end
 
   uninstall script: {

--- a/Casks/p/parallels.rb
+++ b/Casks/p/parallels.rb
@@ -33,17 +33,13 @@ cask "parallels" do
 
   app "Parallels Desktop.app"
 
-  preflight do
-    system_command "chflags",
-                   args: ["nohidden", "#{staged_path}/Parallels Desktop.app"]
-    system_command "xattr",
-                   args: ["-d", "com.apple.FinderInfo", "#{staged_path}/Parallels Desktop.app"]
+  preflight_steps do
+    run "chflags", args: ["nohidden", "{{staged_path}}/Parallels Desktop.app"]
+    run "xattr", args: ["-d", "com.apple.FinderInfo", "{{staged_path}}/Parallels Desktop.app"]
   end
 
-  postflight do
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init"],
-                   sudo: true
+  postflight_steps do
+    run "Parallels Desktop.app/Contents/MacOS/inittool", args: ["init"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/p/parallels@14.rb
+++ b/Casks/p/parallels@14.rb
@@ -25,26 +25,20 @@ cask "parallels@14" do
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/67202
   container type: :naked
 
-  preflight do
-    system_command "/usr/bin/hdiutil",
-                   args: ["attach", "-nobrowse", "#{staged_path}/ParallelsDesktop-#{version}.dmg"]
-    system_command "/Volumes/Parallels Desktop #{version.major}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["install", "-t", "#{appdir}/Parallels Desktop.app", "-s"],
-                   sudo: true
-    system_command "/usr/bin/hdiutil",
-                   args: ["detach", "/Volumes/Parallels Desktop #{version.major}"]
+  preflight_steps do
+    run "/usr/bin/hdiutil", args: ["attach", "-nobrowse", "{{staged_path}}/ParallelsDesktop-#{version}.dmg"]
+    run "/Volumes/Parallels Desktop #{version.major}/Parallels Desktop.app/Contents/MacOS/inittool",
+        args: ["install", "-t", "{{appdir}}/Parallels Desktop.app", "-s"], sudo: true
+    run "/usr/bin/hdiutil", args: ["detach", "/Volumes/Parallels Desktop #{version.major}"]
   end
 
-  postflight do
+  postflight_steps do
     # Unhide the application
-    system_command "/usr/bin/chflags",
-                   args: ["nohidden", "#{appdir}/Parallels Desktop.app"],
-                   sudo: true
+    run "/usr/bin/chflags", args: ["nohidden", "{{appdir}}/Parallels Desktop.app"], sudo: true
 
     # Run the initialization script
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init", "-b", "#{appdir}/Parallels Desktop.app"],
-                   sudo: true
+    run "Parallels Desktop.app/Contents/MacOS/inittool",
+        args: ["init", "-b", "{{appdir}}/Parallels Desktop.app"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/p/parallels@15.rb
+++ b/Casks/p/parallels@15.rb
@@ -24,17 +24,13 @@ cask "parallels@15" do
 
   app "Parallels Desktop.app"
 
-  preflight do
-    system_command "chflags",
-                   args: ["nohidden", "#{staged_path}/Parallels Desktop.app"]
-    system_command "xattr",
-                   args: ["-d", "com.apple.FinderInfo", "#{staged_path}/Parallels Desktop.app"]
+  preflight_steps do
+    run "chflags", args: ["nohidden", "{{staged_path}}/Parallels Desktop.app"]
+    run "xattr", args: ["-d", "com.apple.FinderInfo", "{{staged_path}}/Parallels Desktop.app"]
   end
 
-  postflight do
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init"],
-                   sudo: true
+  postflight_steps do
+    run "Parallels Desktop.app/Contents/MacOS/inittool", args: ["init"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/p/parallels@16.rb
+++ b/Casks/p/parallels@16.rb
@@ -24,17 +24,13 @@ cask "parallels@16" do
 
   app "Parallels Desktop.app"
 
-  preflight do
-    system_command "chflags",
-                   args: ["nohidden", "#{staged_path}/Parallels Desktop.app"]
-    system_command "xattr",
-                   args: ["-d", "com.apple.FinderInfo", "#{staged_path}/Parallels Desktop.app"]
+  preflight_steps do
+    run "chflags", args: ["nohidden", "{{staged_path}}/Parallels Desktop.app"]
+    run "xattr", args: ["-d", "com.apple.FinderInfo", "{{staged_path}}/Parallels Desktop.app"]
   end
 
-  postflight do
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init"],
-                   sudo: true
+  postflight_steps do
+    run "Parallels Desktop.app/Contents/MacOS/inittool", args: ["init"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/p/parallels@17.rb
+++ b/Casks/p/parallels@17.rb
@@ -24,17 +24,13 @@ cask "parallels@17" do
 
   app "Parallels Desktop.app"
 
-  preflight do
-    system_command "chflags",
-                   args: ["nohidden", "#{staged_path}/Parallels Desktop.app"]
-    system_command "xattr",
-                   args: ["-d", "com.apple.FinderInfo", "#{staged_path}/Parallels Desktop.app"]
+  preflight_steps do
+    run "chflags", args: ["nohidden", "{{staged_path}}/Parallels Desktop.app"]
+    run "xattr", args: ["-d", "com.apple.FinderInfo", "{{staged_path}}/Parallels Desktop.app"]
   end
 
-  postflight do
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init"],
-                   sudo: true
+  postflight_steps do
+    run "Parallels Desktop.app/Contents/MacOS/inittool", args: ["init"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/p/parallels@18.rb
+++ b/Casks/p/parallels@18.rb
@@ -32,17 +32,13 @@ cask "parallels@18" do
 
   app "Parallels Desktop.app"
 
-  preflight do
-    system_command "chflags",
-                   args: ["nohidden", "#{staged_path}/Parallels Desktop.app"]
-    system_command "xattr",
-                   args: ["-d", "com.apple.FinderInfo", "#{staged_path}/Parallels Desktop.app"]
+  preflight_steps do
+    run "chflags", args: ["nohidden", "{{staged_path}}/Parallels Desktop.app"]
+    run "xattr", args: ["-d", "com.apple.FinderInfo", "{{staged_path}}/Parallels Desktop.app"]
   end
 
-  postflight do
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init"],
-                   sudo: true
+  postflight_steps do
+    run "Parallels Desktop.app/Contents/MacOS/inittool", args: ["init"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/p/parallels@19.rb
+++ b/Casks/p/parallels@19.rb
@@ -32,17 +32,13 @@ cask "parallels@19" do
 
   app "Parallels Desktop.app"
 
-  preflight do
-    system_command "chflags",
-                   args: ["nohidden", "#{staged_path}/Parallels Desktop.app"]
-    system_command "xattr",
-                   args: ["-d", "com.apple.FinderInfo", "#{staged_path}/Parallels Desktop.app"]
+  preflight_steps do
+    run "chflags", args: ["nohidden", "{{staged_path}}/Parallels Desktop.app"]
+    run "xattr", args: ["-d", "com.apple.FinderInfo", "{{staged_path}}/Parallels Desktop.app"]
   end
 
-  postflight do
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init"],
-                   sudo: true
+  postflight_steps do
+    run "Parallels Desktop.app/Contents/MacOS/inittool", args: ["init"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/p/parallels@20.rb
+++ b/Casks/p/parallels@20.rb
@@ -33,17 +33,13 @@ cask "parallels@20" do
 
   app "Parallels Desktop.app"
 
-  preflight do
-    system_command "chflags",
-                   args: ["nohidden", "#{staged_path}/Parallels Desktop.app"]
-    system_command "xattr",
-                   args: ["-d", "com.apple.FinderInfo", "#{staged_path}/Parallels Desktop.app"]
+  preflight_steps do
+    run "chflags", args: ["nohidden", "{{staged_path}}/Parallels Desktop.app"]
+    run "xattr", args: ["-d", "com.apple.FinderInfo", "{{staged_path}}/Parallels Desktop.app"]
   end
 
-  postflight do
-    system_command "#{appdir}/Parallels Desktop.app/Contents/MacOS/inittool",
-                   args: ["init"],
-                   sudo: true
+  postflight_steps do
+    run "Parallels Desktop.app/Contents/MacOS/inittool", args: ["init"], base: :appdir, sudo: true
   end
 
   uninstall_preflight_steps do

--- a/Casks/s/shadowsocksx-ng-r.rb
+++ b/Casks/s/shadowsocksx-ng-r.rb
@@ -12,8 +12,8 @@ cask "shadowsocksx-ng-r" do
 
   app "ShadowsocksX-NG-R8.app"
 
-  postflight do
-    system_command "#{appdir}/ShadowsocksX-NG-R8.app/Contents/Resources/install_helper.sh"
+  postflight_steps do
+    run "ShadowsocksX-NG-R8.app/Contents/Resources/install_helper.sh", base: :appdir
   end
 
   uninstall launchctl: [

--- a/Casks/s/soundflower.rb
+++ b/Casks/s/soundflower.rb
@@ -14,10 +14,8 @@ cask "soundflower" do
 
   pkg "Soundflower.pkg"
 
-  postflight do
-    system_command "/sbin/kextload",
-                   args: ["-b", "com.Cycling74.driver.Soundflower"],
-                   sudo: true
+  postflight_steps do
+    run "/sbin/kextload", args: ["-b", "com.Cycling74.driver.Soundflower"], sudo: true
   end
 
   # early_script is a workaround for a slowly unloading kext, see private-eye Cask

--- a/Casks/s/squirrelsql.rb
+++ b/Casks/s/squirrelsql.rb
@@ -11,80 +11,76 @@ cask "squirrelsql" do
   depends_on :macos
   container type: :naked
 
-  installoptions = "#{staged_path}/install-options.xml"
-
-  preflight do
+  preflight_steps do
     # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-    File.open(installoptions, "w") do |f|
-      f.print <<~EOS
-        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-        <AutomatedInstallation langpack="eng">
-        <com.izforge.izpack.panels.hello.HelloPanel id="HelloPanel_0"/>
-        <com.izforge.izpack.panels.htmlinfo.HTMLInfoPanel id="HTMLInfoPanel_1"/>
-        <com.izforge.izpack.panels.target.TargetPanel id="TargetPanel_2">
-        <installpath>#{appdir}/SQuirreLSQL.app</installpath>
-        </com.izforge.izpack.panels.target.TargetPanel>
-        <com.izforge.izpack.panels.packs.PacksPanel id="PacksPanel_3">
-        <pack index="0" name="Base" selected="true"/>
-        <pack index="1" name="Standard" selected="true"/>
-        <pack index="2" name="Optional Plugin - Mac OS Plugin (older Mac versions only)" selected="true"/>
-        <pack index="3" name="Optional Plugin - Greenplum" selected="true"/>
-        <pack index="4" name="Optional Plugin - WIKI table configurations" selected="true"/>
-        <pack index="5" name="Optional Plugin - Swing Violation Dedector" selected="true"/>
-        <pack index="6" name="Optional Plugin - Multi Source" selected="true"/>
-        <pack index="7" name="Optional Plugin - Vertica" selected="true"/>
-        <pack index="8" name="Optional Plugin - DB2" selected="true"/>
-        <pack index="9" name="Optional Plugin - Derby" selected="true"/>
-        <pack index="10" name="Optional Plugin - Firebird " selected="true"/>
-        <pack index="11" name="Optional Plugin - Hibernate" selected="true"/>
-        <pack index="12" name="Optional Plugin - H2 " selected="true"/>
-        <pack index="13" name="Optional Plugin - Informix " selected="true"/>
-        <pack index="14" name="Optional Plugin - Microsoft SQL Server " selected="true"/>
-        <pack index="15" name="Optional Plugin - MySQL " selected="true"/>
-        <pack index="16" name="Optional Plugin - Netezza " selected="true"/>
-        <pack index="17" name="Optional Plugin - Oracle" selected="true"/>
-        <pack index="18" name="Optional Plugin - PostgreSQL " selected="true"/>
-        <pack index="19" name="Optional Plugin - Session Scripts" selected="true"/>
-        <pack index="20" name="Optional Plugin - Smart Tools " selected="true"/>
-        <pack index="21" name="Optional Plugin - SQL Parametrisation " selected="true"/>
-        <pack index="22" name="Optional Plugin - SQL Replace " selected="true"/>
-        <pack index="23" name="Optional Plugin - SQL Validator " selected="true"/>
-        <pack index="24" name="Optional Plugin - Sybase " selected="true"/>
-        <pack index="25" name="Optional Plugin - High resolution icon " selected="true"/>
-        <pack index="26" name="Optional Plugin - Internationalization " selected="true"/>
-        <pack index="27" name="Optional Plugin - Intersystems Cache Plugin " selected="true"/>
-        <pack index="28" name="Optional Translation - Brazilian Portuguese" selected="true"/>
-        <pack index="29" name="Optional Translation - Bulgarian" selected="true"/>
-        <pack index="30" name="Optional Translation - Czech" selected="true"/>
-        <pack index="31" name="Optional Translation - Simplified Chinese" selected="true"/>
-        <pack index="32" name="Optional Translation - French" selected="true"/>
-        <pack index="33" name="Optional Translation - German" selected="true"/>
-        <pack index="34" name="Optional Translation - Italian" selected="true"/>
-        <pack index="35" name="Optional Translation - Japanese" selected="true"/>
-        <pack index="36" name="Optional Translation - Korean" selected="true"/>
-        <pack index="37" name="Optional Translation - Polish" selected="true"/>
-        <pack index="38" name="Optional Translation - Russian" selected="true"/>
-        <pack index="39" name="Optional Translation - Spanish" selected="true"/>
-        </com.izforge.izpack.panels.packs.PacksPanel>
-        <com.izforge.izpack.panels.install.InstallPanel id="InstallPanel_4"/>
-        <com.izforge.izpack.panels.finish.FinishPanel id="FinishPanel_5"/>
-        </AutomatedInstallation>
-      EOS
-    end
+    write "install-options.xml", <<~EOS
+      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+      <AutomatedInstallation langpack="eng">
+      <com.izforge.izpack.panels.hello.HelloPanel id="HelloPanel_0"/>
+      <com.izforge.izpack.panels.htmlinfo.HTMLInfoPanel id="HTMLInfoPanel_1"/>
+      <com.izforge.izpack.panels.target.TargetPanel id="TargetPanel_2">
+      <installpath>{{appdir}}/SQuirreLSQL.app</installpath>
+      </com.izforge.izpack.panels.target.TargetPanel>
+      <com.izforge.izpack.panels.packs.PacksPanel id="PacksPanel_3">
+      <pack index="0" name="Base" selected="true"/>
+      <pack index="1" name="Standard" selected="true"/>
+      <pack index="2" name="Optional Plugin - Mac OS Plugin (older Mac versions only)" selected="true"/>
+      <pack index="3" name="Optional Plugin - Greenplum" selected="true"/>
+      <pack index="4" name="Optional Plugin - WIKI table configurations" selected="true"/>
+      <pack index="5" name="Optional Plugin - Swing Violation Dedector" selected="true"/>
+      <pack index="6" name="Optional Plugin - Multi Source" selected="true"/>
+      <pack index="7" name="Optional Plugin - Vertica" selected="true"/>
+      <pack index="8" name="Optional Plugin - DB2" selected="true"/>
+      <pack index="9" name="Optional Plugin - Derby" selected="true"/>
+      <pack index="10" name="Optional Plugin - Firebird " selected="true"/>
+      <pack index="11" name="Optional Plugin - Hibernate" selected="true"/>
+      <pack index="12" name="Optional Plugin - H2 " selected="true"/>
+      <pack index="13" name="Optional Plugin - Informix " selected="true"/>
+      <pack index="14" name="Optional Plugin - Microsoft SQL Server " selected="true"/>
+      <pack index="15" name="Optional Plugin - MySQL " selected="true"/>
+      <pack index="16" name="Optional Plugin - Netezza " selected="true"/>
+      <pack index="17" name="Optional Plugin - Oracle" selected="true"/>
+      <pack index="18" name="Optional Plugin - PostgreSQL " selected="true"/>
+      <pack index="19" name="Optional Plugin - Session Scripts" selected="true"/>
+      <pack index="20" name="Optional Plugin - Smart Tools " selected="true"/>
+      <pack index="21" name="Optional Plugin - SQL Parametrisation " selected="true"/>
+      <pack index="22" name="Optional Plugin - SQL Replace " selected="true"/>
+      <pack index="23" name="Optional Plugin - SQL Validator " selected="true"/>
+      <pack index="24" name="Optional Plugin - Sybase " selected="true"/>
+      <pack index="25" name="Optional Plugin - High resolution icon " selected="true"/>
+      <pack index="26" name="Optional Plugin - Internationalization " selected="true"/>
+      <pack index="27" name="Optional Plugin - Intersystems Cache Plugin " selected="true"/>
+      <pack index="28" name="Optional Translation - Brazilian Portuguese" selected="true"/>
+      <pack index="29" name="Optional Translation - Bulgarian" selected="true"/>
+      <pack index="30" name="Optional Translation - Czech" selected="true"/>
+      <pack index="31" name="Optional Translation - Simplified Chinese" selected="true"/>
+      <pack index="32" name="Optional Translation - French" selected="true"/>
+      <pack index="33" name="Optional Translation - German" selected="true"/>
+      <pack index="34" name="Optional Translation - Italian" selected="true"/>
+      <pack index="35" name="Optional Translation - Japanese" selected="true"/>
+      <pack index="36" name="Optional Translation - Korean" selected="true"/>
+      <pack index="37" name="Optional Translation - Polish" selected="true"/>
+      <pack index="38" name="Optional Translation - Russian" selected="true"/>
+      <pack index="39" name="Optional Translation - Spanish" selected="true"/>
+      </com.izforge.izpack.panels.packs.PacksPanel>
+      <com.izforge.izpack.panels.install.InstallPanel id="InstallPanel_4"/>
+      <com.izforge.izpack.panels.finish.FinishPanel id="FinishPanel_5"/>
+      </AutomatedInstallation>
+    EOS
   end
 
-  postflight do
-    system_command "/usr/bin/java",
-                   args: ["-jar", "#{staged_path}/squirrel-sql-#{version}-MACOSX-install.jar", installoptions.to_s]
+  postflight_steps do
+    run "/usr/bin/java",
+        args: ["-jar", "{{staged_path}}/squirrel-sql-#{version}-MACOSX-install.jar",
+               "{{staged_path}}/install-options.xml"]
   end
 
-  uninstall_preflight do
-    system_command "/usr/bin/java",
-                   args:         ["-jar", "#{appdir}/SQuirreLSQL.app/Uninstaller/uninstaller.jar", "-f", "-c"],
-                   must_succeed: false
-  end
-
-  uninstall delete: "#{appdir}/SQuirreLSQL.app"
+  uninstall script: {
+              executable:   "/usr/bin/java",
+              args:         ["-jar", "#{appdir}/SQuirreLSQL.app/Uninstaller/uninstaller.jar", "-f", "-c"],
+              must_succeed: false,
+            },
+            delete: "#{appdir}/SQuirreLSQL.app"
 
   zap trash: "~/.squirrel-sql"
 

--- a/Casks/t/topaz-video.rb
+++ b/Casks/t/topaz-video.rb
@@ -23,9 +23,9 @@ cask "topaz-video" do
   # options for the user to manually install the plugins post-installation. Until this is resolved
   # by the vendor, trigger the plugin installation scripts here so the end state is a ready-to-use
   # installation as per the previous version users are likely to be transitioning from.
-  postflight do
-    system "sudo", "bash", "#{appdir}/Topaz Video.app/Contents/Resources/ae_inst.sh"
-    system "sudo", "bash", "#{appdir}/Topaz Video.app/Contents/Resources/ofx_inst.sh"
+  postflight_steps do
+    run "/bin/bash", args: ["{{appdir}}/Topaz Video.app/Contents/Resources/ae_inst.sh"], sudo: true
+    run "/bin/bash", args: ["{{appdir}}/Topaz Video.app/Contents/Resources/ofx_inst.sh"], sudo: true
   end
 
   uninstall launchctl: "com.topazlabs.veai.nukepath",

--- a/Casks/u/unison-app.rb
+++ b/Casks/u/unison-app.rb
@@ -30,8 +30,8 @@ cask "unison-app" do
   app "Unison.app"
   binary "#{appdir}/Unison.app/Contents/MacOS/cltool", target: "unison"
 
-  postflight do
-    system_command "/usr/bin/defaults", args: ["write", "edu.upenn.cis.Unison", "CheckCltool", "-bool", "false"]
+  postflight_steps do
+    run "/usr/bin/defaults", args: ["write", "edu.upenn.cis.Unison", "CheckCltool", "-bool", "false"]
   end
 
   zap trash: [

--- a/Casks/v/vnc-server.rb
+++ b/Casks/v/vnc-server.rb
@@ -18,9 +18,11 @@ cask "vnc-server" do
 
   pkg "VNC-Server-#{version}-MacOSX-universal.pkg"
 
-  uninstall_preflight do
-    file = "/Applications/RealVNC/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh"
-    system_command file, print_stderr: false, sudo: true if File.exist?(file)
+  uninstall_preflight_steps do
+    if_path_exists "/Applications/RealVNC/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh" do
+      run "/Applications/RealVNC/Uninstall VNC Server.app/Contents/Resources/uninstaller.sh",
+          print_stderr: false, sudo: true
+    end
   end
 
   uninstall launchctl: [


### PR DESCRIPTION
Twenty-four casks invoke known executables with literal arguments during
flight phases.

- serialise environments, streams, working directories and guards
- retain file, removal, replacement and wrapper work in mixed blocks
- remove each fully represented Ruby flight block
- depend on Homebrew/brew's matching
  `Add constrained install commands` change

Needs https://github.com/Homebrew/brew/pull/23186

