### PR TITLE
Migrate cask process termination (6/8)

### DIFF
--- a/Casks/a/appvolume.rb
+++ b/Casks/a/appvolume.rb
@@ -22,10 +22,8 @@ cask "appvolume" do
 
   pkg "AppVolume-#{version}-#{arch}.pkg"
 
-  uninstall_postflight do
-    system_command "/usr/bin/killall",
-                   args: ["coreaudiod"],
-                   sudo: true
+  uninstall_postflight_steps do
+    terminate_process "coreaudiod", sudo: true, must_succeed: true
   end
 
   uninstall launchctl: "io.appvolume.daemon",

--- a/Casks/a/awesun.rb
+++ b/Casks/a/awesun.rb
@@ -23,13 +23,18 @@ cask "awesun" do
 
   pkg "AweSun.pkg"
 
-  postflight do
+  postflight_steps do
     # The postinstall script automatically opens the app. Therefore, we must
     # suppress this behavior to make the cask installation non-interactive.
-    retries ||= 3
-    ohai "The AweSun package postinstall script launches the app" if retries >= 3
-    ohai "Attempting to close AweSun to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/AweSun.app"]
+    terminate_process(
+      "/Applications/AweSun.app",
+      match:        :full,
+      must_succeed: true,
+      notices:      [
+        "The AweSun package postinstall script launches the app",
+        "Attempting to close AweSun to avoid unwanted user intervention",
+      ],
+    )
   end
 
   uninstall launchctl: [

--- a/Casks/b/background-music.rb
+++ b/Casks/b/background-music.rb
@@ -16,11 +16,8 @@ cask "background-music" do
 
   pkg "BackgroundMusic-#{version}.pkg"
 
-  uninstall_postflight do
-    system_command "/usr/bin/killall",
-                   args:         ["coreaudiod"],
-                   sudo:         true,
-                   must_succeed: true
+  uninstall_postflight_steps do
+    terminate_process "coreaudiod", sudo: true, must_succeed: true
   end
 
   uninstall launchctl: "com.bearisdriving.BGM.XPCHelper",

--- a/Casks/b/beid-token.rb
+++ b/Casks/b/beid-token.rb
@@ -16,18 +16,21 @@ cask "beid-token" do
 
   pkg "eID-Quickinstaller-signed.pkg"
 
-  postflight do
+  postflight_steps do
     # Description: Ensure console variant of postinstall is non-interactive.
     # This is because `open "$APP_PATH"&` is called from the postinstall
     # script of the package and we don't want any user intervention there.
-    retries ||= 3
-    ohai "The BEIDToken package postinstall script launches the BEIDToken app" if retries >= 3
-    ohai "Attempting to close BEIDToken.app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/BEIDToken.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close BEIDToken.app"
+    terminate_process(
+      "/Applications/BEIDToken.app",
+      match:           :full,
+      attempts:        3,
+      must_succeed:    false,
+      notices:         [
+        "The BEIDToken package postinstall script launches the BEIDToken app",
+        "Attempting to close BEIDToken.app to avoid unwanted user intervention",
+      ],
+      failure_message: "Unable to forcibly close BEIDToken.app",
+    )
   end
 
   uninstall quit:    [

--- a/Casks/b/blurscreen.rb
+++ b/Casks/b/blurscreen.rb
@@ -17,18 +17,21 @@ cask "blurscreen" do
 
   pkg "BlurScreen-v2.pkg"
 
-  postflight do
+  postflight_steps do
     # Description: Ensure console variant of postinstall is non-interactive.
     # This is because `open "$APP_PATH"&` is called from the postinstall
     # script of the package and we don't want any user intervention there.
-    retries ||= 3
-    ohai "The BlurScreen package postinstall script launches the BlurScreen app" if retries >= 3
-    ohai "Attempting to close BlurScreen.app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/BlurScreen.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close BlurScreen.app"
+    terminate_process(
+      "/Applications/BlurScreen.app",
+      match:           :full,
+      attempts:        3,
+      must_succeed:    false,
+      notices:         [
+        "The BlurScreen package postinstall script launches the BlurScreen app",
+        "Attempting to close BlurScreen.app to avoid unwanted user intervention",
+      ],
+      failure_message: "Unable to forcibly close BlurScreen.app",
+    )
   end
 
   uninstall quit:    "com.sanskar.blurscreen",

--- a/Casks/g/gamemaker.rb
+++ b/Casks/g/gamemaker.rb
@@ -17,18 +17,21 @@ cask "gamemaker" do
 
   pkg "GameMaker-#{version}.pkg"
 
-  postflight do
+  postflight_steps do
     # Description: Ensure console variant of postinstall is non-interactive.
     # This is because `open "$APP_PATH"&` is called from the postinstall
     # script of the package and we don't want any user intervention there.
-    retries ||= 3
-    ohai "The GameMaker package postinstall script launches the GameMaker app" if retries >= 3
-    ohai "Attempting to close com.yoyogames.gms2 to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/GameMaker.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close GameMaker.app"
+    terminate_process(
+      "/Applications/GameMaker.app",
+      match:           :full,
+      attempts:        3,
+      must_succeed:    false,
+      notices:         [
+        "The GameMaker package postinstall script launches the GameMaker app",
+        "Attempting to close com.yoyogames.gms2 to avoid unwanted user intervention",
+      ],
+      failure_message: "Unable to forcibly close GameMaker.app",
+    )
   end
 
   uninstall pkgutil: "com.yoyogames.gms2",

--- a/Casks/l/luniistore.rb
+++ b/Casks/l/luniistore.rb
@@ -21,13 +21,18 @@ cask "luniistore" do
 
   pkg "Lunii-#{version}-#{arch}.pkg"
 
-  postflight do
+  postflight_steps do
     # The postinstall script automatically opens the app. Therefore, we must
     # suppress this behavior to make the cask installation non-interactive.
-    retries ||= 3
-    ohai "The Luniistore package postinstall script launches the app" if retries >= 3
-    ohai "Attempting to close Luniistore to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/Lunii.app"]
+    terminate_process(
+      "/Applications/Lunii.app",
+      match:        :full,
+      must_succeed: true,
+      notices:      [
+        "The Luniistore package postinstall script launches the app",
+        "Attempting to close Luniistore to avoid unwanted user intervention",
+      ],
+    )
   end
 
   uninstall quit:    "com.lunii.luniistore",

--- a/Casks/p/proxy-audio-device.rb
+++ b/Casks/p/proxy-audio-device.rb
@@ -12,22 +12,16 @@ cask "proxy-audio-device" do
   app "Proxy Audio Device Settings.app"
   artifact "ProxyAudioDevice.driver", target: "/Library/Audio/Plug-Ins/HAL/ProxyAudioDevice.driver"
 
-  postflight do
+  postflight_steps do
     set_ownership "/Library/Audio/Plug-Ins/HAL/ProxyAudioDevice.driver",
                   user:  "root",
                   group: "wheel"
 
-    system_command "/usr/bin/killall",
-                   args:         ["coreaudiod"],
-                   sudo:         true,
-                   must_succeed: true
+    terminate_process "coreaudiod", sudo: true, must_succeed: true
   end
 
-  uninstall_postflight do
-    system_command "/usr/bin/killall",
-                   args:         ["coreaudiod"],
-                   sudo:         true,
-                   must_succeed: true
+  uninstall_postflight_steps do
+    terminate_process "coreaudiod", sudo: true, must_succeed: true
   end
 
   zap trash: "~/Library/Saved Application State/net.briankendall.Proxy-Audio-Device-Settings.savedState"

--- a/Casks/t/teamviewer.rb
+++ b/Casks/t/teamviewer.rb
@@ -62,16 +62,19 @@ cask "teamviewer" do
   conflicts_with cask: "teamviewer-host"
   depends_on :macos
 
-  postflight do
+  postflight_steps do
     # postinstall launches the app
-    retries ||= 3
-    ohai "The TeamViewer package postinstall script launches the TeamViewer app" if retries >= 3
-    ohai "Attempting to close the TeamViewer app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/TeamViewer.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close TeamViewer"
+    terminate_process(
+      "/Applications/TeamViewer.app",
+      match:           :full,
+      attempts:        3,
+      must_succeed:    false,
+      notices:         [
+        "The TeamViewer package postinstall script launches the TeamViewer app",
+        "Attempting to close the TeamViewer app to avoid unwanted user intervention",
+      ],
+      failure_message: "Unable to forcibly close TeamViewer",
+    )
   end
 
   uninstall launchctl: [

--- a/Casks/t/trader-workstation.rb
+++ b/Casks/t/trader-workstation.rb
@@ -32,11 +32,11 @@ cask "trader-workstation" do
     ],
   }
 
-  uninstall_preflight do
-    ohai "Stopping all running instances of Trader Workstation prior to uninstall"
-    system_command "/usr/bin/pkill", args: ["-f", "#{appdir}/Trader Workstation/Trader Workstation.app"]
-  rescue RuntimeError
-    ohai "No running instances of Trader Workstation found"
+  uninstall_preflight_steps do
+    terminate_process "{{appdir}}/Trader Workstation/Trader Workstation.app",
+                      match: :full, must_succeed: false,
+                      notices: ["Stopping all running instances of Trader Workstation prior to uninstall"],
+                      failure_message: "No running instances of Trader Workstation found"
   end
 
   uninstall quit:   "com.install4j.5889-6375-8446-2021",

--- a/Casks/u/uuremote.rb
+++ b/Casks/u/uuremote.rb
@@ -19,17 +19,20 @@ cask "uuremote" do
 
   pkg "uuyc_#{version}.pkg"
 
-  postflight do
+  postflight_steps do
     # The postinstall script automatically opens the app. Therefore, we must
     # suppress this behavior to make the cask installation non-interactive.
-    retries ||= 3
-    ohai "The UU Remote package postinstall script launches the app" if retries >= 3
-    ohai "Attempting to close UU Remote to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/UURemote.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close UU Remote"
+    terminate_process(
+      "/Applications/UURemote.app",
+      match:           :full,
+      attempts:        3,
+      must_succeed:    false,
+      notices:         [
+        "The UU Remote package postinstall script launches the app",
+        "Attempting to close UU Remote to avoid unwanted user intervention",
+      ],
+      failure_message: "Unable to forcibly close UU Remote",
+    )
   end
 
   uninstall launchctl: [

--- a/Casks/v/vcam.rb
+++ b/Casks/v/vcam.rb
@@ -16,18 +16,21 @@ cask "vcam" do
 
   pkg "VCam_#{version}.pkg"
 
-  postflight do
+  postflight_steps do
     # Description: Ensure console variant of postinstall is non-interactive.
     # This is because `open /Applications/VCam/VCam.app` is called from the
     # postinstall script of the package and we don't want any user intervention there.
-    retries ||= 3
-    ohai "The VCam package postinstall script launches the VCam app" if retries >= 3
-    ohai "Attempting to close VCam.app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/VCam/VCam.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close VCam.app"
+    terminate_process(
+      "/Applications/VCam/VCam.app",
+      match:           :full,
+      attempts:        3,
+      must_succeed:    false,
+      notices:         [
+        "The VCam package postinstall script launches the VCam app",
+        "Attempting to close VCam.app to avoid unwanted user intervention",
+      ],
+      failure_message: "Unable to forcibly close VCam.app",
+    )
   end
 
   uninstall quit:    "ai.vcam.desktop",

--- a/Casks/z/zoom.rb
+++ b/Casks/z/zoom.rb
@@ -22,18 +22,21 @@ cask "zoom" do
 
   pkg "zoomusInstallerFull.pkg"
 
-  postflight do
+  postflight_steps do
     # Description: Ensure console variant of postinstall is non-interactive.
     # This is because `open "$APP_PATH"&` is called from the postinstall
     # script of the package and we don't want any user intervention there.
-    retries ||= 3
-    ohai "The Zoom package postinstall script launches the Zoom app" if retries >= 3
-    ohai "Attempting to close zoom.us.app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/zoom.us.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close zoom.us.app"
+    terminate_process(
+      "/Applications/zoom.us.app",
+      match:           :full,
+      attempts:        3,
+      must_succeed:    false,
+      notices:         [
+        "The Zoom package postinstall script launches the Zoom app",
+        "Attempting to close zoom.us.app to avoid unwanted user intervention",
+      ],
+      failure_message: "Unable to forcibly close zoom.us.app",
+    )
   end
 
   uninstall launchctl: [


### PR DESCRIPTION
Thirteen casks stop applications or helpers before install or uninstall
work.

- replace process-control Ruby with declarative termination steps
- preserve matching, attempts and privilege policy
- retain user notices, warnings and optional-failure behaviour
- depend on Homebrew/brew's matching
  `Add process termination steps` change

Needs https://github.com/Homebrew/brew/pull/23187

