### PR TITLE
Migrate existing cask flight steps (7/8)

### DIFF
--- a/Casks/a/adobe-creative-cloud.rb
+++ b/Casks/a/adobe-creative-cloud.rb
@@ -32,12 +32,6 @@ cask "adobe-creative-cloud" do
     print_stderr: false,
   }
 
-  uninstall_postflight do
-    stdout, * = system_command "/bin/launchctl", args: ["print", "gui/#{Process.uid}"]
-    ccx_processes = stdout.lines.grep(/com\.adobe\.CCXProcess\.\d{5}/) { Regexp.last_match(0) }.uniq
-    ccx_processes.each { |id| system "/bin/launchctl", "bootout", "gui/#{Process.uid}/#{id}" }
-  end
-
   uninstall early_script: {
               executable:   "/usr/bin/pluginkit",
               args:         [
@@ -53,6 +47,7 @@ cask "adobe-creative-cloud" do
               "com.adobe.AdobeCreativeCloud",
               "com.adobe.AdobeDesktopService",
               "com.adobe.ccxprocess",
+              "com.adobe.CCXProcess.*",
             ],
             quit:         "com.adobe.acc.AdobeCreativeCloud",
             signal:       ["QUIT", "com.adobe.accmac"],

--- a/Casks/d/distroav.rb
+++ b/Casks/d/distroav.rb
@@ -19,23 +19,11 @@ cask "distroav" do
   # The pkg installs the plugin files to /Library/Application Support/obs-studio/plugins
   # however OBS Studio expects them to be in ~/Library/Application Support/obs-studio/plugins
   # so we create symlinks to correctly link the plugin files for OBS Studio.
-  postflight do
-    puts "Creating #{token} symlinks in ~/Library/Application Support/obs-studio/plugins"
-    target = Pathname.new("~/Library/Application Support/obs-studio/plugins").expand_path
-    source = "/Library/Application Support/obs-studio/plugins"
-
-    FileUtils.mkdir_p target
-    File.symlink("#{source}/distroav.plugin", "#{target}/distroav.plugin")
-    File.symlink("#{source}/distroav.plugin.dSYM", "#{target}/distroav.plugin.dSYM")
-  end
-
-  uninstall_preflight do
-    puts "Removing #{token} symlinks from in ~/Library/Application Support/obs-studio/plugins"
-    target = Pathname.new("~/Library/Application Support/obs-studio/plugins").expand_path
-
-    if File.symlink?("#{target}/distroav.plugin")
-      File.unlink("#{target}/distroav.plugin", "#{target}/distroav.plugin.dSYM")
-    end
+  postflight_steps do
+    symlink "/Library/Application Support/obs-studio/plugins/distroav.plugin",
+            "~/Library/Application Support/obs-studio/plugins/distroav.plugin", remove_on_uninstall: true
+    symlink "/Library/Application Support/obs-studio/plugins/distroav.plugin.dSYM",
+            "~/Library/Application Support/obs-studio/plugins/distroav.plugin.dSYM", remove_on_uninstall: true
   end
 
   uninstall pkgutil: [

--- a/Casks/d/docker-desktop.rb
+++ b/Casks/d/docker-desktop.rb
@@ -46,22 +46,11 @@ cask "docker-desktop" do
   zsh_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.zsh-completion"
   zsh_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.zsh-completion"
 
-  postflight do
-    kubectl_target = Pathname("/usr/local/bin/kubectl")
-
+  postflight_steps do
     # Only link if `kubernetes-cli` is not installed.
-    next if kubectl_target.exist?
-
-    system_command "/bin/ln", args: ["-sfn", appdir/"Docker.app/Contents/Resources/bin/kubectl", kubectl_target],
-                              sudo: !kubectl_target.dirname.writable?
-  end
-
-  uninstall_postflight do
-    kubectl_target = Pathname("/usr/local/bin/kubectl")
-
-    if kubectl_target.symlink? && kubectl_target.readlink == appdir/"Docker.app/Contents/Resources/bin/kubectl"
-      system_command "/bin/rm", args: [kubectl_target],
-                                sudo: !kubectl_target.dirname.writable?
+    unless_path_exists "/usr/local/bin/kubectl" do
+      symlink "{{appdir}}/Docker.app/Contents/Resources/bin/kubectl", "/usr/local/bin/kubectl",
+              remove_on_uninstall: true, sudo: :if_needed, overwrite: true
     end
   end
 

--- a/Casks/h/hummingbird.rb
+++ b/Casks/h/hummingbird.rb
@@ -20,8 +20,8 @@ cask "hummingbird" do
 
   binary "hummingbird-macos-#{arch}-#{version}/hummingbird"
 
-  postflight do
-    set_ownership("#{staged_path}/hummingbird-macos-#{arch}-#{version}/hummingbird", user: "root")
+  postflight_steps do
+    set_ownership "hummingbird-macos-*-#{version}/hummingbird", user: "root"
   end
 
   # No zap stanza required

--- a/Casks/l/libcblite-community.rb
+++ b/Casks/l/libcblite-community.rb
@@ -20,17 +20,11 @@ cask "libcblite-community" do
   artifact "libcblite-#{version}/lib/cmake/CouchbaseLite", target: "#{HOMEBREW_PREFIX}/lib/cmake/CouchbaseLite"
   artifact "libcblite-#{version}/lib/libcblite.#{version}.dylib", target: "#{HOMEBREW_PREFIX}/lib/libcblite.#{version}.dylib"
 
-  postflight do
-    puts "Creating library symlinks in #{HOMEBREW_PREFIX}/lib"
-    File.symlink("libcblite.#{version}.dylib", "#{HOMEBREW_PREFIX}/lib/libcblite.#{version.major}.dylib")
-    File.symlink("libcblite.#{version.major}.dylib", "#{HOMEBREW_PREFIX}/lib/libcblite.dylib")
-  end
-
-  uninstall_postflight do
-    if File.symlink?("#{HOMEBREW_PREFIX}/lib/libcblite.#{version.major}.dylib")
-      puts "Removing library symlinks in #{HOMEBREW_PREFIX}/lib"
-      File.unlink("#{HOMEBREW_PREFIX}/lib/libcblite.#{version.major}.dylib", "#{HOMEBREW_PREFIX}/lib/libcblite.dylib")
-    end
+  postflight_steps do
+    symlink "libcblite.#{version}.dylib", "{{HOMEBREW_PREFIX}}/lib/libcblite.#{version.major}.dylib",
+            source_base: :relative, remove_on_uninstall: true
+    symlink "libcblite.#{version.major}.dylib", "{{HOMEBREW_PREFIX}}/lib/libcblite.dylib",
+            source_base: :relative, remove_on_uninstall: true
   end
 
   # No zap stanza required

--- a/Casks/l/libcblite.rb
+++ b/Casks/l/libcblite.rb
@@ -21,17 +21,11 @@ cask "libcblite" do
   artifact "libcblite-#{version}/lib/cmake/CouchbaseLite", target: "#{HOMEBREW_PREFIX}/lib/cmake/CouchbaseLite"
   artifact "libcblite-#{version}/lib/libcblite.#{version}.dylib", target: "#{HOMEBREW_PREFIX}/lib/libcblite.#{version}.dylib"
 
-  postflight do
-    puts "Creating library symlinks in #{HOMEBREW_PREFIX}/lib"
-    File.symlink("libcblite.#{version}.dylib", "#{HOMEBREW_PREFIX}/lib/libcblite.#{version.major}.dylib")
-    File.symlink("libcblite.#{version.major}.dylib", "#{HOMEBREW_PREFIX}/lib/libcblite.dylib")
-  end
-
-  uninstall_postflight do
-    if File.symlink?("#{HOMEBREW_PREFIX}/lib/libcblite.#{version.major}.dylib")
-      puts "Removing library symlinks in #{HOMEBREW_PREFIX}/lib"
-      File.unlink("#{HOMEBREW_PREFIX}/lib/libcblite.#{version.major}.dylib", "#{HOMEBREW_PREFIX}/lib/libcblite.dylib")
-    end
+  postflight_steps do
+    symlink "libcblite.#{version}.dylib", "{{HOMEBREW_PREFIX}}/lib/libcblite.#{version.major}.dylib",
+            source_base: :relative, remove_on_uninstall: true
+    symlink "libcblite.#{version.major}.dylib", "{{HOMEBREW_PREFIX}}/lib/libcblite.dylib",
+            source_base: :relative, remove_on_uninstall: true
   end
 
   # No zap stanza required

--- a/Casks/m/meshlab.rb
+++ b/Casks/m/meshlab.rb
@@ -20,10 +20,11 @@ cask "meshlab" do
 
   app "MeshLab#{version}.app"
 
-  postflight do
+  postflight_steps do
     # workaround for bug which breaks the app on case-sensitive filesystems
-    Dir.chdir("#{appdir}/MeshLab#{version}.app/Contents/MacOS") do
-      File.symlink("meshlab", "MeshLab") unless File.exist? "MeshLab"
+    unless_path_exists "{{appdir}}/MeshLab#{version}.app/Contents/MacOS/MeshLab" do
+      symlink "meshlab", "MeshLab#{version}.app/Contents/MacOS/MeshLab",
+              source_base: :relative, target_base: :appdir
     end
   end
 

--- a/Casks/m/multipass.rb
+++ b/Casks/m/multipass.rb
@@ -3,9 +3,9 @@ cask "multipass" do
   sha256 "7d6eab39614139884cfb5a4aeb68f9b25334356c142d5d4b1f74acdd76082c18"
 
   on_arm do
-    postflight do
-      File.symlink("/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
-                   "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass")
+    postflight_steps do
+      symlink "/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
+              "{{HOMEBREW_PREFIX}}/etc/bash_completion.d/multipass", remove_on_uninstall: true
     end
   end
 

--- a/Casks/r/rodecaster.rb
+++ b/Casks/r/rodecaster.rb
@@ -16,11 +16,9 @@ cask "rodecaster" do
 
   depends_on :macos
 
-  pkg "RØDECaster App.pkg"
+  rename "RØDECaster App*.pkg", "RØDECaster App.pkg"
 
-  preflight do
-    staged_path.glob("RØDECaster App*.pkg")&.first&.rename(staged_path/"RØDECaster App.pkg")
-  end
+  pkg "RØDECaster App.pkg"
 
   uninstall quit:    "com.rode.rodecastercomp",
             pkgutil: "com.rodecastercomp.installer"


### PR DESCRIPTION
Nine casks can replace flight Ruby with canonical structured artifacts
or file steps.

- preserve guarded links, ownership, moves and uninstall behaviour
- use the uninstall signal DSL for Adobe CCX process labels
- remove each matching Ruby flight block
- depend on Homebrew/brew's matching
  `Align shared install step interfaces` change

Needs https://github.com/Homebrew/brew/pull/23193

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.