### PR TITLE
Align canonical install step names (8/8)

### DIFF
--- a/Casks/a/android-ndk.rb
+++ b/Casks/a/android-ndk.rb
@@ -23,7 +23,7 @@ cask "android-ndk" do
 
   preflight_steps do
     symlink "AndroidNDK*.app/Contents/NDK", "share/android-ndk",
-            target_base: :homebrew_prefix, source_glob: true, force: true
+            target_base: :homebrew_prefix, source_glob: true, overwrite: true
   end
 
   uninstall delete: "#{HOMEBREW_PREFIX}/share/android-ndk"

--- a/Casks/a/autofirma.rb
+++ b/Casks/a/autofirma.rb
@@ -29,8 +29,8 @@ cask "autofirma" do
 
   # remove 'Autofirma ROOT' and '127.0.0.1' certificates from keychain (these were installed by pkg)
   uninstall_postflight_steps do
-    delete_keychain_certificate "AutoFirma ROOT"
-    delete_keychain_certificate "127.0.0.1"
+    delete_keychain_certificates "AutoFirma ROOT"
+    delete_keychain_certificates "127.0.0.1"
   end
 
   uninstall quit:    "es.gob.afirma",

--- a/Casks/b/betwixt.rb
+++ b/Casks/b/betwixt.rb
@@ -15,8 +15,8 @@ cask "betwixt" do
   app "Betwixt-darwin-x64/Betwixt.app"
 
   uninstall_postflight_steps do
-    delete_keychain_certificate "NodeMITMProxyCA",
-                                matching_certificate: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
+    delete_keychain_certificates "NodeMITMProxyCA",
+                                 fingerprint_of: "~/Library/Application Support/betwixt/ssl/certs/ca.pem"
   end
 
   zap trash: [

--- a/Casks/c/charles.rb
+++ b/Casks/c/charles.rb
@@ -18,7 +18,7 @@ cask "charles" do
   app "Charles.app"
 
   uninstall_postflight_steps do
-    delete_keychain_certificate "Charles"
+    delete_keychain_certificates "Charles"
   end
 
   uninstall launchctl: "com.xk72.Charles.ProxyHelper",

--- a/Casks/c/charles@4.rb
+++ b/Casks/c/charles@4.rb
@@ -18,7 +18,7 @@ cask "charles@4" do
   app "Charles.app"
 
   uninstall_postflight_steps do
-    delete_keychain_certificate "Charles"
+    delete_keychain_certificates "Charles"
   end
 
   uninstall launchctl: "com.xk72.Charles.ProxyHelper",

--- a/Casks/c/chatty.rb
+++ b/Casks/c/chatty.rb
@@ -19,7 +19,7 @@ cask "chatty" do
 
   preflight_steps do
     # There is no sub-folder in the ZIP; the root *is* the folder
-    move_children ".", "Chatty"
+    move_contents ".", "Chatty"
   end
 
   zap trash: "~/.chatty"

--- a/Casks/d/dnsmonitor.rb
+++ b/Casks/d/dnsmonitor.rb
@@ -13,7 +13,7 @@ cask "dnsmonitor" do
   app "DNSMonitor.app"
 
   postflight_steps do
-    write "unload.sh", <<~SH, overwrite: true
+    write_file "unload.sh", <<~SH
       #!/bin/sh
       systemextensionsctl list | grep -q "com.objective-see.dnsmonitor.extension.*activated" && \
         /Applications/DNSMonitor.app/Contents/MacOS/DNSMonitor -unload

--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -63,7 +63,7 @@ cask "gcloud-cli" do
   postflight_steps do
     # HACK: Allow existing shell profiles to work by linking the current version to the `latest` directory.
     unless_path_exists "{{caskroom_path}}/latest" do
-      symlink "{{staged_path}}", "{{caskroom_path}}/latest", force: true
+      symlink "{{staged_path}}", "{{caskroom_path}}/latest", overwrite: true
     end
 
     on_macos do

--- a/Casks/k/klayout.rb
+++ b/Casks/k/klayout.rb
@@ -94,7 +94,7 @@ cask "klayout" do
 
   preflight_steps do
     # There is no sub-folder in the DMG; the root *is* the folder
-    move_children ".", "KLayout"
+    move_contents ".", "KLayout"
   end
 
   uninstall quit:    "klayout.de",

--- a/Casks/l/lightproxy.rb
+++ b/Casks/l/lightproxy.rb
@@ -15,7 +15,7 @@ cask "lightproxy" do
   app "LightProxy.app"
 
   uninstall_postflight_steps do
-    delete_keychain_certificate "LightProxy"
+    delete_keychain_certificates "LightProxy"
   end
 
   caveats do

--- a/Casks/p/proxyman.rb
+++ b/Casks/p/proxyman.rb
@@ -19,7 +19,7 @@ cask "proxyman" do
   binary "#{appdir}/Proxyman.app/Contents/MacOS/proxyman-cli"
 
   uninstall_postflight_steps do
-    delete_keychain_certificate "Proxyman"
+    delete_keychain_certificates "Proxyman"
   end
 
   uninstall launchctl: "com.proxyman.NSProxy.HelperTool",

--- a/Casks/q/quakespasm.rb
+++ b/Casks/q/quakespasm.rb
@@ -17,7 +17,7 @@ cask "quakespasm" do
 
   preflight_steps do
     # There is no sub-folder; the root *is* the folder
-    move_children ".", "QuakeSpasm"
+    move_contents ".", "QuakeSpasm"
   end
 
   caveats <<~EOS

--- a/Casks/r/reqable.rb
+++ b/Casks/r/reqable.rb
@@ -17,7 +17,7 @@ cask "reqable" do
   app "Reqable.app"
 
   uninstall_postflight_steps do
-    delete_keychain_certificate "Reqable Proxy"
+    delete_keychain_certificates "Reqable Proxy"
   end
 
   zap trash: [

--- a/Casks/s/squirrelsql.rb
+++ b/Casks/s/squirrelsql.rb
@@ -13,7 +13,7 @@ cask "squirrelsql" do
 
   preflight_steps do
     # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-    write "install-options.xml", <<~EOS
+    write_file "install-options.xml", <<~EOS
       <?xml version="1.0" encoding="UTF-8" standalone="no"?>
       <AutomatedInstallation langpack="eng">
       <com.izforge.izpack.panels.hello.HelloPanel id="HelloPanel_0"/>

--- a/Casks/v/virtual-ii.rb
+++ b/Casks/v/virtual-ii.rb
@@ -23,7 +23,7 @@ cask "virtual-ii" do
 
   preflight_steps do
     # There is no sub-folder in the DMG; the root *is* the folder
-    move_children ".", "Virtual ]["
+    move_contents ".", "Virtual ]["
   end
 
   zap trash: [

--- a/Casks/w/warsaw.rb
+++ b/Casks/w/warsaw.rb
@@ -13,8 +13,8 @@ cask "warsaw" do
   pkg "warsaw_setup.pkg"
 
   uninstall_postflight_steps do
-    delete_keychain_certificate "Warsaw Personal CA"
-    delete_keychain_certificate "127.0.0.1"
+    delete_keychain_certificates "Warsaw Personal CA"
+    delete_keychain_certificates "127.0.0.1"
   end
 
   uninstall launchctl: [


### PR DESCRIPTION
Sixteen existing structured casks should use the current shared vocabulary while brew retains released aliases for
compatibility.

- replace short file and link aliases with canonical operation names
- use nested platform and path guards with shared command options
- update certificate steps without changing behaviour
- depend on Homebrew/brew's matching Align shared install step interfaces change

Needs https://github.com/Homebrew/brew/pull/23193

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
