### PR TITLE
atoll 2.3.2

### DIFF
--- a/Casks/a/atoll.rb
+++ b/Casks/a/atoll.rb
@@ -1,8 +1,8 @@
 cask "atoll" do
-  version "2.2.0"
-  sha256 "30e532e69650a7183769dff222bca7106de7dfe4936e9bd9c2096e20f58a4cb2"
+  version "2.3.2"
+  sha256 "b2b81d6eebb719cc50db04694d25101f85a201bac477418001348c23cecce8b8"
 
-  url "https://github.com/Ebullioscopic/Atoll/releases/download/v#{version}/Atoll.#{version}.dmg",
+  url "https://github.com/Ebullioscopic/Atoll/releases/download/v#{version}/Atoll-#{version}.dmg",
       verified: "github.com/Ebullioscopic/Atoll/"
   name "Atoll"
   desc "Dynamic Island for the MacBook notch"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

`atoll` is autobumped but the workflow failed to update to version 2.3.2 because the dmg file name uses a hyphen as a delimiter (between the app name and version) instead of a dot. This updates the version and `url` accordingly.