### PR TITLE
Test cask syntax with stable brew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           persist-credentials: false
 
       - name: Clean up CI machine
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && !matrix.stable
         run: brew test-bot --cleanup --only-cleanup-before
 
       - name: Cache Homebrew Gems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           restore-keys: ${{ matrix.runner }}-rubygems-
 
       - name: Cache style cache
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && !matrix.stable
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Caches/Homebrew/style

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           core: true
           cask: true
+          stable: ${{ matrix.stable || false }}
 
       - name: Enable debug mode
         run: |
@@ -121,15 +122,15 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Caches/Homebrew/style
-          key: macos-style-cache-${{ github.sha }}
-          restore-keys: macos-style-cache-
+          key: macos-style-cache-${{ matrix.stable && 'stable-' || 'main-' }}${{ github.sha }}
+          restore-keys: macos-style-cache-${{ matrix.stable && 'stable-' || 'main-' }}
 
       - name: Run brew config
         run: brew config
 
       - name: Run brew test-bot --only-tap-syntax
         id: tap-syntax
-        run: brew test-bot --tap '${{ matrix.tap }}' --only-tap-syntax
+        run: brew test-bot --tap '${{ matrix.tap }}' --only-tap-syntax ${{ matrix.stable && '--stable' || '' }}
         if: always() && !matrix.cask
 
       - name: Run brew fetch --cask ${{ matrix.cask.token }}


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/23222

Cask syntax changes need coverage against both the current development branch and the latest stable Homebrew release.

- consume current and stable syntax rows generated by Homebrew/brew
- select stable setup and test-bot behaviour for stable rows
- keep style caches isolated between stable and main runs

-----

- [x] AI was used to generate or assist with generating this PR.

OpenAI Codex 5.6 Sol xhigh with local review.

<!-- If ticked, explain below how AI was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----