### PR TITLE
nextline 0.9.1 (new cask)

### DIFF
--- a/Casks/n/nextline.rb
+++ b/Casks/n/nextline.rb
@@ -1,0 +1,30 @@
+cask "nextline" do
+  version "0.9.1"
+  sha256 "fd7fd47a515a31525fc1c8b4ca28a91370916ec7945a88d12bbc8d9df182ef88"
+
+  url "https://zalex666.github.io/inline-autocomplete/Nextline-#{version}.dmg",
+      verified: "zalex666.github.io/inline-autocomplete/"
+  name "Nextline"
+  desc "System-wide inline autocomplete powered by a local LLM"
+  homepage "https://www.thenextline.app/"
+
+  livecheck do
+    url "https://zalex666.github.io/inline-autocomplete/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "Nextline.app"
+
+  uninstall quit: "app.inline.Inline"
+
+  zap trash: [
+    "~/Library/Application Support/Inline",
+    "~/Library/Caches/app.inline.Inline",
+    "~/Library/HTTPStorages/app.inline.Inline",
+    "~/Library/Preferences/app.inline.Inline.plist",
+  ]
+end


### PR DESCRIPTION
[Nextline](https://www.thenextline.app/) is a system-wide inline autocomplete app for macOS, powered by a local LLM (on-device, no cloud calls). I'm the developer. The app is Developer ID-signed and notarized, distributed as a DMG with a Sparkle update feed, which the `livecheck` block follows. The download is served from the project's GitHub Pages (hence `url ... verified:`) because the source repo is private and private release assets aren't anonymously downloadable.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+nextline&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

How AI was used, and what was manually verified:

- The cask was authored with AI assistance (Claude, supervised by me).
- `sha256` was computed from the published DMG, and `depends_on macos: :sonoma` comes from the app bundle's actual `LSMinimumSystemVersion` (14.0), both read from the artifact rather than guessed.
- `zap` paths were verified against a real installation's on-disk directories: `~/Library/Application Support/Inline` plus the `Caches`/`HTTPStorages`/`Preferences` entries under the bundle id `app.inline.Inline` (the bundle id predates the app's rename and is kept for update continuity, which is also why `uninstall quit:` uses it).
- `livecheck` was verified against the live appcast (resolves 0.9.0 correctly).
- All checklist commands above were run locally against this identical cask file served from my own tap (`zalex666/tap/nextline`), since a new cask can't be addressed by bare token before it exists in homebrew/cask. The install/uninstall test used `--appdir` pointed at a temporary directory because my machine runs a production copy of the app.
