### PR TITLE
mojito 1.8.0 (new cask)

### DIFF
--- a/Casks/m/mojito.rb
+++ b/Casks/m/mojito.rb
@@ -1,0 +1,28 @@
+cask "mojito" do
+  version "1.8.0"
+  sha256 "596efdb2f3b80562cc6137e54560fff3f2268fda2a55ed4c81d1c297aadccb71"
+
+  url "https://github.com/wr/mojito/releases/download/v#{version}/Mojito.dmg",
+      verified: "github.com/wr/mojito/"
+  name "Mojito"
+  desc "Type :emoji:, ::symbol::, and :::gif::: shortcodes in any text field"
+  homepage "https://mojito.wells.ee/"
+
+  livecheck do
+    url "https://mojito.wells.ee/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Mojito.app"
+
+  uninstall quit: "ee.wells.Mojito"
+
+  zap trash: [
+    "~/Library/Caches/ee.wells.Mojito",
+    "~/Library/HTTPStorages/ee.wells.Mojito",
+    "~/Library/Preferences/ee.wells.Mojito.plist",
+  ]
+end


### PR DESCRIPTION
Adds [Mojito](https://mojito.wells.ee/), a free, open-source menu-bar utility that expands `:emoji:` shortcodes into real emoji in any macOS text field (plus `::symbol::` and `:::gif:::` variants). Signed with a Developer ID certificate and notarized; self-updates via Sparkle. I'm the app's developer.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) drafted the cask file and this PR under my direction; I'm the developer of the app. Verification performed locally: `brew style --fix` and `brew audit --cask --online`/`--new` run against the cask in a local tap (all clean); the release DMG downloaded and its sha256 computed independently of the appcast; `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask mojito` and `brew uninstall --cask mojito` both run successfully. The three `zap` paths were confirmed to exist on a machine where the app is in real use (`~/Library/Preferences/ee.wells.Mojito.plist`, `~/Library/Caches/ee.wells.Mojito`, `~/Library/HTTPStorages/ee.wells.Mojito`); the app's bundle id is `ee.wells.Mojito` and it stores settings in UserDefaults only.

-----