### PR TITLE
roslynpad 22 (new cask)

### DIFF
--- a/Casks/r/roslynpad.rb
+++ b/Casks/r/roslynpad.rb
@@ -1,0 +1,38 @@
+cask "roslynpad" do
+  arch arm: "arm64", intel: "x64"
+
+  version "22"
+  sha256 arm:   "009899acb3697a6739e7bef69e4efada66b2be1118ddced5e114c91e3e14d20d",
+         intel: "4005d9d8309def06c6a4a4cff1e3816469c516d32a521abb871b3c45da99cdc3"
+
+  url "https://github.com/roslynpad/roslynpad/releases/download/#{version}/RoslynPad-macos-#{arch}.dmg",
+      verified: "github.com/roslynpad/roslynpad/"
+  name "RoslynPad"
+  desc "C# editor and runner based on Roslyn"
+  homepage "https://roslynpad.net/"
+
+  livecheck do
+    url :url
+    # Releases are tagged without trailing zero components ("22", "21.1"),
+    # which the default strategy regex rejects.
+    regex(/^v?(\d+(?:\.\d+)*)$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
+  end
+
+  depends_on macos: :sequoia
+
+  app "RoslynPad.app"
+
+  # ~/RoslynPad holds the user's own documents, so it is deliberately not zapped.
+  zap trash: "~/Library/Preferences/net.roslynpad.plist"
+
+  caveats <<~EOS
+    RoslynPad needs a supported .NET SDK to compile and run programs:
+      brew install --cask dotnet-sdk
+  EOS
+end

--- a/Casks/r/roslynpad.rb
+++ b/Casks/r/roslynpad.rb
@@ -13,26 +13,12 @@ cask "roslynpad" do
 
   livecheck do
     url :url
-    # Releases are tagged without trailing zero components ("22", "21.1"),
-    # which the default strategy regex rejects.
     regex(/^v?(\d+(?:\.\d+)*)$/i)
-    strategy :github_latest do |json, regex|
-      match = json["tag_name"]&.match(regex)
-      next if match.blank?
-
-      match[1]
-    end
   end
 
   depends_on macos: :sequoia
 
   app "RoslynPad.app"
 
-  # ~/RoslynPad holds the user's own documents, so it is deliberately not zapped.
   zap trash: "~/Library/Preferences/net.roslynpad.plist"
-
-  caveats <<~EOS
-    RoslynPad needs a supported .NET SDK to compile and run programs:
-      brew install --cask dotnet-sdk
-  EOS
 end


### PR DESCRIPTION
Adds a cask for [RoslynPad](https://roslynpad.net), a cross-platform C# editor built on Roslyn. I'm the author and maintainer of the app, so the release process on the other side is under my control.

Notes for reviewers:

- The DMG is signed and notarized with a Developer ID Application certificate (`spctl -a -vvv` reports `Notarized Developer ID`).
- Releases are tagged without trailing zero components (`22`, `21.1`), which the default `:github_latest` regex rejects because it requires at least one `.`. The `livecheck` block therefore supplies its own regex; `brew livecheck` resolves `22` correctly against the current release.
- `caveats` mentions the .NET SDK because RoslynPad needs it to compile the programs the user writes. The app itself launches without it — the macOS bundle ships its own runtime — so this is not a `depends_on`.
- The app stores user documents in `~/RoslynPad`, which the `zap` stanza deliberately leaves alone.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I used Claude Code to draft the cask and run the verification commands, working from my own release artifacts and reviewing each step.

Every command in the checklist above was actually run against a local tap on macOS 15 (arm64), not assumed: `brew style` and `brew audit --cask --online --new` both come back clean, and the install/uninstall cycle put `RoslynPad.app` in `/Applications` and removed it again.

On the `zap` path specifically: `~/Library/Preferences/net.roslynpad.plist` is confirmed present on a machine that has been running this app for months, and `defaults read net.roslynpad` shows it holds the app's own window and panel state. A `~/Library/Saved Application State/net.roslynpad.savedState` entry was in an earlier draft; I dropped it after checking that it does not exist on that same machine, rather than ship a path that only looked plausible. There are no `Application Support` or `Caches` directories for the bundle ID. I did not run `brew uninstall --zap` end to end, because the one path listed is my real preferences file and I did not want to delete it — I verified the path's existence and ownership directly instead.
