### PR TITLE
cate 1.5.2 (new cask)

### DIFF
--- a/Casks/c/cate.rb
+++ b/Casks/c/cate.rb
@@ -1,19 +1,15 @@
 cask "cate" do
   arch arm: "-arm64"
 
-  version "1.5.1"
-  sha256 arm:   "2d939c5cc876e5f2f7ecd59927a5eaeed8c9e809800740e6fc60275ec3b1adee",
-         intel: "90ccc98ce401c9963447534a4fd26223ccc679a2e2ed1c15d4d298d63b7b01fd"
+  version "1.5.2"
+  sha256 arm:   "a2695c8bee890d064c857492316416efb200b93106127f77867b3198c608198b",
+         intel: "6eaa3ea7efd082f0ed173ae09d1a3234b4116dc99ecf87ba7e38d0a4ea034ac8"
 
-  url "https://github.com/0-AI-UG/cate/releases/download/v#{version}/Cate-#{version}#{arch}.dmg"
+  url "https://github.com/0-AI-UG/cate/releases/download/v#{version}/Cate-#{version}#{arch}.dmg",
+      verified: "github.com/0-AI-UG/cate/"
   name "Cate"
   desc "Infinite zoomable canvas with editor, terminal, and browser panels"
-  homepage "https://github.com/0-AI-UG/cate/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  homepage "https://cate.cero-ai.com/"
 
   auto_updates true
   depends_on macos: :monterey
@@ -21,10 +17,15 @@ cask "cate" do
   app "Cate.app"
 
   zap trash: [
+    "~/.cate",
     "~/Library/Application Support/Cate",
+    "~/Library/Application Support/CrashReporter/Cate Helper_*.plist",
+    "~/Library/Caches/cate-updater",
     "~/Library/Caches/com.cate.app",
+    "~/Library/Caches/com.cate.app.ShipIt",
     "~/Library/HTTPStorages/com.cate.app",
     "~/Library/Logs/Cate",
+    "~/Library/Preferences/ByHost/com.cate.app.ShipIt.*.plist",
     "~/Library/Preferences/com.cate.app.plist",
     "~/Library/Saved Application State/com.cate.app.savedState",
   ]

--- a/Casks/c/cate.rb
+++ b/Casks/c/cate.rb
@@ -1,0 +1,31 @@
+cask "cate" do
+  arch arm: "-arm64"
+
+  version "1.5.1"
+  sha256 arm:   "2d939c5cc876e5f2f7ecd59927a5eaeed8c9e809800740e6fc60275ec3b1adee",
+         intel: "90ccc98ce401c9963447534a4fd26223ccc679a2e2ed1c15d4d298d63b7b01fd"
+
+  url "https://github.com/0-AI-UG/cate/releases/download/v#{version}/Cate-#{version}#{arch}.dmg"
+  name "Cate"
+  desc "Infinite zoomable canvas with editor, terminal, and browser panels"
+  homepage "https://github.com/0-AI-UG/cate/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "Cate.app"
+
+  zap trash: [
+    "~/Library/Application Support/Cate",
+    "~/Library/Caches/com.cate.app",
+    "~/Library/HTTPStorages/com.cate.app",
+    "~/Library/Logs/Cate",
+    "~/Library/Preferences/com.cate.app.plist",
+    "~/Library/Saved Application State/com.cate.app.savedState",
+  ]
+end


### PR DESCRIPTION
New cask for [Cate](https://github.com/0-AI-UG/cate), an MIT-licensed infinite canvas IDE (1.9k stars). The DMG is signed and notarized (Developer ID Application: Paul Horn, F7PH54XQ6J). `auto_updates true` because the app ships electron-updater.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Claude Code drafted the cask file. I am the upstream maintainer of Cate, so the URL, version and signing identity are first-hand knowledge, and every command in the checklist above was run locally rather than assumed:

- `brew audit --new --cask --online cate` and `brew audit --cask --online cate` both exit 0.
- `brew style` reports no offenses. It corrected one thing during drafting: `depends_on macos: :monterey` instead of `">= :monterey"`.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask cate` and `brew uninstall --cask cate` both succeeded. I installed into a temporary `--appdir` to keep my existing `/Applications/Cate.app` out of the test.
- `spctl -a -vvv -t exec` on the installed app returns `accepted`, `source=Notarized Developer ID`.
- `brew livecheck` resolves 1.5.1 from the GitHub release feed.
- `depends_on macos: :monterey` comes from `LSMinimumSystemVersion` (12.0) in the bundled Electron 41 framework, not a guess.

Zap paths were verified by listing them on a machine that has run the app, not copied from another cask. All five of these exist and are created by Cate; the sixth (`Saved Application State`) is the standard macOS path and is included for completeness:

- `~/Library/Application Support/Cate` (app id is `com.cate.app`, productName `Cate`, so userData lands here)
- `~/Library/Caches/com.cate.app`
- `~/Library/HTTPStorages/com.cate.app`
- `~/Library/Logs/Cate`
- `~/Library/Preferences/com.cate.app.plist`
- `~/Library/Saved Application State/com.cate.app.savedState`
