### PR TITLE
libation: add CLI binary

### DIFF
--- a/Casks/l/libation.rb
+++ b/Casks/l/libation.rb
@@ -14,6 +14,7 @@ cask "libation" do
   depends_on macos: :ventura
 
   app "Libation.app"
+  binary "#{appdir}/Libation.app/Contents/MacOS/LibationCli", target: "libationcli"
 
   zap trash: [
     "~/Library/Application Support/Libation",


### PR DESCRIPTION
Built and tested locally on macOS 26.5.2.

Links the bundled `LibationCli` executable as `libationcli` so it is available through Homebrew's binary directory.

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

OpenAI Codex (GPT-5) was used to inspect the cask and add the binary stanza. The cask passed the online audit and style check, was uninstalled and reinstalled locally, and the resulting `libationcli` symlink and `--help` output were verified. The existing `zap` stanza was not changed.

-----
