### PR TITLE
cmd/lib/check: ignore apple shortcuts

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -5,7 +5,7 @@ require "system_command"
 
 APPLE_LAUNCHJOBS_REGEX =
   /\A(?:application\.)?com\.apple\.
-  (AppStore|installer|Preview|Safari|systemevents|systempreferences|Terminal)
+  (AppStore|installer|Preview|Safari|shortcuts|systemevents|systempreferences|Terminal)
   (?:\.|$)/x
 
 GOOGLE_LAUNCHJOBS_REGEX = /com\.google\.(keystone|GoogleUpdater)/


### PR DESCRIPTION
When checking for newly installed/running launchjobs on CI, we should skip `com.apple.shortcuts`.
Discovered in https://github.com/Homebrew/homebrew-cask/actions/runs/29782002004/job/88485309220?pr=276144

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
