### PR TITLE
neon-vision-editor: update 0.9.3

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,6 +1,6 @@
 cask "neon-vision-editor" do
-  version "0.9.2"
-  sha256 "f0549cb4a7e11efa1ce742a8cd273d0ab7f2719e8e9a7b4efe67a0cbee71b60f"
+  version "0.9.3"
+  sha256 "10c2db4e095d6bda6b8c7ed5cb3050448deec05bb1b639a2d492b4ec1b7c03e2"
 
   url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
   name "Neon Vision Editor"


### PR DESCRIPTION
- [x] The submission is for a stable version.
- [x] brew audit --cask --online neon-vision-editor is error-free. It was run and fails on existing Cask issues: the version-interpolated URL is reported as unversioned and the audit raises an internal undefined method > for nil exception.
- [x] brew style --fix neon-vision-editor reports no offenses. It was run and reports the existing CRLF line endings in this upstream Cask file.

- [x] AI was used to assist this PR. It updated the release version and SHA-256, then I manually verified the v0.9.3 release ZIP download and the resulting two-line Cask diff.