### PR TITLE
android-studio-preview@*: update livecheck

### DIFF
--- a/Casks/a/android-studio-preview@beta.rb
+++ b/Casks/a/android-studio-preview@beta.rb
@@ -13,7 +13,7 @@ cask "android-studio-preview@beta" do
 
   livecheck do
     url :homepage
-    regex(%r{(?:Beta|RC).*href=.*?/v?(\d+(?:\.\d+)+)/android[._-]studio(?:[._-]([^"' >]+))?[._-]#{arch}\.dmg}im)
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/android[._-]studio(?:[._-]([^"' >]+))?[._-]#{arch}\.dmg[^>]*?beta}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         match[1].present? ? "#{match[0]},#{match[1]}" : match[0]

--- a/Casks/a/android-studio-preview@canary.rb
+++ b/Casks/a/android-studio-preview@canary.rb
@@ -13,7 +13,7 @@ cask "android-studio-preview@canary" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/android[._-]studio(?:[._-]([^"' >]+))?[._-]#{arch}\.dmg}i)
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/android[._-]studio(?:[._-]([^"' >]+))?[._-]#{arch}\.dmg[^>]*?canary}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         match[1].present? ? "#{match[0]},#{match[1]}" : match[0]


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The `livecheck` block for `android-studio-preview@canary` doesn't restrict matching to only Canary versions, whether intentional or not. The cask was recently updated to a Beta version, `2026.1.3.5,quail3-rc1`, as it was higher than the Canary version, `2026.1.3.4,quail3-canary4`. A user reported that installing the cask returned an error: "It seems the App source '/usr/local/Caskroom/ android-studio-preview@canary/2026.1.3.5,quail3-rc1/Android Studio Preview Canary.app' is not there" (https://github.com/Homebrew/homebrew-cask/issues/275384). This was due to a `rename` bug but the issue brought this situation to my attention.

The in-app updater for the Beta/RC app only uses the Beta channel, so I don't think it's appropriate for the Canary cask to update to those versions. This updates the `livecheck` block regex to restrict matching to Canary versions.

This also updates the `android-studio-preview@beta` cask to use the same regex format for consistency. To be clear, the "beta" text in the regex is matching the Beta channel name, so it will continue to pick up both Beta and RC releases.