### PR TITLE
wezterm@nightly: fix install on case-insensitive filesystems

### DIFF
--- a/Casks/w/wezterm@nightly.rb
+++ b/Casks/w/wezterm@nightly.rb
@@ -27,8 +27,8 @@ cask "wezterm@nightly" do
 
   preflight_steps do
     # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder
-    move "{WezTerm-*,wezterm-*}/WezTerm.app", ".", source_glob: true
-    remove ["WezTerm-*", "wezterm-*"], recursive: true
+    move "WezTerm-*/WezTerm.app", ".", source_glob: true
+    remove "WezTerm-*", recursive: true
   end
 
   zap trash: "~/Library/Saved Application State/com.github.wez.wezterm.savedState"


### PR DESCRIPTION
> Supersedes #276450, which became un-reopenable after its head branch was momentarily deleted during fork initialisation (GitHub returns HTTP 422 on reopen, so the auto-reopen workflow cannot recover it). Re-filed here with the complete template.

## Problem

`brew install --cask wezterm@nightly` fails on case-insensitive filesystems (the macOS default, e.g. non-case-sensitive APFS):

```text
Error: install step source glob must match exactly one path:
/opt/homebrew/Caskroom/wezterm@nightly/latest/{WezTerm-*,wezterm-*}/WezTerm.app
```

## Cause

#0e23e31ac ("wezterm@nightly: migrate flight removals") replaced the previous duplicate-tolerant `preflight do … .glob([...]).first` with a `move` step:

```ruby
move "{WezTerm-*,wezterm-*}/WezTerm.app", ".", source_glob: true
```

The `move` step resolves its source with `Pathname.glob` and requires **exactly one** match (`Cask::Artifact` → `install_steps.rb#resolve_step_source`). The nightly zip extracts to a single folder, `WezTerm-macos-<date>/`. On a case-insensitive filesystem **both** brace alternatives match that one folder:

- `WezTerm-*/WezTerm.app` → matches
- `wezterm-*/WezTerm.app` → also matches the same folder (case-insensitive)

so the glob returns the path **twice** (length `2` ≠ `1`) and the step aborts. The old `.first` form silently tolerated the duplicate; the strict `move` form does not.

## Fix

The macOS nightly artifact is always named `WezTerm-macos-*` (capitalised), so one glob alternative matches exactly once on both case-insensitive and case-sensitive filesystems; the lowercase `wezterm-*` alternative was redundant.

## Testing

- `brew style` — no offenses.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask wezterm@nightly` (via a local tap carrying this change) installs cleanly on non-case-sensitive APFS; `wezterm --version` → `20260716-195552-76b606ec`; all four binaries link.
- `brew audit --cask --online` still reports `No binaries in App` + an `index 0 outside of array bounds` exception, **but this is pre-existing and unrelated to this change**: `brew audit`'s `extract_artifacts` unpacks the zip without running `preflight_steps`, so it looks for `WezTerm.app` at the staged root while the app is still inside `WezTerm-macos-*/`. I reproduced the identical audit failure against the unchanged `main` content (brace-glob version), so this PR neither introduces nor is able to fix it.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

**AI usage:** Claude (Claude Code) diagnosed the root cause and drafted the one-line change. Every claim was verified manually by me:

- Confirmed the filesystem is non-case-sensitive APFS and that each brace alternative matches the single `WezTerm-macos-*` folder (so `Pathname.glob` returns two identical paths → the `move` step's "exactly one path" check fails).
- Ran `brew style` (clean) and installed from a local tap with the change; `wezterm --version` runs and all binaries link.
- Verified the `brew audit` errors are pre-existing by reproducing them against the unchanged `main` content.
- `zap` stanza: the app's `CFBundleIdentifier` is `com.github.wez.wezterm`, so the existing `~/Library/Saved Application State/com.github.wez.wezterm.savedState` path is correct (the `zap` stanza is unchanged by this PR).
