### PR TITLE
neon-vision-editor: update 0.9.4

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,6 +1,6 @@
 cask "neon-vision-editor" do
-  version "0.9.3"
-  sha256 "10c2db4e095d6bda6b8c7ed5cb3050448deec05bb1b639a2d492b4ec1b7c03e2"
+  version "0.9.4"
+  sha256 "52c37139ba4555ded44f18931e9a68605be6eb615def0ece82e3bd254c711f16"
 
   url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
   name "Neon Vision Editor"


### PR DESCRIPTION
Updates Neon Vision Editor to v0.9.4 using the signed and notarized GitHub release artifact published by the project release workflow.