### PR TITLE
claude-status-bar 0.4.0

### DIFF
--- a/Casks/c/claude-status-bar.rb
+++ b/Casks/c/claude-status-bar.rb
@@ -1,15 +1,20 @@
 cask "claude-status-bar" do
-  version "0.3.4"
-  sha256 "d812ebf2b3ef161c06b700636789b517b47222a093d2074f0cc324903b514aea"
+  version "0.4.0"
+  sha256 "d66b984fa4362b412417df81500bb8df4b524c839de48a70d5c8d8a6d27c55b6"
 
   url "https://github.com/m1ckc3s/claude-status-bar/releases/download/v#{version}/ClaudeStatusBar.dmg"
   name "Claude Status Bar"
   desc "Menu bar status indicator for Claude Code"
   homepage "https://github.com/m1ckc3s/claude-status-bar"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: :monterey
 
-  app "ClaudeStatusBar.app"
+  app "Claude Status Bar.app"
 
   zap trash: [
     "~/.claude/statusbar",


### PR DESCRIPTION
Bumps claude-status-bar to v0.4.0.

This release also renames the app bundle from `ClaudeStatusBar.app` to `Claude Status Bar.app`, fulfilling the commitment made in #274337 (token/name consistency), so the `app` stanza is updated in the same bump.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I'm the developer of the app (see #274337). AI (Claude Code) helped prepare the cask edit and this PR. Manually verified on macOS: `brew audit --cask --online` and `brew style` pass against the released DMG; install, upgrade from 0.3.4 across the bundle rename, and uninstall were all tested end to end; the zap paths were verified with `brew uninstall --zap` (they are this app's actual state dir and macOS-created files, nothing else).

-----
