### PR TITLE
neon-vision-editor 0.9.5

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,6 +1,6 @@
 cask "neon-vision-editor" do
-  version "0.9.4"
-  sha256 "52c37139ba4555ded44f18931e9a68605be6eb615def0ece82e3bd254c711f16"
+  version "0.9.5"
+  sha256 "da2bbc4de889ae3ce37db385dedfa8c63bb7678091ccade4e5fad842cdf2ade8"
 
   url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
   name "Neon Vision Editor"


### PR DESCRIPTION
-----

- [x] The submission is for a stable version.
- [x] `brew audit --cask --online neon-vision-editor` is error-free.
- [x] `brew style --fix neon-vision-editor` reports no offenses.

-----

- [x] AI was used to assist with this PR. It prepared the two-line version and checksum update. The public v0.9.5 ZIP SHA-256 was verified, `brew audit --cask --online` and `brew style --fix` passed against this Cask, and the existing `zap` paths were reviewed and left unchanged.

-----
