### PR TITLE
betterzip: add CLI binary, refresh sha256

### DIFF
--- a/Casks/b/betterzip.rb
+++ b/Casks/b/betterzip.rb
@@ -1,6 +1,6 @@
 cask "betterzip" do
   version "6.0"
-  sha256 "19e2bf96ca0d33be907528828b4e0d27edd6acfe8f3317431d784537ebc96723"
+  sha256 "10cef4dad336335fdd0c989ad4230f7850573c2bff139d168dc9ee704fd5e767"
 
   url "https://macitbetter.com/dl/BetterZip-#{version}.zip"
   name "BetterZip"
@@ -16,6 +16,7 @@ cask "betterzip" do
   depends_on macos: :ventura
 
   app "BetterZip.app"
+  binary "#{appdir}/BetterZip.app/Contents/Resources/betterzip"
 
   zap trash: [
     "~/Library/Application Scripts/79RR9LPM2N.group.com.macitbetter.betterzip",


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

BetterZip 6.0 ships a `betterzip` CLI at `Contents/Resources/betterzip`; this links it into the Homebrew prefix.

Also refreshes `sha256`: upstream re-packaged `BetterZip-6.0.zip` at the same URL, so the checksum on file no longer matched. New checksum verified against a fresh download.

Verified locally on macOS 26.5 that the binary exists and runs (`betterzip help`). `zap` stanza is unchanged.

AI assistance: Claude Code was used to locate the CLI path, write the `binary` stanza, recompute the checksum, and run `brew style`/`brew audit`. Output was reviewed manually.
