### PR TITLE
kero 0.1.20 (new cask)

### DIFF
--- a/Casks/k/kero.rb
+++ b/Casks/k/kero.rb
@@ -1,6 +1,6 @@
 cask "kero" do
-  version "0.1.16"
-  sha256 "f36804088590bfd43c4be0e779b7e0d0220a3bff861ba4d46f70bbb4ca85ac29"
+  version "0.1.20"
+  sha256 "69a601b90e293acbfecf7d2e20113542476d7552a5cd5bb4894685fee44b6759"
 
   url "https://releases.kero.sh/kero-#{version}.dmg"
   name "Kero"

--- a/Casks/k/kero.rb
+++ b/Casks/k/kero.rb
@@ -1,0 +1,28 @@
+cask "kero" do
+  version "0.1.16"
+  sha256 "f36804088590bfd43c4be0e779b7e0d0220a3bff861ba4d46f70bbb4ca85ac29"
+
+  url "https://releases.kero.sh/kero-#{version}.dmg"
+  name "Kero"
+  desc "Keyboard-first terminal workspace with projects, sessions, and git"
+  homepage "https://kero.sh/"
+
+  livecheck do
+    url "https://releases.kero.sh/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sequoia
+
+  app "Kero.app"
+
+  zap trash: [
+    "~/Library/Application Support/kero",
+    "~/Library/Caches/sh.kero",
+    "~/Library/HTTPStorages/sh.kero",
+    "~/Library/Preferences/sh.kero.plist",
+    "~/Library/Saved Application State/sh.kero.savedState",
+    "~/Library/WebKit/sh.kero",
+  ]
+end


### PR DESCRIPTION
Adds a cask for [Kero](https://kero.sh/) — a native macOS terminal workspace (projects, persistent sessions, files and git in one window). Free, no telemetry, no subscription. It's open source https://github.com/egoist/kero

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----
An AI assistant drafted the cask and ran the commands above; I reviewed the result and verified it by hand:

- `sha256` recomputed locally from the downloaded `kero-0.1.16.dmg`.
- Mounted the DMG and confirmed the artifact is `Kero.app` with `CFBundleIdentifier` `sh.kero`, `CFBundleShortVersionString` `0.1.16` and `LSMinimumSystemVersion` `15.6` (hence `depends_on macos: :sequoia`); signature and notarization checked with `codesign -dv`.
- Install and uninstall were run for real on macOS 27 (into a scratch `--appdir` so my existing copy in `/Applications` wasn't touched).
- `brew livecheck --cask kero` resolves `0.1.16` from the Sparkle appcast.
- Every `zap` path was confirmed to exist on disk after running the app, and cross-checked against the app's source: `~/Library/Application Support/kero` is the support directory the app writes (it uses `kero-dev` only for debug builds, which is why that path is not listed), and `~/Library/Caches/sh.kero`, `~/Library/HTTPStorages/sh.kero`, `~/Library/WebKit/sh.kero` and `~/Library/Preferences/sh.kero.plist` all match the shipping bundle id. The app is not sandboxed, so there is no container to remove.
