### PR TITLE
neodisk 2.70.2 (new cask)

### DIFF
--- a/Casks/n/neodisk.rb
+++ b/Casks/n/neodisk.rb
@@ -1,0 +1,29 @@
+cask "neodisk" do
+  version "2.70.2"
+  sha256 "15107271c56c4512e11c5634ea3768295e360a624e090231be0cfada56b7aa6b"
+
+  url "https://github.com/tkslucas/Neodisk/releases/download/v#{version}/Neodisk-#{version}.dmg",
+      verified: "github.com/tkslucas/Neodisk/"
+  name "Neodisk"
+  desc "Read-only disk space visualiser"
+  homepage "https://neodisk.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "Neodisk.app"
+
+  zap trash: [
+    "~/Library/Application Support/Neodisk",
+    "~/Library/Caches/com.lucastakayasu.Neodisk",
+    "~/Library/HTTPStorages/com.lucastakayasu.Neodisk",
+    "~/Library/Preferences/com.lucastakayasu.Neodisk.plist",
+    "~/Library/Saved Application State/com.lucastakayasu.Neodisk.savedState",
+  ]
+end


### PR DESCRIPTION
Built and tested locally on macOS 26.

-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, as this adds a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

Codex with GPT-5.6 Sol High was used to research the current Homebrew requirements and draft the cask. The cask, release checksum, and `zap` paths were manually reviewed. The `zap` paths were verified against files created by the launched application. Audit, style, livecheck, install, uninstall, typecheck, and `brew lgtm --online` all passed locally.

-----
