### PR TITLE
mac-sai: quit app before upgrade and zap shared prefs

### DIFF
--- a/Casks/m/mac-sai.rb
+++ b/Casks/m/mac-sai.rb
@@ -16,7 +16,8 @@ cask "mac-sai" do
 
   app "Mac Sai.app"
 
-  uninstall launchctl: "com.macclean.menu"
+  uninstall launchctl: "com.macclean.menu",
+            quit:      "com.macclean.app"
 
   zap trash: [
     "~/Library/Application Support/MacClean",
@@ -24,6 +25,7 @@ cask "mac-sai" do
     "~/Library/HTTPStorages/com.macclean.app",
     "~/Library/Logs/MacClean",
     "~/Library/Preferences/com.macclean.app.plist",
+    "~/Library/Preferences/com.macclean.shared.plist",
     "~/Library/Saved Application State/com.macclean.app.savedState",
   ]
 end


### PR DESCRIPTION
Two small correctness fixes for the `mac-sai` cask (I'm the app author).

- **Add `quit: "com.macclean.app"`** to `uninstall`. macOS can't replace a running `.app`, so upgrading while Mac Sai is open left the old copy behind. Quitting it first makes `brew upgrade` replace it cleanly. (Kept alongside the existing `launchctl:` for the menu-bar helper, in canonical order.)
- **Add `~/Library/Preferences/com.macclean.shared.plist` to `zap`.** The app writes a shared-defaults suite there (used by the app and its menu-bar helper); it was the one leftover a `--zap` uninstall didn't clear.

No version change. `brew style` passes.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked that there aren't other open pull requests for the same change?
- [x] Have you built your changes locally? (`brew style` clean)