### PR TITLE
Add nameYourSafariWindow 0.3.0

### DIFF
--- a/Casks/n/nameyoursafariwindow.rb
+++ b/Casks/n/nameyoursafariwindow.rb
@@ -1,0 +1,18 @@
+cask "nameyoursafariwindow" do
+  version "0.3.0"
+  sha256 "9d4001562013189df5c9016505e262a0839084f8b2f654a26dde41f71f20f53a"
+
+  url "https://github.com/bricolageTheory/NameYourSafariWindow/releases/download/v#{version}/SafariWindowSwitcher-v#{version}.zip"
+  name "Safari Window Switcher"
+  desc "Assign custom names to Safari windows and switch focus effortlessly"
+  homepage "https://github.com/bricolageTheory/NameYourSafariWindow"
+
+  depends_on macos: :big_sur
+
+  app "Safari Window Switcher.app"
+
+  zap trash: [
+    "~/Library/Containers/com.coolnick.SafariWindowSwitcher",
+    "~/Library/Containers/com.coolnick.SafariWindowSwitcher.Extension",
+  ]
+end


### PR DESCRIPTION
Add `nameyoursafariwindow` 0.3.0 - Safari Window Switcher.

Assign custom names to Safari windows, filter open windows instantly, and switch focus effortlessly.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online nameyoursafariwindow` is error-free.
- [x] `brew style --fix nameyoursafariwindow` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new nameyoursafariwindow` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask nameyoursafariwindow` worked successfully.
- [x] `brew uninstall --cask nameyoursafariwindow` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Used AI to format the Ruby Cask DSL formula. Manually compiled the app bundle, verified SHA256 checksum (`9d4001562...`), ran `brew style` (0 offenses), and confirmed the `zap` stanza container paths match the app's macOS bundle identifiers (`com.coolnick.SafariWindowSwitcher` and `com.coolnick.SafariWindowSwitcher.Extension`).*

-----
