### PR TITLE
battery-autopilot 1.5.0 (new cask)

### DIFF
--- a/Casks/b/battery-autopilot.rb
+++ b/Casks/b/battery-autopilot.rb
@@ -1,0 +1,30 @@
+cask "battery-autopilot" do
+  version "1.5.0"
+  sha256 "b9d1ceed1c164d6bb1ed94b31ac2fee6c7c30be72e5a0f920b8abec6130650cc"
+
+  url "https://macbattery.net/updates/BatteryAutopilot-#{version}.dmg"
+  name "Battery Autopilot"
+  desc "AI battery care with 80% charge limit and measured power savings"
+  homepage "https://macbattery.net/"
+
+  livecheck do
+    url "https://macbattery.net/updates/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sequoia
+  depends_on arch: :arm64
+
+  app "Battery Autopilot.app"
+
+  uninstall launchctl: "net.anysocial.batterypilot.helper",
+            quit:      "net.anysocial.batterypilot"
+
+  zap trash: [
+    "~/Library/Application Support/BatteryPilot",
+    "~/Library/Caches/net.anysocial.batterypilot",
+    "~/Library/HTTPStorages/net.anysocial.batterypilot",
+    "~/Library/Preferences/net.anysocial.batterypilot.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

**AI usage and manual verification:** AI (a coding agent operated by the developer — I'm affiliated with ANYSOCIAL HOLDINGS, Inc.) drafted the cask at our direction. All fields were derived from the shipped product, not guessed: `sha256` computed from the actual distributed DMG; `livecheck` points at the app's real Sparkle appcast; the `launchctl` label matches the privileged helper's bundle identifier (`net.anysocial.batterypilot.helper`) in the app source; `zap` paths were taken from the app's actual storage locations in source (`~/Library/Application Support/BatteryPilot` for its data store, plus standard Preferences/Caches/HTTPStorages paths under the bundle id `net.anysocial.batterypilot`). `brew style` was run locally with no offenses, and the versioned URL was verified to serve the notarized DMG with a matching checksum.

**Why the audit/install boxes are unchecked:** the local dev machine's Command Line Tools are too outdated for `brew audit`/`brew install` to run, and the app is already installed there from the developer's DMG (the same notarized artifact this cask downloads). The `test battery-autopilot (macos-26, arm)` CI job on this PR — which audits, installs and uninstalls the cask — passed.

**About the app:** Battery Autopilot is a menu bar battery manager for Apple Silicon Macs (macOS 15+): SMC-level 80% charge limit with a self-healing guard, measured power-saving automation and departure-aware full charging. Developer ID signed and notarized, distributed as a versioned DMG with a Sparkle appcast. We maintain a fallback tap at `anysocial-g/homebrew-tap` and will keep this cask updated.