### PR TITLE
Add ClipKit

### DIFF
--- a/Casks/c/clipkit.rb
+++ b/Casks/c/clipkit.rb
@@ -1,0 +1,13 @@
+cask "clipkit" do
+  version "2.1.0"
+  sha256 "3ff93fc50ef1842724cd32148f6567beccc7edaae0c548ddcdf2da3ca7e3512a"
+
+  url "https://github.com/arrrev/clipkit/releases/download/v#{version}/ClipKit-#{version}.zip"
+  name "ClipKit"
+  desc "Clipboard manager with history, text transforms, and global hotkeys"
+  homepage "https://github.com/arrrev/clipkit"
+
+  app "ClipKit.app"
+
+  zap trash: "~/.clipkit"
+end


### PR DESCRIPTION
-----

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online clipkit` is error-free.
- [x] `brew style --fix clipkit` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new clipkit` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask clipkit` worked successfully.
- [x] `brew uninstall --cask clipkit` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. Claude (claude.ai) assisted in writing the cask file and running the audit/style checks. The cask was manually verified by installing, running, and uninstalling the app on macOS 15 (arm64). The `zap` stanza removes `~/.clipkit` which is the only data directory the app creates.

-----