### PR TITLE
quicken: update homepage url

### DIFF
--- a/Casks/q/quicken.rb
+++ b/Casks/q/quicken.rb
@@ -1,11 +1,11 @@
 cask "quicken" do
-  version "9.1.0,901.61320.100"
-  sha256 "e92b2735fa56299c197ade0006c9f6b13a610bf748ce66c4d9bb6d2fa17cf4cc"
+  version "9.1.1,901.61363.100"
+  sha256 "7c95212ef123e09214dd1717e07151ee93e550010c19d5e0777bb92e5d6e7234"
 
   url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/Quicken-#{version.csv.second}/Quicken-#{version.csv.second}.zip"
   name "Quicken"
   desc "Personal finance manager"
-  homepage "https://www.quicken.com/mac"
+  homepage "https://www.quicken.com/products/classic-premier-deluxe-mac/"
 
   livecheck do
     url "https://download.quicken.com/mac/Quicken/001/Release/031A96D9-EFE6-4520-8B6A-7F465DDAA3E4/appcast.xml"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The autobump detected the new Quicken version but could not open an update PR because the existing homepage returns HTTP 404.

[Autobump Actions log](https://github.com/Homebrew/homebrew-cask/actions/runs/30066985430/job/89399780608)

```
audit for quicken: failed
 - The homepage URL https://www.quicken.com/mac is not reachable (HTTP status code 404)
Error: 1 problem in 1 cask detected.
quicken
  * The homepage URL https://www.quicken.com/mac is not reachable (HTTP status code 404)
Error: The homepage URL https://www.quicken.com/mac is not reachable (HTTP status code 404)
Error: `brew audit` failed!
```

Closes #277000 