### PR TITLE
tickernotch 1.7.3 (new cask)

### DIFF
--- a/Casks/t/tickernotch.rb
+++ b/Casks/t/tickernotch.rb
@@ -1,0 +1,25 @@
+cask "tickernotch" do
+  version "1.3.0"
+  sha256 "a4e8db3287ea4dd53deb98c167940e58b77a154a8bdd1787d85bb949aa70e1c7"
+
+  url "https://bitvibelabs.com/tickernotch/TickerNotch-v#{version}.dmg"
+  name "TickerNotch"
+  desc "Tickers, news, weather and social counters beside the notch or in the menu bar"
+  homepage "https://bitvibelabs.com/tickernotch/"
+
+  livecheck do
+    url "https://bitvibelabs.com/tickernotch/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "TickerNotch.app"
+
+  zap trash: [
+    "~/Library/Caches/com.bitvibelabs.tickernotch",
+    "~/Library/HTTPStorages/com.bitvibelabs.tickernotch",
+    "~/Library/Preferences/com.bitvibelabs.tickernotch.plist",
+  ]
+end

--- a/Casks/t/tickernotch.rb
+++ b/Casks/t/tickernotch.rb
@@ -1,6 +1,6 @@
 cask "tickernotch" do
-  version "1.3.0"
-  sha256 "a4e8db3287ea4dd53deb98c167940e58b77a154a8bdd1787d85bb949aa70e1c7"
+  version "1.7.3"
+  sha256 "46709ccc3845769e5f95676c59517b9d95aa0b0b49e34adb923d876595eac850"
 
   url "https://bitvibelabs.com/tickernotch/TickerNotch-v#{version}.dmg"
   name "TickerNotch"
@@ -20,6 +20,9 @@ cask "tickernotch" do
   zap trash: [
     "~/Library/Caches/com.bitvibelabs.tickernotch",
     "~/Library/HTTPStorages/com.bitvibelabs.tickernotch",
+    "~/Library/HTTPStorages/com.bitvibelabs.tickernotch.binarycookies",
+    "~/Library/Logs/TickerNotch",
     "~/Library/Preferences/com.bitvibelabs.tickernotch.plist",
+    "~/Library/WebKit/com.bitvibelabs.tickernotch",
   ]
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

The cask was drafted with AI assistance and every stanza was verified by running the real commands on macOS 26 (Apple Silicon), re-run in full for 1.3.0: `brew style` (no offenses after fixing the deprecated `depends_on` form), `brew audit --cask --strict --online` and `brew audit --cask --new` (both exit 0), a full `brew install --cask` + `brew uninstall --cask` cycle, and `brew livecheck` (resolves 1.3.0 from the Sparkle appcast). The zap paths are the artifacts an actual install leaves on disk (`~/Library/Preferences/com.bitvibelabs.tickernotch.plist`, `~/Library/Caches/com.bitvibelabs.tickernotch`, `~/Library/HTTPStorages/com.bitvibelabs.tickernotch`), checked against a machine that runs the app. Gatekeeper assessment on the installed app: `Notarized Developer ID`, accepted.

-----

TickerNotch is a native Swift menu bar app that shows live stock/crypto tickers, RSS news, weather and social follower counts in the black bars beside the MacBook notch, and as of 1.3.0 can pin any of those to the macOS menu bar as its own item. Signed and notarized (Developer ID team QVL96XM7YU), Sparkle auto-updates (hence `auto_updates true`), versioned stable download URLs. I'm the developer.

-----

This supersedes #277198, which I closed by accident while cleaning up its branch. The cask content is identical, and both `test tickernotch` jobs passed there (macOS 26 arm and macOS 15 intel) after I fixed the download issue: my host had Cloudflare Bot Fight Mode enabled, which challenged the CI runners and returned a 403. It is off now and the DMG fetches fine from automated clients.
