### PR TITLE
Add Mainspring 3.0.1

### DIFF
--- a/Casks/m/mainspring.rb
+++ b/Casks/m/mainspring.rb
@@ -1,0 +1,25 @@
+cask "mainspring" do
+  version "3.0.1"
+  sha256 "a9927f0758fd02f65fcdd5c2c8b05a1411cf4275a31f914486cdfd309fb914d8"
+
+  url "https://trymainspring.com/downloads/Mainspring-#{version}.pkg",
+      verified: "trymainspring.com/"
+  name "Mainspring"
+  desc "Utility for reversibly toggling hidden system settings"
+  homepage "https://trymainspring.com/"
+
+  livecheck do
+    url "https://trymainspring.com/downloads/Mainspring.pkg"
+    strategy :header_match do |headers|
+      headers["content-disposition"][/Mainspring[._-]v?(\d+(?:\.\d+)+)\.pkg/i, 1]
+    end
+  end
+
+  depends_on macos: :ventura
+
+  pkg "Mainspring-#{version}.pkg"
+
+  uninstall pkgutil: "app.mainspring.pkg"
+
+  zap trash: "~/Library/Preferences/app.mainspring.plist"
+end


### PR DESCRIPTION
Adds a cask for [Mainspring](https://trymainspring.com), a native macOS utility that turns hidden system settings into one-click, reversible toggles.

- Signed and notarized by Apple; pkg identifier `app.mainspring.pkg`.
- livecheck reads the version from the download's Content-Disposition header.

Verification performed:
- [x] `brew audit --cask --new --online mainspring` passes (downloads and extracts the notarized pkg successfully)
- [x] `brew style` passes
- [ ] Full `brew install`/uninstall not run in my environment (the pkg installs a privileged helper and requires sudo). Happy to run it if needed.

Note: Mainspring is a new, closed-source commercial app, so I understand it may not yet meet the notability guidelines. Flagging that openly. A working install is also available via a personal tap (`chipmunk1101/mainspring`) if core inclusion is premature.