### PR TITLE
brilliant 0.1.0-beta.36 (new app generation)

### DIFF
--- a/Casks/b/brilliant.rb
+++ b/Casks/b/brilliant.rb
@@ -1,26 +1,31 @@
 cask "brilliant" do
-  version "1.8.9"
-  sha256 "e801b856964c38462739be98986eeb03c2954bb633c5d40415d5baf40f48e631"
+  version "0.1.0-beta.36"
+  sha256 "7eea166e2b885f5dbe3707decb87ff5d77a1da7409a2b9585c31334606d4d3ad"
 
-  url "https://s3.eu-north-1.amazonaws.com/brilliant.design/Brilliant.Design-#{version}-Installer.dmg",
-      verified: "s3.eu-north-1.amazonaws.com/brilliant.design/"
+  url "https://api.brilliant.design/v1/download/macos/#{version}"
   name "Brilliant"
-  desc "Design and communication tool"
+  desc "AI-native design tool"
   homepage "https://brilliant.design/"
 
   livecheck do
-    skip "No version information available"
+    url "https://api.brilliant.design/v1/versions/latest"
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
   auto_updates true
-  depends_on macos: :ventura
+  depends_on macos: :sonoma
 
-  app "Brilliant.Design.app"
+  app "brilliant.app"
 
   zap trash: [
+    "~/.config/brilliant",
     "~/.config/brilliant.design",
     "~/Library/Application Support/Brilliant",
+    "~/Library/Application Support/design.brilliant",
     "~/Library/Caches/design.brilliant",
     "~/Library/Preferences/design.brilliant.plist",
+    "~/Library/Saved Application State/design.brilliant.savedState",
   ]
 end


### PR DESCRIPTION
Brilliant (https://brilliant.design/) shipped a new generation of its macOS app; 1.8.9 was the final release of the legacy app and is no longer maintained. This updates the cask to the new app from the same vendor (I am the developer):

- New stable versioned download URL (`https://api.brilliant.design/v1/download/macos/#{version}`), served by our release API. Artifacts are Developer ID-signed, notarized, and stapled; universal (arm64 + x86_64).
- Working `livecheck` against `https://api.brilliant.design/v1/versions/latest` (JSON, top-level `version`), replacing the previous `skip "No version information available"` — future versions can autobump.
- The version string restarts at `0.1.0-beta.36` (the new app's own line). Since cask outdatedness is an inequality check and the cask has `auto_updates true`, existing 1.8.9 installs are not force-"upgraded" by a plain `brew upgrade`; an explicit `brew upgrade brilliant` or `--greedy` moves users to the new app, which is intended.
- App bundle is `brilliant.app` (was `Brilliant.Design.app`); zap covers the new app's paths and keeps the legacy paths so migrated users get a full cleanup.
- `depends_on macos: :sonoma` per the app's `LSMinimumSystemVersion` (14.0).

After making all changes to the cask:
- [x] `brew audit --cask --online brilliant` passes
- [x] `brew style --cask brilliant` passes
- [x] `brew install --cask brilliant` works
- [x] `brew uninstall --cask brilliant` works
