### PR TITLE
sidebarfavorites 1.0.0 (new cask)

### DIFF
--- a/Casks/s/sidebarfavorites.rb
+++ b/Casks/s/sidebarfavorites.rb
@@ -1,0 +1,26 @@
+cask "sidebarfavorites" do
+  version "1.0.0"
+  sha256 "41a96dc65295a2542e14ed7b83d06a4cafa3e6d679e6e37b2a84fb1fc13a23ec"
+
+  url "https://github.com/ivg-design/SidebarFavorites/releases/download/v#{version}/SidebarFavorites-#{version}.dmg"
+  name "SidebarFavorites Manager"
+  desc "Adds custom icons to folders in Finder's sidebar"
+  homepage "https://github.com/ivg-design/SidebarFavorites"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "SidebarFavorites Manager.app"
+
+  uninstall quit: "com.ivg-design.SidebarFavoritesManager"
+
+  zap trash: [
+    "~/Library/Application Support/SidebarFavorites",
+    "~/Library/Preferences/com.ivg-design.SidebarFavoritesManager.plist",
+    "~/Library/Saved Application State/com.ivg-design.SidebarFavoritesManager.savedState",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----


**How AI was used:** the cask file and this PR body were drafted with Claude, which also ran every command in the checklist above and reported its output. The first version of this PR omitted this template entirely and was closed by your bot — that was the AI's mistake, corrected here.

**Manual verification performed:**

- **`zap` paths were confirmed to exist on disk**, not guessed. After running the app: `~/Library/Application Support/SidebarFavorites` (present — holds the app's config and the icon helper bundle it generates) and `~/Library/Preferences/com.ivg-design.SidebarFavoritesManager.plist` (present). `~/Library/Saved Application State/com.ivg-design.SidebarFavoritesManager.savedState` is the standard path for this bundle identifier. The app writes nothing outside these.
- **Install/uninstall round-tripped locally** on macOS 26.5 (Apple Silicon): installed from the local tap, launched the app, confirmed it runs, uninstalled, confirmed `/Applications/SidebarFavorites Manager.app` was removed and that the zap paths were correctly left in place (zap was not requested), then reinstalled.
- **Signature verified independently:** `spctl -a -vv` on the installed app reports `accepted / source=Notarized Developer ID`. Both the DMG and the app are Developer ID signed, notarized and stapled.
- **Two audit failures were found and fixed before submitting:** a redundant `verified:` parameter on `url` (its domain matches `homepage`), and the `depends_on macos:` syntax.

I am the upstream maintainer of this application.

---

Adds a cask for [SidebarFavorites](https://github.com/ivg-design/SidebarFavorites) — a macOS utility that gives folders in Finder's sidebar custom SF Symbol icons. MIT licensed, 108 stars, first released January 2026.
