### PR TITLE
neon-vision-editor 1.0

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,6 +1,6 @@
 cask "neon-vision-editor" do
-  version "1.0.0"
-  sha256 "3b4d71feecece7fe1e57f7074328723ff5f2992857cf632f0daa0567ff0edeed"
+  version "1.0"
+  sha256 "9a3b908aaa1b14db18a5a489844503922d614cd4fee9e31f7efae3912e7c150d"
 
   url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
   name "Neon Vision Editor"


### PR DESCRIPTION
Updates neon-vision-editor to the canonical v1.0 release.

- Version: 1.0
- SHA256: 9a3b908aaa1b14db18a5a489844503922d614cd4fee9e31f7efae3912e7c150d
- Release asset: https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.0/Neon.Vision.Editor.app.zip