### PR TITLE
xnconvert: update sha256 for 1.112.0

### DIFF
--- a/Casks/x/xnconvert.rb
+++ b/Casks/x/xnconvert.rb
@@ -1,6 +1,6 @@
 cask "xnconvert" do
   version "1.112.0"
-  sha256 "65162b95a9e8a85c1aa63cea5dd0d4cd2cc94524fc2503ab8855d49cc1ec11e3"
+  sha256 "7f9211670fe6af7705bdb4f93df73d0158d5436a29e70101108c6bfc84e09cb3"
 
   url "https://download.xnview.com/old_versions/XnConvert/XnConvert-#{version}-mac.dmg"
   name "XnSoft XnConvert"


### PR DESCRIPTION
The upstream binary for XnConvert 1.112.0 was re-released with a different checksum, causing installation to fail with a SHA-256 mismatch.

**Expected:** `65162b95a9e8a85c1aa63cea5dd0d4cd2cc94524fc2503ab8855d49cc1ec11e3`
**Actual:**   `7f9211670fe6af7705bdb4f93df73d0158d5436a29e70101108c6bfc84e09cb3`

This PR updates the sha256 to match the current upstream file.