### PR TITLE
betterzip: update sha256

### DIFF
--- a/Casks/b/betterzip.rb
+++ b/Casks/b/betterzip.rb
@@ -1,6 +1,6 @@
 cask "betterzip" do
   version "6.0.2"
-  sha256 "8f5645f920870ef85d30c01e58a505517d16486c4dd64fcb455b83498e865df6"
+  sha256 "054517c7be150b21d60094d347cb666cd4dc160df8a8b38b88845a2c7f656644"
 
   url "https://macitbetter.com/dl/BetterZip-#{version}.zip"
   name "BetterZip"


### PR DESCRIPTION
-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI assisted with preflight, checksum verification, and PR preparation. The current artifact checksum and one-line diff were independently verified, and the audit, style, install, and uninstall checks were run locally in an isolated Homebrew environment. The `zap` stanza is unchanged.

-----

Built and tested locally on macOS 26.5.2 (arm64).

The artifact currently served by the existing upstream URL has SHA-256 `054517c7be150b21d60094d347cb666cd4dc160df8a8b38b88845a2c7f656644`, which differs from the value recorded in the cask. The [official appcast](https://macitbetter.com/BetterZip6.rss) identifies the artifact as BetterZip 6.0.2, build 260727.4. No upstream explanation for the difference was found.
