### PR TITLE
tight-studio 3.0.5 (new cask)

### DIFF
--- a/Casks/t/tight-studio.rb
+++ b/Casks/t/tight-studio.rb
@@ -1,0 +1,32 @@
+cask "tight-studio" do
+  version "3.0.5"
+  sha256 "d711591a5a4891d2b12ef4369f0585e5d9e3adaab1303f44b615500b016b1f70"
+
+  url "https://downloads.tight.studio/TightStudio-#{version}-arm64.dmg"
+  name "Tight Studio"
+  desc "Screen recorder and video editor"
+  homepage "https://tight.studio/"
+
+  livecheck do
+    url "https://downloads.tight.studio/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :ventura
+
+  app "Tight Studio.app"
+
+  uninstall quit: "tight.studio"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/tight.studio.sfl*",
+    "~/Library/Application Support/Tight Studio",
+    "~/Library/Caches/tight.studio",
+    "~/Library/Caches/tight.studio.ShipIt",
+    "~/Library/HTTPStorages/tight.studio",
+    "~/Library/Logs/Tight Studio",
+    "~/Library/Preferences/tight.studio.plist",
+  ]
+end


### PR DESCRIPTION
Adds [Tight Studio](https://tight.studio/), a screen recorder and video editor for macOS (Apple Silicon). The app is Developer ID-signed and notarized, distributed as a DMG from the vendor's own domain, with versioned immutable artifacts and an `electron-builder` update feed that the `livecheck` block tracks.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+tight-studio&type=pullrequests).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Note on the unchecked audit boxes: `brew audit` aborts on this machine with "Your Command Line Tools are too outdated" (CLT below minimum for this macOS), which I could not resolve without an OS-level update. `brew style`, `livecheck` (correctly reports 3.0.5 via the `:electron_builder` strategy), install, and uninstall were all verified locally; deferring the audit to CI.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

The cask was drafted with Claude Code, operated by the app's developer (I am the vendor of Tight Studio). Manual verification: the `zap` paths were enumerated from a real installation's on-disk footprint (each path confirmed to exist under `~/Library`); the sha256 was computed from the published artifact and re-verified after download; install/uninstall were tested locally via `HOMEBREW_NO_INSTALL_FROM_API=1`; `brew livecheck` was run against the cask and returned the current version.

-----
