### PR TITLE
affine: add Linux AppImage

### DIFF
--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -7,7 +7,7 @@ cask "affine" do
   extension = on_system_conditional(
     macos: "zip",
     linux: "appimage",
-    )
+  )
   artifact = "affine-#{version}-stable-#{os}-#{arch}.#{extension}"
 
   url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/#{artifact}",

--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -4,13 +4,9 @@ cask "affine" do
 
   version "0.27.3"
 
-  extension = on_system_conditional(
-    macos: "zip",
-    linux: "appimage",
-  )
-  artifact = "affine-#{version}-stable-#{os}-#{arch}.#{extension}"
+  url_end = on_system_conditional macos: ".zip", linux: ".appimage"
 
-  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/#{artifact}",
+  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-#{os}-#{arch}#{url_end}",
       verified: "github.com/toeverything/AFFiNE/"
   name "AFFiNE"
   desc "Note editor and whiteboard"
@@ -44,6 +40,6 @@ cask "affine" do
 
     depends_on arch: :x86_64
 
-    app_image artifact, target: "AFFiNE.AppImage"
+    app_image "affine-#{version}-stable-linux-#{arch}.appimage", target: "AFFiNE.AppImage"
   end
 end

--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -2,10 +2,13 @@ cask "affine" do
   arch arm: "arm64", intel: "x64"
 
   version "0.27.3"
-  sha256 arm:   "bdeaa87ae8f200d63c738dfcdc3a8435fd8386e82cb28ef8b1ac5cc975207264",
-         intel: "41ca92935673f2e94f994cbc13af6698c6276886bd5debe09ba19d703eb04090"
 
-  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/affine-#{version}-stable-macos-#{arch}.zip",
+  artifact = on_system_conditional(
+    macos: "affine-#{version}-stable-macos-#{arch}.zip",
+    linux: "affine-#{version}-stable-linux-x64.appimage",
+  )
+
+  url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/#{artifact}",
       verified: "github.com/toeverything/AFFiNE/"
   name "AFFiNE"
   desc "Note editor and whiteboard"
@@ -17,14 +20,28 @@ cask "affine" do
   end
 
   auto_updates true
-  depends_on macos: :monterey
 
-  app "AFFiNE.app"
+  on_macos do
+    sha256 arm:   "bdeaa87ae8f200d63c738dfcdc3a8435fd8386e82cb28ef8b1ac5cc975207264",
+           intel: "41ca92935673f2e94f994cbc13af6698c6276886bd5debe09ba19d703eb04090"
 
-  zap trash: [
-    "~/Library/Application Support/AFFiNE",
-    "~/Library/Logs/AFFiNE",
-    "~/Library/Preferences/pro.affine.app.plist",
-    "~/Library/Saved Application State/pro.affine.app.savedState",
-  ]
+    depends_on macos: :monterey
+
+    app "AFFiNE.app"
+
+    zap trash: [
+      "~/Library/Application Support/AFFiNE",
+      "~/Library/Logs/AFFiNE",
+      "~/Library/Preferences/pro.affine.app.plist",
+      "~/Library/Saved Application State/pro.affine.app.savedState",
+    ]
+  end
+
+  on_linux do
+    sha256 "bc132e3f8dea5a05c3943da79822d92ed7f3218456eb051bd81d11d4f0580114"
+
+    depends_on arch: :x86_64
+
+    app_image artifact, target: "AFFiNE.AppImage"
+  end
 end

--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -1,12 +1,14 @@
 cask "affine" do
   arch arm: "arm64", intel: "x64"
+  os macos: "macos", linux: "linux"
 
   version "0.27.3"
 
-  artifact = on_system_conditional(
-    macos: "affine-#{version}-stable-macos-#{arch}.zip",
-    linux: "affine-#{version}-stable-linux-x64.appimage",
-  )
+  extension = on_system_conditional(
+    macos: "zip",
+    linux: "appimage",
+    )
+  artifact = "affine-#{version}-stable-#{os}-#{arch}.#{extension}"
 
   url "https://github.com/toeverything/AFFiNE/releases/download/v#{version}/#{artifact}",
       verified: "github.com/toeverything/AFFiNE/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I've used AI (ChatGPT) to do preliminary research on how homebrew supports Linux, mainly the distribution channels (GitHub and AppImage in this case) to see if adding the Linux support is viable.

Steps I have taken to manually verify the work:

1. I've read the contributors guidelines and the documentation on modifying/creating new casks.
2. I've used the `block-buzz` as a template for my work, as I've found it very simple and similar to what I wanted to do.
3. I've built and run the application locally.
4. I've run the validation tooling (`brew lgtm --online`, and the commands required by this template).

-----
