### PR TITLE
micro-sniff: disable

### DIFF
--- a/Casks/m/micro-sniff.rb
+++ b/Casks/m/micro-sniff.rb
@@ -7,6 +7,8 @@ cask "micro-sniff" do
   desc "Monitor microphone activity"
   homepage "https://github.com/dwarvesf/micro-sniff"
 
+  disable! date: "2026-07-28", because: :moved_to_mas
+
   depends_on :macos
 
   app "Micro Sniff.app"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

The scheduled autobump has reported blurred as unable to livecheck:

https://github.com/Homebrew/homebrew-cask/actions/runs/30318652280/job/90149681260

```sh
==> micro-sniff
Current cask version:     1.2.0
Latest livecheck version: unable to get versions
```
The upstream GitHub organization still exists, but the repository and release asset are no longer publicly available now return 404:

- https://github.com/dwarvesf/micro-sniff
- https://github.com/dwarvesf/micro-sniff/releases/download/v1.2.0/Micro.Sniff.1.2.0.dmg
The app remains available through the Mac App Store.
Since upstream no longer provides a direct download and the app is now available only through the Mac App Store, this disables the cask with because: :moved_to_mas.