### PR TITLE
neon-vision-editor: update 1.0.2

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,0 +1,25 @@
+cask "neon-vision-editor" do
+  version "1.0.2"
+  sha256 "54a0efdebf36587881098cd8be21b597d7bbb6694e9e55d46a8fc28237882f8e"
+
+  url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
+  name "Neon Vision Editor"
+  desc "Native code and text editor"
+  homepage "https://github.com/h3pdesign/Neon-Vision-Editor"
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Neon Vision Editor.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/group.h3p.Neon-Vision-Editor",
+    "~/Library/Application Scripts/h3p.Neon-Vision-Editor*",
+    "~/Library/Application Support/NeonVisionEditor",
+    "~/Library/Caches/h3p.Neon-Vision-Editor",
+    "~/Library/Containers/h3p.Neon-Vision-Editor",
+    "~/Library/Group Containers/group.h3p.Neon-Vision-Editor",
+    "~/Library/Logs/NeonVisionEditorUpdater.log",
+    "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
+  ]
+end


### PR DESCRIPTION
Updates the Neon Vision Editor cask to the published v1.0.2 release.

- URL: https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.0.2/Neon.Vision.Editor.app.zip
- SHA-256: 54a0efdebf36587881098cd8be21b597d7bbb6694e9e55d46a8fc28237882f8e
- Release: https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.0.2