### PR TITLE
Fix Thaw cask repository URLs

### DIFF
--- a/Casks/t/thaw.rb
+++ b/Casks/t/thaw.rb
@@ -2,10 +2,10 @@ cask "thaw" do
   version "1.2.0"
   sha256 "d67f4d31ef9fa057849a98540b810cfa42e0bc66019d3605abd08e45c69aa06f"
 
-  url "https://github.com/stonerl/Thaw/releases/download/#{version}/Thaw_#{version}.zip"
+  url "https://github.com/thaw-app/Thaw/releases/download/#{version}/Thaw_#{version}.zip"
   name "Thaw"
   desc "Menu bar manager"
-  homepage "https://github.com/stonerl/Thaw/"
+  homepage "https://github.com/thaw-app/Thaw/"
 
   auto_updates true
   depends_on macos: :sonoma

--- a/Casks/t/thaw@beta.rb
+++ b/Casks/t/thaw@beta.rb
@@ -2,10 +2,10 @@ cask "thaw@beta" do
   version "2.0.0-rc.1"
   sha256 "3be7a39bd12586f4b627c4bd317f7053bb7f68eb889a3a2c59b07e6cc8dd698f"
 
-  url "https://github.com/stonerl/Thaw/releases/download/#{version}/Thaw_#{version}.zip"
+  url "https://github.com/thaw-app/Thaw/releases/download/#{version}/Thaw_#{version}.zip"
   name "Thaw"
   desc "Menu bar manager"
-  homepage "https://github.com/stonerl/Thaw/"
+  homepage "https://github.com/thaw-app/Thaw/"
 
   livecheck do
     url :url


### PR DESCRIPTION
## What changed

- Update the stable `thaw` cask URL and homepage from `stonerl/Thaw` to `thaw-app/Thaw`.
- Update the `thaw@beta` cask URL and homepage to the active repository as well.

## Why

The Thaw repository moved from `stonerl/Thaw` to `thaw-app/Thaw`. The existing casks still point at the old repository, whose release asset URLs return 404. The same ZIP filenames and checksums are available from the active repository.

## Validation

- `ruby -c Casks/t/thaw.rb` — Syntax OK
- `ruby -c Casks/t/thaw@beta.rb` — Syntax OK
- Stable asset URL follows redirects and returns HTTP 200 (4,771,584 bytes)
- Beta asset URL follows redirects and returns HTTP 200 (8,084,607 bytes)
- Diff limited to the two Thaw cask files; versions, checksums, and `zap` stanza paths are unchanged

The full `brew audit --cask --online --git --changed` could not run against a plain clone because Homebrew requires a registered local tap for `--changed`; the targeted local audit path is disabled by this Homebrew version.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark a checkbox done before creation, or just click the checkboxes with the pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. I used AI to identify the stale repository URLs, prepare the two-file patch, and draft the PR. I manually verified the current Cask contents, both release asset URLs, checksums, Ruby syntax, and the final diff. The existing `zap` stanza paths were checked and left unchanged.

-----