### PR TITLE
neon-vision-editor closed

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,6 +1,6 @@
 cask "neon-vision-editor" do
-  version "1.0.1"
-  sha256 "73bea008f945d55cdb391ae9195ca20c6a953fc104f3aac2bf5fc769985d5856"
+  version "1.0.2"
+  sha256 "54a0efdebf36587881098cd8be21b597d7bbb6694e9e55d46a8fc28237882f8e"
 
   url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
   name "Neon Vision Editor"


### PR DESCRIPTION
Updates the existing Neon Vision Editor cask from 1.0.1 to 1.0.2.

- Release: https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.0.2
- ZIP: https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.0.2/Neon.Vision.Editor.app.zip
- SHA-256: 54a0efdebf36587881098cd8be21b597d7bbb6694e9e55d46a8fc28237882f8e

This branch is based on current upstream main and modifies the existing cask rather than adding a new cask.