### PR TITLE
rapidraw 1.6.0 (new cask)

### DIFF
--- a/Casks/r/rapidraw.rb
+++ b/Casks/r/rapidraw.rb
@@ -1,0 +1,21 @@
+cask "rapidraw" do
+  arch arm: "macos-14_aarch64", intel: "macos-15-intel_x64"
+
+  version "1.6.0"
+  sha256 arm:   "badcd5c35b39e57fde91c88b54fd94c89b403db84666beb4c39d6ca9cc5ee826",
+         intel: "3cdf964c5488e00c139dc3d1e1fe639a2c9bf3ef71b6bbe14fc12149aaa3062e"
+
+  url "https://github.com/CyberTimon/RapidRAW/releases/download/v#{version}/02_RapidRAW_v#{version}_#{arch}.dmg"
+  name "RapidRAW"
+  desc "Open-source RAW photo editor"
+  homepage "https://github.com/CyberTimon/RapidRAW"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "RapidRAW.app"
+
+  zap trash: "~/Library/Application Support/io.github.CyberTimon.RapidRAW"
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version or documented exception.
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR.

AI drafted the initial Cask. I manually verified the upstream release URLs, downloaded both macOS DMGs, calculated their SHA-256 checksums, inspected the application bundle and identifier, and ran a Ruby syntax check. The `zap` path is derived from the bundle identifier and has not been runtime-verified. Homebrew audit, style, install, and uninstall require an official-tap token and were not run against the standalone contribution.