### PR TITLE
t3-code: fix checksum

### DIFF
--- a/Casks/t/t3-code.rb
+++ b/Casks/t/t3-code.rb
@@ -18,8 +18,8 @@ cask "t3-code" do
   end
 
   on_macos do
-    sha256 arm:   "f50f4f33dc1b70369a16c97309bfc9a534a9eaddabad7b8040b2e891538ddf32",
-           intel: "e1f89635435922c87150da41d2d69abe5d69b60fba6678be62c36fae24af7a05"
+    sha256 arm:   "ec0a309a67b85a9973d5e477eb4a19781d8d7d100f192594a8956f142618ea3b",
+           intel: "19cb6234228784054f543c82b41a06d35376c685474b3770f65544896eba83d4"
 
     auto_updates true
     depends_on macos: :monterey
@@ -38,7 +38,7 @@ cask "t3-code" do
   end
 
   on_linux do
-    sha256 "4274f6b6aa36ef1946d4a1c95e32653481007c00d09df727aa31aa6e9c9ffbc9"
+    sha256 "38030aa4f0fe0131426978787442ca903b40b2f928d52a11d16893b9d9ca8cf4"
 
     depends_on arch: :x86_64
     app_image artifact, target: "T3 Code.AppImage"


### PR DESCRIPTION
Fixes the `SHA-256 mismatch` error when installing/upgrading `t3-code` 0.0.29.

### Root cause
The upstream `v0.0.29` GitHub release assets were **re-uploaded in place** after this cask was bumped, so the recorded checksums no longer match the served files:

- Release `v0.0.29` published: `2026-07-27T22:35:51Z`
- Cask bump commit (recorded old checksums): `2026-07-27T22:41:48Z`
- arm64 asset `updated_at` (re-upload): `2026-07-27T22:53:29Z` — ~12 min **after** the checksums were recorded

All three assets (arm, intel, linux) were replaced, so all three `sha256` values are updated here.

### Verification
Downloaded each current asset and computed the SHA-256:

```
T3-Code-0.0.29-arm64.dmg      ec0a309a67b85a9973d5e477eb4a19781d8d7d100f192594a8956f142618ea3b
T3-Code-0.0.29-x64.dmg        19cb6234228784054f543c82b41a06d35376c685474b3770f65544896eba83d4
T3-Code-0.0.29-x86_64.AppImage 38030aa4f0fe0131426978787442ca903b40b2f928d52a11d16893b9d9ca8cf4
```

These replace the previously recorded `f50f4f33…` (arm), `e1f89635…` (intel), and `4274f6b6…` (linux).

Related upstream report: pingdotgg/t3code#4694

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same change?
- [x] Have you built your cask locally prior to submission with `brew install --cask <cask>`?
- [x] Have you tried the [`audit`, `style`, and `readall` commands](https://docs.brew.sh/Cask-Cookbook#getting-started) if applicable?

Co-Authored-By: Oz <oz-agent@warp.dev>
