### PR TITLE
meetingrecorder 1.6.2 (new cask)

### DIFF
--- a/Casks/m/meetingrecorder.rb
+++ b/Casks/m/meetingrecorder.rb
@@ -9,7 +9,7 @@ cask "meetingrecorder" do
 
   livecheck do
     url "https://raw.githubusercontent.com/emishin/meetingrecorder-updates/main/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/m/meetingrecorder.rb
+++ b/Casks/m/meetingrecorder.rb
@@ -8,8 +8,8 @@ cask "meetingrecorder" do
   homepage "https://meetingsrecorder.com/"
 
   livecheck do
-    url "https://github.com/emishin/meetingrecorder-updates/releases"
-    strategy :github_latest
+    url "https://raw.githubusercontent.com/emishin/meetingrecorder-updates/main/appcast.xml"
+    strategy :sparkle
   end
 
   auto_updates true

--- a/Casks/m/meetingrecorder.rb
+++ b/Casks/m/meetingrecorder.rb
@@ -1,0 +1,27 @@
+cask "meetingrecorder" do
+  version "1.6.2"
+  sha256 "d1b09afa21f2c4ab90411ab777b7cffc27452fc2d494a8478636be9e2679637d"
+
+  url "https://meetingsrecorder.com/downloads/MeetingRecorder-#{version}.dmg"
+  name "MeetingRecorder"
+  desc "Recorder for meetings capturing mic and system audio, no bot in the call"
+  homepage "https://meetingsrecorder.com/"
+
+  livecheck do
+    url "https://github.com/emishin/meetingrecorder-updates/releases"
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sequoia
+  depends_on arch: :arm64
+
+  app "MeetingRecorder.app"
+
+  zap trash: [
+    "~/Library/Application Support/MeetingRecorder",
+    "~/Library/Caches/com.meetingrecorder.app",
+    "~/Library/HTTPStorages/com.meetingrecorder.app",
+    "~/Library/Preferences/com.meetingrecorder.app.plist",
+  ]
+end

--- a/Casks/m/meetingrecorder.rb
+++ b/Casks/m/meetingrecorder.rb
@@ -4,7 +4,7 @@ cask "meetingrecorder" do
 
   url "https://meetingsrecorder.com/downloads/MeetingRecorder-#{version}.dmg"
   name "MeetingRecorder"
-  desc "Recorder for meetings capturing mic and system audio, no bot in the call"
+  desc "Recorder for meetings capturing mic and system audio"
   homepage "https://meetingsrecorder.com/"
 
   livecheck do


### PR DESCRIPTION
Free menu-bar meeting recorder for macOS. Hosted download, notarized, Sequoia+ / arm64.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. The cask file (stanzas, the `sha256` computed from the release DMG, and the zap paths) was assembled with AI (Claude Code). I verified everything manually on my Mac: `brew audit --cask --new`, `brew style`, and `brew install`/`uninstall` all pass. The zap paths derive from the app's bundle id `com.meetingrecorder.app` and standard macOS locations (Application Support, Caches, HTTPStorages for Sparkle, preferences plist). User recordings live in a user-chosen folder (default `~/Documents/MeetingRecordings`) and are intentionally not zapped.

-----