### PR TITLE
spacejump 1.6.6 (new cask)

### DIFF
--- a/Casks/s/spacejump.rb
+++ b/Casks/s/spacejump.rb
@@ -1,0 +1,26 @@
+cask "spacejump" do
+  version "1.6.6"
+  sha256 "7110926a1969469480e0056374022a6ce6c3567743551aa5dce3e58357ac6955"
+
+  url "https://pub-2f1e73dd67bd462192b6592baa57a0ce.r2.dev/SpaceJump-v#{version}.dmg",
+      verified: "pub-2f1e73dd67bd462192b6592baa57a0ce.r2.dev/"
+  name "SpaceJump"
+  desc "Menu bar utility to name and switch desktop Spaces"
+  homepage "https://getspacejump.com/"
+
+  livecheck do
+    url "https://getspacejump.com/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :ventura
+
+  app "SpaceJump.app"
+
+  zap trash: [
+    "~/Library/Caches/com.ideabridge.spacejump",
+    "~/Library/Logs/SpaceJump",
+    "~/Library/Preferences/com.ideabridge.spacejump.plist",
+  ]
+end

--- a/Casks/s/spacejump.rb
+++ b/Casks/s/spacejump.rb
@@ -19,7 +19,9 @@ cask "spacejump" do
   app "SpaceJump.app"
 
   zap trash: [
+    "~/Library/Application Support/com.ideabridge.spacejump",
     "~/Library/Caches/com.ideabridge.spacejump",
+    "~/Library/HTTPStorages/com.ideabridge.spacejump*",
     "~/Library/Logs/SpaceJump",
     "~/Library/Preferences/com.ideabridge.spacejump.plist",
   ]


### PR DESCRIPTION
Adds a cask for [SpaceJump](https://getspacejump.com), a macOS menu bar utility for naming, labelling and switching desktop Spaces.

The app ships as a Developer ID signed and notarized DMG and updates itself via Sparkle, so the cask sets `auto_updates true` and uses the `:sparkle` livecheck strategy against the published appcast with `&:short_version`, since the download URL contains the marketing version only.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

I am the developer of SpaceJump. The cask was drafted with Claude Code and then verified manually on macOS 15 (arm64) before submitting:

- `brew style --fix` and `brew audit --cask --online` / `--new` were all run locally and are error-free.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask` and `brew uninstall --cask` were both run for real against a clean `/Applications` (my pre-existing manual install was moved aside for the test and restored afterwards). Install placed `SpaceJump.app` correctly and uninstall removed it.
- `brew livecheck` resolves against the Sparkle appcast (`spacejump: 1.6.6 ==> 1.6.6`).
- The `zap` paths were verified against a real installation on my own machine: as the app's developer I can confirm the bundle identifier is `com.ideabridge.spacejump`, and that it writes exactly `~/Library/Preferences/com.ideabridge.spacejump.plist` (all app settings and notes), `~/Library/Caches/com.ideabridge.spacejump`, and `~/Library/Logs/SpaceJump`. No other paths are created outside the app bundle.
