### PR TITLE
tableplus: update zap path

### DIFF
--- a/Casks/t/tableplus.rb
+++ b/Casks/t/tableplus.rb
@@ -18,9 +18,11 @@ cask "tableplus" do
   app "TablePlus.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.tinyapp.tableplus.sfl*",
     "~/Library/Application Support/com.tinyapp.TablePlus",
     "~/Library/Caches/com.tinyapp.TablePlus",
     "~/Library/Cookies/com.tinyapp.TablePlus.binarycookies",
+    "~/Library/HTTPStorages/com.tinyapp.TablePlus",
     "~/Library/Preferences/com.tinyapp.TablePlus.plist",
     "~/Library/Saved Application State/com.tinyapp.TablePlus.savedState",
   ]


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

brew generate-zap found a path not covered by tableplus's current zap stanza, so this PR adds it
Reference:
https://github.com/Homebrew/homebrew-cask/actions/runs/30381993323

