### PR TITLE
codex: restore package release asset

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -3,12 +3,12 @@ cask "codex" do
   os macos: "apple-darwin", linux: "unknown-linux-musl"
 
   version "0.146.0"
-  sha256 arm:          "2750132d300e64f1dbffb95e3d913fd9c9dc7812bc8e1bce5c61357248b7929e",
-         intel:        "710d727b0fa2b4ab2189eb1bdc5ab40177c168296af264913eb7ab3ce848d04b",
-         arm64_linux:  "975bac91562abeedeb8f79636d51a86649b31f34a9de6a3bcb059565b6cf1f87",
-         x86_64_linux: "5ba3b9405543953081f661d0854d266f76e2abbe51d41349355a36de7673776a"
+  sha256 arm:          "cd961b480f6dfc4703bd244601f1927231fa31a587cb9046ccdffa6c4c29e7d5",
+         intel:        "f72f5ab71729e90b8e86343e9199c0f7a7eebbca5d6b1fc4cfcdaf35a3e5b641",
+         arm64_linux:  "c6eb28ec19bb5615b60e6787165ef28482481c2ce2617da565b83e591bc44c13",
+         x86_64_linux: "3c89125af1d7c98abec8beb551292ef99daca52e204e5852a9139feae2c467e5"
 
-  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-#{arch}-#{os}.tar.gz"
+  url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-package-#{arch}-#{os}.tar.gz"
   name "Codex"
   desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
@@ -19,10 +19,8 @@ cask "codex" do
     strategy :github_latest
   end
 
-  depends_on formula: "ripgrep"
-
-  binary "codex-#{arch}-#{os}", target: "codex"
-  generate_completions_from_executable "codex-#{arch}-#{os}", "completion", base_name: "codex"
+  binary "bin/codex"
+  generate_completions_from_executable "bin/codex", "completion"
 
   zap rmdir: "~/.codex"
 end


### PR DESCRIPTION
Built and tested locally on macOS 26.6 (arm64).

This restores the package release asset introduced in Homebrew/homebrew-cask#268453. That change was reverted because the bundled `rg` executable was not signed. openai/codex#35264 updated the release workflow to sign and notarize the bundled macOS helper binaries, so the package is now suitable for the cask.

The cask unpacks the release archive as one Homebrew-managed tree and links the canonical `bin/codex` entrypoint. Codex resolves its other executables relative to that tree, so adding or moving internal helpers does not require cask changes. Upgrades replace the staged package tree as a unit.

`depends_on formula: "ripgrep"` is removed because the package includes the `codex-path/rg` binary that Codex expects. Keeping the formula dependency would be redundant and could mask failures to resolve the packaged helper.

Representative contents of the unpacked release archive:

```text
.
├── bin
│   ├── codex
│   └── codex-code-mode-host
├── codex-package.json
├── codex-path
│   └── rg
└── codex-resources
    └── zsh
        └── bin
            └── zsh
```

The sample `codex-package.json`:

```json
{
  "layoutVersion": 1,
  "version": "0.145.0",
  "target": "aarch64-apple-darwin",
  "variant": "codex",
  "entrypoint": "bin/codex",
  "resourcesDir": "codex-resources",
  "pathDir": "codex-path"
}
```

Validation:

- `brew audit --cask --online codex`
- `brew style --fix codex`
- Source cask install and uninstall with `HOMEBREW_NO_INSTALL_FROM_API=1`
- `codex doctor --json` confirmed the Brew package layout and bundled `rg`
- All bundled arm64 macOS executables passed Developer ID signature verification

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

Codex assisted with the cask edit, validation, and PR preparation. The validation commands listed above were run locally. The existing `zap rmdir: "~/.codex"` stanza is unchanged and was inspected; `--zap` was not run because it would remove the current user's Codex state.

-----
