### PR TITLE
Add tatamio 0.12.2

### DIFF
--- a/Casks/t/tatamio.rb
+++ b/Casks/t/tatamio.rb
@@ -1,0 +1,25 @@
+cask "tatamio" do
+  version "0.12.2"
+  sha256 "23fba937c7782ed476dc4201498ea5997a722d9b378768ecd55784c46841cbce"
+
+  url "https://tatamio.app/downloads/Tatamio-#{version}.dmg"
+  name "Tatamio"
+  desc "Tiling window manager with snap zones, workspaces and a screen-share portal"
+  homepage "https://tatamio.app/"
+
+  livecheck do
+    url "https://tatamio.app/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Tatamio.app"
+
+  zap trash: [
+    "~/.tatami",
+    "~/.tatamio",
+    "~/Library/Application Support/app.tatamio",
+  ]
+end

--- a/Casks/t/tatamio.rb
+++ b/Casks/t/tatamio.rb
@@ -9,17 +9,19 @@ cask "tatamio" do
 
   livecheck do
     url "https://tatamio.app/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: ">= :ventura"
 
   app "Tatamio.app"
 
   zap trash: [
     "~/.tatami",
-    "~/.tatamio",
     "~/Library/Application Support/app.tatamio",
+    "~/Library/Caches/app.tatamio.mac",
+    "~/Library/HTTPStorages/app.tatamio.mac",
+    "~/Library/Preferences/app.tatamio.mac.plist",
   ]
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+tatamio&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) drafted the cask and this PR under my direction; I am the developer of the app. Manual verification: `brew style` and `brew audit --cask --online --new` run locally against this exact file (error-free); every `zap` path checked against an actual installation on disk (paths that did not exist were removed); the same DMG (identical sha256) is installed and in daily use via the vendor tap `folivaresrios/tatamio`, where install/uninstall were exercised end-to-end. The install checkbox above is unticked only because this machine already runs the app from that tap — same artifact, same caveats.

-----

Tatamio is a native macOS window manager (snap zones + i3-style tiling + per-monitor workspaces) with a screen-sharing "portal" for meetings. Signed and notarized (Developer ID), distributed as a versioned DMG with Sparkle in-app updates — hence `auto_updates true` and the `:sparkle` livecheck (with `&:short_version`, as the appcast's `sparkle:version` carries a build id). Minimum macOS matches the app's `LSMinimumSystemVersion` (Ventura).

Homepage: https://tatamio.app
