### PR TITLE
ankerwork: skip autobump

### DIFF
--- a/Casks/a/ankerwork.rb
+++ b/Casks/a/ankerwork.rb
@@ -10,10 +10,15 @@ cask "ankerwork" do
   desc "Webcam & audio device software"
   homepage "https://us.ankerwork.com/pages/download-software"
 
+  # The homepage can return a 429 (Too many requests) response based on IP
+  # address when fetched outside of a browser. This happens in the autobump
+  # and CI environments, so we have to skip it in those instances for now.
   livecheck do
     url :homepage
     regex(/For\s+Mac.*?>\s*V?(\d+(?:\.\d+)+)\s*</im)
   end
+
+  no_autobump! because: "Livecheck is unreachable in autobump environment"
 
   depends_on :macos
 

--- a/Casks/a/ankerwork.rb
+++ b/Casks/a/ankerwork.rb
@@ -4,8 +4,8 @@ cask "ankerwork" do
   version "3.0.4"
   sha256 :no_check
 
-  url "https://ankerwork.s3.amazonaws.com/electron/AnkerWork-Setup-#{arch}.dmg",
-      verified: "ankerwork.s3.amazonaws.com/electron/"
+  url "https://ankerwork.s3.us-west-2.amazonaws.com/electron/AnkerWork-Setup-#{arch}.dmg",
+      verified: "ankerwork.s3.us-west-2.amazonaws.com/electron/"
   name "AnkerWork"
   desc "Webcam & audio device software"
   homepage "https://us.ankerwork.com/pages/download-software"

--- a/Casks/a/ankerwork.rb
+++ b/Casks/a/ankerwork.rb
@@ -4,8 +4,8 @@ cask "ankerwork" do
   version "3.0.4"
   sha256 :no_check
 
-  url "https://ankerwork.s3.us-west-2.amazonaws.com/electron/AnkerWork-Setup-#{arch}.dmg",
-      verified: "ankerwork.s3.us-west-2.amazonaws.com/electron/"
+  url "https://ankerwork.s3.amazonaws.com/electron/AnkerWork-Setup-#{arch}.dmg",
+      verified: "ankerwork.s3.amazonaws.com/electron/"
   name "AnkerWork"
   desc "Webcam & audio device software"
   homepage "https://us.ankerwork.com/pages/download-software"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

-----

Fixes the livecheck error reported by autobump:

```sh
==> ankerwork
Current cask version:     3.0.4
Latest livecheck version: unable to get versions
```

Reference:
- https://github.com/Homebrew/homebrew-cask/actions/runs/30422456059/job/90481871446