### PR TITLE
fujitsu-scansnap-home 4.0.0 (fix livecheck)

### DIFF
--- a/Casks/f/fujitsu-scansnap-home.rb
+++ b/Casks/f/fujitsu-scansnap-home.rb
@@ -1,6 +1,6 @@
 cask "fujitsu-scansnap-home" do
-  version "3.7.0"
-  sha256 "346a10e3095fd68fc32abbfcb5dfe8fe8a41e04ab1044c3ac149f2154f87a400"
+  version "4.0.0"
+  sha256 "02a42ef28f902a7c1fb87555572bf3694180a4f8f9ca5d55ee1a515bd50af61f"
 
   url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg",
       verified: "origin.pfultd.com/"

--- a/Casks/f/fujitsu-scansnap-home.rb
+++ b/Casks/f/fujitsu-scansnap-home.rb
@@ -9,11 +9,8 @@ cask "fujitsu-scansnap-home" do
   homepage "https://www.fujitsu.com/global/products/computing/peripheral/scanners/soho/sshome/"
 
   livecheck do
-    url "https://www.pfu.ricoh.com/global/scanners/scansnap/dl/mac-sshoffline.html"
-    regex(/m-sshoffline[._-]v?(\d+(?:[._]\d+)+)\.html/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match[0].tr("_", ".") }
-    end
+    url "https://www.pfu.ricoh.com/imaging/ss_hist/en/mac/index.html"
+    regex(/ScanSnap\s+Home\s+for\s+Mac\s+v?(\d+(?:\.\d+)+)\s+Released/i)
   end
 
   auto_updates true


### PR DESCRIPTION
The previous livecheck page (`global/scanners/scansnap/dl/mac-sshoffline.html`) now redirects (meta refresh) to a JavaScript-rendered page with no version information, so livecheck has been silently returning no matches and autobump stopped picking up new versions — the cask was stuck at 3.7.0 while the latest release is 4.0.0 (2026-07-14).

This PR:
- switches livecheck to the [Mac update history page](https://www.pfu.ricoh.com/imaging/ss_hist/en/mac/index.html), which lists releases as "ScanSnap Home for Mac X.Y.Z Released" in static HTML (`brew livecheck --autobump` now reports `3.7.0 ==> 4.0.0`)
- bumps the cask to 4.0.0 (verified: download URL template unchanged, nested container `Download/MacSSHomeInstaller_4_0_0.dmg` and `ScanSnap Home.pkg` names unchanged by mounting the DMG)

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths*.

AI (Claude Code) was used to diagnose the broken livecheck and author the change. Manual verification performed on macOS (arm64): fetched the old livecheck URL and confirmed it is now a meta-refresh redirect to a JS-only page; ran `brew livecheck --cask fujitsu-scansnap-home --autobump` → `3.7.0 ==> 4.0.0`; downloaded `MacSSHOfflineInstaller_4_0_0.dmg` (HTTP 200) and computed its sha256; mounted the outer and nested DMGs to confirm `Download/MacSSHomeInstaller_4_0_0.dmg` and `ScanSnap Home.pkg` paths are unchanged; ran `brew audit --cask --online` (error-free) and `brew style` (no offenses). The `zap` stanza is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aYhwi4PPBTvHwxZRDfQMa