### PR TITLE
fujitsu-scansnap-home 4.0.0

### DIFF
--- a/Casks/f/fujitsu-scansnap-home.rb
+++ b/Casks/f/fujitsu-scansnap-home.rb
@@ -1,6 +1,6 @@
 cask "fujitsu-scansnap-home" do
-  version "3.7.0"
-  sha256 "346a10e3095fd68fc32abbfcb5dfe8fe8a41e04ab1044c3ac149f2154f87a400"
+  version "4.0.0"
+  sha256 "02a42ef28f902a7c1fb87555572bf3694180a4f8f9ca5d55ee1a515bd50af61f"
 
   url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg",
       verified: "origin.pfultd.com/"
@@ -9,8 +9,8 @@ cask "fujitsu-scansnap-home" do
   homepage "https://www.fujitsu.com/global/products/computing/peripheral/scanners/soho/sshome/"
 
   livecheck do
-    url "https://www.pfu.ricoh.com/global/scanners/scansnap/dl/mac-sshoffline.html"
-    regex(/m-sshoffline[._-]v?(\d+(?:[._]\d+)+)\.html/i)
+    url "https://www.pfu.ricoh.com/imaging/ssacc/en/sshoffline.html"
+    regex(/MacSSHOfflineInstaller[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match[0].tr("_", ".") }
     end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`fujitsu-scansnap-home` is autobumped but the workflow failed to update to version 4.0.0 because the `livecheck` block produces an "Unable to get versions error". The `livecheck` block URL redirects to the main ScanSnap download page, which links to the download page for the offline installer instead of providing links to the installer files itself, so the check fails. This updates the version and brings the `livecheck` block up to date.