### PR TITLE
neon-vision-editor: update 1.1.0

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -22,4 +22,4 @@ cask "neon-vision-editor" do
     "~/Library/Logs/NeonVisionEditorUpdater.log",
     "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
   ]
-end\n
+end

--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,6 +1,6 @@
 cask "neon-vision-editor" do
-  version "1.0.2"
-  sha256 "54a0efdebf36587881098cd8be21b597d7bbb6694e9e55d46a8fc28237882f8e"
+  version "1.1.0"
+  sha256 "70ab821f3694b9542b2be51b231ce157411a59d3b009f793c5acef31a82b1e44"
 
   url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
   name "Neon Vision Editor"

--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -22,4 +22,4 @@ cask "neon-vision-editor" do
     "~/Library/Logs/NeonVisionEditorUpdater.log",
     "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
   ]
-end
+end\n


### PR DESCRIPTION
## Summary
- update the existing `neon-vision-editor` cask to 1.1.0
- update the checksum to match the verified v1.1.0 release ZIP

The upstream v1.1.0 release asset and SHA-256 were verified before opening this PR.