### PR TITLE
cmtrace-open 1.5.0 (new cask)

### DIFF
--- a/Casks/c/cmtrace-open.rb
+++ b/Casks/c/cmtrace-open.rb
@@ -1,0 +1,28 @@
+cask "cmtrace-open" do
+  version "1.5.0"
+  sha256 "f84eda748efa13087ed4283ff69e4080898388f02702917592c0582e3f3ecb04"
+
+  url "https://github.com/adamgell/cmtraceopen/releases/download/v#{version}/CMTrace.Open_#{version}_aarch64.dmg",
+      verified: "github.com/adamgell/cmtraceopen/"
+  name "CMTrace Open"
+  name "CMTrace"
+  desc "Log viewer for ConfigMgr, Intune, and Windows diagnostic logs"
+  homepage "https://cmtraceopen.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on arch: :arm64
+  depends_on :macos
+
+  app "CMTrace Open.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.cmtrace.open",
+    "~/Library/Logs/com.cmtrace.open",
+    "~/Library/Preferences/com.cmtrace.open.plist",
+    "~/Library/WebKit/com.cmtrace.open",
+  ]
+end

--- a/Casks/c/cmtrace-open.rb
+++ b/Casks/c/cmtrace-open.rb
@@ -5,7 +5,6 @@ cask "cmtrace-open" do
   url "https://github.com/adamgell/cmtraceopen/releases/download/v#{version}/CMTrace.Open_#{version}_aarch64.dmg",
       verified: "github.com/adamgell/cmtraceopen/"
   name "CMTrace Open"
-  name "CMTrace"
   desc "Log viewer for ConfigMgr, Intune, and Windows diagnostic logs"
   homepage "https://cmtraceopen.com/"
 
@@ -21,6 +20,7 @@ cask "cmtrace-open" do
 
   zap trash: [
     "~/Library/Application Support/com.cmtrace.open",
+    "~/Library/Caches/com.cmtrace.open",
     "~/Library/Logs/com.cmtrace.open",
     "~/Library/Preferences/com.cmtrace.open.plist",
     "~/Library/WebKit/com.cmtrace.open",


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: this cask was drafted with Claude (Anthropic, Opus). Every claim below was verified by running the named command against the real artifact rather than accepted from the model.

The `zap` stanza specifically was reviewed rather than generated. Its four paths were enumerated on a machine that had actually installed and run the release build, then confirmed by running `brew uninstall --zap --cask`, which trashed exactly those four paths and nothing else. `~/Library/Caches`, `~/Library/HTTPStorages`, and `~/Library/Saved Application State` are deliberately absent because this app does not create them; they were not included on convention. The bundle identifier `com.cmtrace.open` was read from the shipped `Info.plist` and cross-checked against the project's `tauri.conf.json`.

Command results: `brew audit --cask --online` exit 0, no offenses. `brew audit --cask --new` exit 0, no offenses. `brew style --fix` reports no offenses and changed nothing. `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask` exit 0. `brew uninstall --cask` exit 0, leaving user data intact. `brew livecheck` resolves 1.5.0. The `sha256` matches the digest GitHub reports for the release asset.

-----

### About the cask

[CMTrace Open](https://cmtraceopen.com) is a free, open-source log viewer and troubleshooting tool. Repository: https://github.com/adamgell/cmtraceopen (MIT, 237 stars).

The project is best known for replacing Microsoft's Windows-only CMTrace.exe, so the macOS relevance is worth stating: the app ships a macOS Diagnostics workspace covering Intune, Microsoft Defender, configuration profile, and package diagnostics, and the viewer reads logs collected from any platform.

**Apple Silicon only.** Upstream publishes a single `aarch64` DMG containing an arm64-thin binary, verified with `codesign -dv --verbose=4` reporting `Mach-O thin (arm64)`. There is no x86_64 or universal artifact, so the cask declares `depends_on arch: :arm64` and Homebrew refuses on Intel rather than failing later.

`livecheck` uses `strategy :github_latest` deliberately: the repository also publishes a rolling `nightly` tag as a prerelease, which `releases/latest` correctly excludes.

The app is signed and notarized: `spctl -a -t install` reports `source=Notarized Developer ID` and `xcrun stapler validate` passes.
