### PR TITLE
unity-hub@beta 3.20.0 (new cask)

### DIFF
--- a/Casks/u/unity-hub@beta.rb
+++ b/Casks/u/unity-hub@beta.rb
@@ -1,0 +1,44 @@
+cask "unity-hub@beta" do
+  arch arm: "arm64", intel: on_system_conditional(macos: "x64", linux: "x86_64")
+  url_end = on_system_conditional macos: "dmg", linux: "AppImage"
+
+  version "3.20.0"
+  sha256 arm:          "49bb701e48ac7aa02f352348fb6e0aae20f808730ee8f4c371b3c3494c6232d9",
+         intel:        "f74aa268470f9cc2a97b5aae1ebd2ded05ecbe37689d982c3f01a45d6caa9999",
+         x86_64_linux: "af1eda02fa1a036e478df0b68c2ef684d6734304b40f6b6e44e73dc42ad76d21"
+
+  on_macos do
+    depends_on macos: :monterey
+
+    app "Unity Hub.app"
+
+    uninstall quit: "com.unity3d.unityhub"
+
+    zap trash: [
+          "~/Library/Application Support/UnityHub",
+          "~/Library/Preferences/com.unity3d.unityhub.helper.plist",
+          "~/Library/Preferences/com.unity3d.unityhub.plist",
+        ],
+        rmdir: "/Applications/Unity/Hub"
+  end
+  on_linux do
+    depends_on arch: :x86_64
+
+    app_image "UnityHubSetup-#{version}-#{arch}.AppImage", target: "Unity Hub.AppImage"
+
+    zap trash: "~/.config/unityhub"
+  end
+
+  url "https://public-cdn.cloud.unity3d.com/hub/prod/#{version}/UnityHubSetup-#{version}-#{arch}.#{url_end}"
+  name "Unity Hub"
+  desc "Management tool for Unity"
+  homepage "https://docs.unity.com/en-us/hub"
+
+  livecheck do
+    url "https://public-cdn.cloud.unity3d.com/hub/prod/beta-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  conflicts_with cask: "unity-hub"
+end


### PR DESCRIPTION
Adds a beta-channel cask for Unity Hub (macOS DMGs + Linux x86_64 AppImage), tracking Unity's official beta update feed. Unity (my employer — I work on the Hub's release pipeline) publishes versioned per-arch artifacts and an electron-builder-format `beta-mac.yml` channel feed on the same CDN the existing `unity-hub` cask uses, so the livecheck mirrors the main cask with the beta feed URL. The beta channel currently points at 3.20.0 (the stable release was rolled forward to it, by design); it diverges when the next beta ships.

`conflicts_with cask: "unity-hub"` since both install the same `Unity Hub.app` / bundle id.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version). (Beta-channel cask; upstream maintains this channel permanently, per the `@beta` cask convention.)
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully. (Default-path install on arm64 macOS: app staged to /Applications, `codesign --verify --deep --strict` passes, Gatekeeper `accepted, source=Notarized Developer ID`, app launches. `conflicts_with cask: "unity-hub"` also verified — install is correctly blocked while `unity-hub` is registered.)
- [x] `brew uninstall --cask <cask>` worked successfully. (Run while the app was open: the `uninstall quit:` stanza quit it cleanly, app removed, cask unregistered. `zap` not exercised — this machine's real Unity Hub profile lives in those paths.)

Linux `app_image` install/uninstall is exercised by the `ubuntu-latest` CI cell (green).

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: drafted with Claude Code (Anthropic, Claude Fable 5 model). I reviewed the output; the zap stanza is copied from the existing `unity-hub` cask, which I help maintain upstream (the paths are the Hub's real profile/preferences locations). Hashes were computed directly from the published CDN artifacts and verified by `brew audit --online` and the local install.

-----