### PR TITLE
paraview: do not livecheck RC versions and downgrade to 6.1.1

### DIFF
--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -2,12 +2,12 @@ cask "paraview" do
   arch arm: "arm64", intel: "x86_64"
 
   on_arm do
-    version "6.2.0,RC1-MPI-OSX11.0-Python3.12"
-    sha256 "bfe448296cb326b69a3d881d2904c55a8d3fbad4ccac75c4daefd9dc1f5216a5"
+    version "6.1.1,MPI-OSX11.0-Python3.12"
+    sha256 "d6066631ed3dbd5bc237f611bc3fae13bfef3f15229e8e5b993716ab4a19ec30"
   end
   on_intel do
-    version "6.2.0,RC1-MPI-OSX10.15-Python3.12"
-    sha256 "dfb98aa594ecde6e61126bd5322a73290804b15fae628bbc2f3f58d0c17fcf33"
+    version "6.1.1,MPI-OSX10.15-Python3.12"
+    sha256 "8c4db0916fed24dc0dab3a4e765c156b8fb24dcd76ff98bbd459c7689fb8ef8b"
   end
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.csv.first.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}-#{arch}.dmg",
@@ -20,16 +20,18 @@ cask "paraview" do
     url "https://www.paraview.org/files/listing.txt"
     regex(%r{/v?(?:\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:[.-]\d+)+)(?:[._-](.*?))?[._-](?:#{arch}|universal)\.dmg}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      page.scan(regex).filter_map do |version, suffix|
+        next if suffix.to_s.match?(/\ARC\d+(?:[._-]|\z)/i)
+
+        suffix.present? ? "#{version},#{suffix}" : version
       end
     end
   end
 
   depends_on macos: :big_sur
 
-  app "ParaView-#{version.csv.first}-#{version.csv.second.split("-").first}.app"
-  binary "#{appdir}/ParaView-#{version.csv.first}-#{version.csv.second.split("-").first}.app/Contents/MacOS/paraview"
+  app "ParaView-#{version.csv.first}.app"
+  binary "#{appdir}/ParaView-#{version.csv.first}.app/Contents/MacOS/paraview"
 
   zap trash: [
     "~/.config/ParaView",

--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -20,10 +20,10 @@ cask "paraview" do
     url "https://www.paraview.org/files/listing.txt"
     regex(%r{/v?(?:\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:[.-]\d+)+)(?:[._-](.*?))?[._-](?:#{arch}|universal)\.dmg}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).filter_map do |version, suffix|
-        next if suffix.to_s.match?(/\ARC\d+(?:[._-]|\z)/i)
+      page.scan(regex).filter_map do |match|
+        next if match[1]&.match?(/^RC/i)
 
-        suffix.present? ? "#{version},#{suffix}" : version
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
       end
     end
   end


### PR DESCRIPTION
Currently, the `paraview` cask updates to release candidate versions in addition to stable versions, and the current version is 6.2.0 RC1 instead of 6.1.1 stable. Since most users likely expect the stable version, this PR prevents the cask from updating to unstable RC versions, and reverts back to 6.1.1.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Assisted by GPT-5.6 Sol in Codex, manually verified.

-----
