### PR TITLE
agentmicro 0.1.2 (new cask)

### DIFF
--- a/Casks/a/agentmicro.rb
+++ b/Casks/a/agentmicro.rb
@@ -1,0 +1,24 @@
+cask "agentmicro" do
+  version "0.1.2"
+  sha256 "f9fbf1e480b07165821b6d707f421b5d80a097a1ba9d2478de0179a271d3820f"
+
+  url "https://github.com/fizzy718/AgentMicro/releases/download/v#{version}/AgentMicro-macos-universal-#{version}.dmg",
+      verified: "github.com/fizzy718/AgentMicro/"
+  name "AgentMicro"
+  desc "Menu bar companion for Codex task status"
+  homepage "https://github.com/fizzy718/AgentMicro"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "AgentMicro.app"
+
+  uninstall quit: "com.agentmicro.macos"
+
+  zap trash: "~/Library/Preferences/com.agentmicro.macos.plist"
+end


### PR DESCRIPTION
-----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

GPT-5 Codex assisted in drafting the Cask. I reviewed the resulting Cask and its zap path, confirmed the current signed release's SHA-256 from the maintainer's GitHub Release, and validated a no-API Homebrew Cask install and uninstall. The two audit commands are not checked because this machine's globally selected Xcode 26 is below Homebrew's current Xcode 27 requirement; Homebrew's CI should run those audits in its supported environment.

-----
