### PR TITLE
neon-vision-editor closed

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,0 +1,25 @@
+cask "neon-vision-editor" do
+  version "1.1.1"
+  sha256 "085a4ca59da0d11f8503ee7e82dec59e940ccaae348c69b9db8fb7d026a39f98"
+
+  url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
+  name "Neon Vision Editor"
+  desc "Native code and text editor"
+  homepage "https://github.com/h3pdesign/Neon-Vision-Editor"
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Neon Vision Editor.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/group.h3p.Neon-Vision-Editor",
+    "~/Library/Application Scripts/h3p.Neon-Vision-Editor*",
+    "~/Library/Application Support/NeonVisionEditor",
+    "~/Library/Caches/h3p.Neon-Vision-Editor",
+    "~/Library/Containers/h3p.Neon-Vision-Editor",
+    "~/Library/Group Containers/group.h3p.Neon-Vision-Editor",
+    "~/Library/Logs/NeonVisionEditorUpdater.log",
+    "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
+  ]
+end


### PR DESCRIPTION
Update Neon Vision Editor to 1.1.1.

Release: https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.1.1

The published ZIP digest matches the cask SHA256.