### PR TITLE
openlogi: add CLI binary

### DIFF
--- a/Casks/o/openlogi.rb
+++ b/Casks/o/openlogi.rb
@@ -19,6 +19,7 @@ cask "openlogi" do
   depends_on macos: :ventura
 
   app "OpenLogi.app"
+  binary "#{appdir}/OpenLogi.app/Contents/MacOS/openlogi"
 
   zap trash: [
     "~/.config/openlogi",


### PR DESCRIPTION
Built and tested locally on macOS 26.5.2.

Links the CLI bundled at `OpenLogi.app/Contents/MacOS/openlogi` into the Homebrew prefix. The upstream bundle has shipped the signed CLI at this path since [AprilNEA/OpenLogi#362](https://github.com/AprilNEA/OpenLogi/pull/362).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online openlogi` is error-free.
- [x] `brew style --fix openlogi` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

OpenAI Codex was used to research the Cask `binary` stanza and assist with the one-line change. The diff was reviewed, and the modified Cask was audited, style-checked, installed, executed, and uninstalled locally.

-----
