### PR TITLE
phosphene 1.2.2 (new cask)

### DIFF
--- a/Casks/p/phosphene.rb
+++ b/Casks/p/phosphene.rb
@@ -1,0 +1,26 @@
+cask "phosphene" do
+  version "1.2.2"
+  sha256 "4bb51500afd3336a59c4463421ce06a9dce23dfaf4cdd23d52fee8f89c0b890e"
+
+  url "https://github.com/kageroumado/phosphene/releases/download/v#{version}/Phosphene-#{version}.dmg",
+      verified: "github.com/kageroumado/phosphene/"
+  name "Phosphene"
+  desc "Custom video wallpapers for the desktop and lock screen"
+  homepage "https://kagerou.glass/phosphene/"
+
+  depends_on macos: :tahoe
+
+  app "Phosphene.app"
+
+  uninstall quit: "glass.kagerou.phosphene"
+
+  zap trash: [
+    "~/Library/Application Scripts/glass.kagerou.phosphene.extension",
+    "~/Library/Caches/glass.kagerou.phosphene",
+    "~/Library/Containers/glass.kagerou.phosphene.extension",
+    "~/Library/Containers/glass.kagerou.phosphene.wallpaper-extension",
+    "~/Library/HTTPStorages/glass.kagerou.phosphene",
+    "~/Library/Preferences/glass.kagerou.phosphene.plist",
+    "~/Library/Saved Application State/glass.kagerou.phosphene.savedState",
+  ]
+end


### PR DESCRIPTION
[Phosphene](https://kagerou.glass/phosphene/) is an open-source (MIT) macOS utility for custom video wallpapers — any video, on the desktop and the lock screen, picked directly from System Settings' Wallpaper pane. Releases are signed, notarized DMGs published on [GitHub releases](https://github.com/kageroumado/phosphene/releases).

This is a self-submission by the app's author: the repository is at **782 stars / 22 forks**, above the 225-star self-submission notability threshold. The app requires macOS 26 (Tahoe) and works on both macOS 26 and the macOS 27 beta.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

**AI disclosure:** this cask was prepared with Claude Code (model `claude-fable-5`). Every checklist command above was actually executed locally (`brew audit --cask --new --online phosphene`, `brew style`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask phosphene` into a test appdir, `brew uninstall --cask phosphene`), and the `zap` paths were verified against a real installation's on-disk footprint rather than guessed. I'm the app's author, I reviewed the cask file, and I'll answer review comments myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvjW3E74XZBo7n8UumpdGC
