### PR TITLE
liquibase-secure 5.2.1

### DIFF
--- a/Casks/l/liquibase-secure.rb
+++ b/Casks/l/liquibase-secure.rb
@@ -1,6 +1,6 @@
 cask "liquibase-secure" do
-  version "5.2.2"
-  sha256 "1011480ad09f2bcb375769472894ca2fbf0f8f2c7becf1316e68ed8af1b501be"
+  version "5.2.1"
+  sha256 "838776e4656de1c6a9d4817ba47f7e6f96c23b76b5a8964298d99a14c376106d"
 
   url "https://package.liquibase.com/downloads/secure/homebrew/liquibase-secure-#{version}.tar.gz"
   name "Liquibase Secure"


### PR DESCRIPTION
Reverts the cask to 5.2.1, undoing the autobump to 5.2.2 in d3f24fd.

**Why a downgrade:** 5.2.2 was an accidental, non-GA release that Liquibase has retracted. Every other distribution channel (Docker Hub, GHCR, ECR Public, apt/yum, direct downloads) has already been rolled back to 5.2.1, and the 5.2.2 artifact was removed from the download host. As a result the cask at HEAD is currently **broken** — `https://package.liquibase.com/downloads/secure/homebrew/liquibase-secure-5.2.2.tar.gz` returns 404, so `brew install --cask liquibase-secure` fails for everyone. This PR restores the exact version/sha256 pair previously shipped in 30bcd24 ("liquibase-secure 5.2.1").

The livecheck source (`https://repo.liquibase.com/releases/secure/`) now lists 5.2.1 as the latest version again, so autobump will not re-bump this to 5.2.2.

I work at Liquibase (same org as @jandroav, who originally added this cask) and am submitting this on behalf of upstream.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: this PR was prepared with Claude Code (Claude Fable 5). I reviewed the two-line diff, independently verified the sha256 of the 5.2.1 tarball (`shasum -a 256` matches `838776e4…`), and ran `brew style` and `brew audit --cask --online` locally (both clean). I will answer review comments myself.

-----
