### PR TITLE
wezterm@nightly: use rename instead of preflight

### DIFF
--- a/Casks/w/wezterm@nightly.rb
+++ b/Casks/w/wezterm@nightly.rb
@@ -9,7 +9,10 @@ cask "wezterm@nightly" do
   homepage "https://wezterm.org/"
 
   conflicts_with cask: "wezterm"
-  depends_on :macos
+  depends_on macos: :big_sur
+
+  # Move "WezTerm-macos-<date>/WezTerm.app" out of the subfolder
+  rename "WezTerm-*/WezTerm.app", "WezTerm.app"
 
   app "WezTerm.app"
   %w[
@@ -24,12 +27,6 @@ cask "wezterm@nightly" do
   bash_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/bash", target: "wezterm"
   fish_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish", target: "wezterm.fish"
   zsh_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh", target: "_wezterm"
-
-  preflight_steps do
-    # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder
-    move "{WezTerm-*,wezterm-*}/WezTerm.app", ".", source_glob: true
-    remove ["WezTerm-*", "wezterm-*"], recursive: true
-  end
 
   zap trash: "~/Library/Saved Application State/com.github.wez.wezterm.savedState"
 end


### PR DESCRIPTION
Alternative to https://github.com/Homebrew/homebrew-cask/pull/276451 that uses the more modern `rename` stanza, allowing better testing on CI for this cask.

Closes #276451 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
