### PR TITLE
android-platform-tools: update sha256

### DIFF
--- a/Casks/a/android-platform-tools.rb
+++ b/Casks/a/android-platform-tools.rb
@@ -2,8 +2,8 @@ cask "android-platform-tools" do
   os macos: "darwin", linux: "linux"
 
   version "37.0.1"
-  sha256 arm:          "7d009f4fb1a70ecaa52937ef4d68f5180c9578e9502fb985f000b50e01b4c9e2",
-         x86_64:       "7d009f4fb1a70ecaa52937ef4d68f5180c9578e9502fb985f000b50e01b4c9e2",
+  sha256 arm:          "ee39ad5967e95c2a07f04dbcbde96b1a0c916ba376096db5d2f498b7727a5d1d",
+         x86_64:       "ee39ad5967e95c2a07f04dbcbde96b1a0c916ba376096db5d2f498b7727a5d1d",
          x86_64_linux: "d230f13842f60f782a8645f9c813f8f845bf36089ea7289f28c48f17979313f1",
          arm64_linux:  "d230f13842f60f782a8645f9c813f8f845bf36089ea7289f28c48f17979313f1"
 


### PR DESCRIPTION
Google republished `platform-tools_r37.0.1-darwin.zip` with different content, so the current macOS sha256 no longer matches and `brew install`/`brew upgrade` fail with a SHA-256 mismatch.

Verified by downloading directly from https://dl.google.com/android/repository/platform-tools_r37.0.1-darwin.zip (multiple times, consistent result):

- old sha256: `7d009f4fb1a70ecaa52937ef4d68f5180c9578e9502fb985f000b50e01b4c9e2`
- new sha256: `ee39ad5967e95c2a07f04dbcbde96b1a0c916ba376096db5d2f498b7727a5d1d`

The archive contains a genuine adb `37.0.1-15733141`. The Linux zip is unchanged (`d230f13842f60f782a8645f9c813f8f845bf36089ea7289f28c48f17979313f1` still matches), so only the `arm` and `x86_64` macOS hashes are updated.

Same situation as #259536, where the artifact was republished under the same version.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] The changes to the cask were tested locally with `brew install --cask <cask>` (macOS arm64).