### PR TITLE
Add earthbackground cask

### DIFF
--- a/Casks/e/earthbackground.rb
+++ b/Casks/e/earthbackground.rb
@@ -1,0 +1,26 @@
+cask "earthbackground" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.5.8"
+  sha256 arm: "f10e827011fab207e7d3315b3d6b4d3eb581f5e5ad717563c4e3638b887d7cb1",
+         intel: "a5c694cb484c6113a140683af88918db48a7b56a21c00213ad68870e56a87800"
+
+  url "https://github.com/LGinC/EarthBackground/releases/download/v2.5.8/EarthBackground-#{version}-osx-#{arch}-brew.zip"
+  name "EarthBackground"
+  desc "Satellite earth wallpaper application built with .NET and Avalonia"
+  homepage "https://github.com/LGinC/EarthBackground"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "EarthBackground.app"
+
+  zap trash: [
+    "~/Library/Preferences/io.github.lginc.earthbackground.plist",
+    "~/Library/Saved Application State/io.github.lginc.earthbackground.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary

Add `earthbackground` cask.

## What this PR adds

- New cask: `earthbackground`
- Apple Silicon asset: https://github.com/LGinC/EarthBackground/releases/download/v2.5.8/EarthBackground-2.5.8-osx-arm64-brew.zip
- Apple Silicon SHA256: f10e827011fab207e7d3315b3d6b4d3eb581f5e5ad717563c4e3638b887d7cb1
- Intel asset: https://github.com/LGinC/EarthBackground/releases/download/v2.5.8/EarthBackground-2.5.8-osx-x64-brew.zip
- Intel SHA256: a5c694cb484c6113a140683af88918db48a7b56a21c00213ad68870e56a87800

## Local verification

- [ ] `brew install --cask ./Casks/e/earthbackground.rb`
- [ ] App launches successfully
- [ ] `brew audit --cask --online earthbackground`

## Notes

- App bundles are distributed as architecture-specific zips containing `EarthBackground.app`.
- `depends_on macos: ">= :big_sur"` is derived from the app bundle minimum system version.
- `zap` paths are a minimal set inferred from `io.github.lginc.earthbackground` and should be rechecked on a real macOS install.
