### PR TITLE
android-platform-tools: update darwin sha256 for 37.0.1

### DIFF
--- a/Casks/a/android-platform-tools.rb
+++ b/Casks/a/android-platform-tools.rb
@@ -2,8 +2,8 @@ cask "android-platform-tools" do
   os macos: "darwin", linux: "linux"
 
   version "37.0.1"
-  sha256 arm:          "7d009f4fb1a70ecaa52937ef4d68f5180c9578e9502fb985f000b50e01b4c9e2",
-         x86_64:       "7d009f4fb1a70ecaa52937ef4d68f5180c9578e9502fb985f000b50e01b4c9e2",
+  sha256 arm:          "ee39ad5967e95c2a07f04dbcbde96b1a0c916ba376096db5d2f498b7727a5d1d",
+         x86_64:       "ee39ad5967e95c2a07f04dbcbde96b1a0c916ba376096db5d2f498b7727a5d1d",
          x86_64_linux: "d230f13842f60f782a8645f9c813f8f845bf36089ea7289f28c48f17979313f1",
          arm64_linux:  "d230f13842f60f782a8645f9c813f8f845bf36089ea7289f28c48f17979313f1"
 


### PR DESCRIPTION
## Description
`brew fetch --cask android-platform-tools` fails with SHA-256 mismatch.

Google re-uploaded `platform-tools_r37.0.1-darwin.zip` (zip entries dated 2026-07-29) without bumping the version string. Autobump only opens PRs on version changes, so darwin hashes stayed stale.

- **Expected (cask):** `7d009f4fb1a70ecaa52937ef4d68f5180c9578e9502fb985f000b50e01b4c9e2`
- **Actual download:** `ee39ad5967e95c2a07f04dbcbde96b1a0c916ba376096db5d2f498b7727a5d1d`

Updated `arm` and `x86_64` (shared `darwin` zip). Linux hashes unchanged.

## Checklist
- [x] Verified sha256 of https://dl.google.com/android/repository/platform-tools_r37.0.1-darwin.zip