### PR TITLE
bazecor 1.9.2

### DIFF
--- a/Casks/b/bazecor.rb
+++ b/Casks/b/bazecor.rb
@@ -1,15 +1,15 @@
 cask "bazecor" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.9.1"
-  sha256 arm:   "02dc5530079844bb78927a688db21761b921d3e0440b64efa5e1f94355b86eec",
-         intel: "4723fb37dc19df62968c288fbdf42466db141b78325fa994892e23ab505763d1"
+  version "1.9.2"
+  sha256 arm:   "55699405c2e2572cacc48db2fe141a421b052b26b15ad5b9df3ba9be1ee9cad6",
+         intel: "2a9b1377b7be417c14d1499d2e152e467dbbc26e0339fac14ff6f0cfa4b011ac"
 
   url "https://github.com/Dygmalab/Bazecor/releases/download/v#{version}/Bazecor-#{version}-#{arch}.dmg",
       verified: "github.com/Dygmalab/Bazecor/"
   name "Bazecor"
   desc "Graphical configurator for Dygma Raise keyboards"
-  homepage "https://dygma.com/pages/programmable-split-keyboard"
+  homepage "https://github.com/Dygmalab/Bazecor"
 
   livecheck do
     url :url


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`bazecor` is autobumped but the workflow failed to update to version 1.9.2 because the homepage returns a 429 (Too many requests) response based on IP address, so `brew audit` fails in the autobump environment. This updates the version and switches the homepage to the GitHub repository, so autobump will work again for this cask.