### PR TITLE
degr 1.3 (new cask)

### DIFF
--- a/Casks/d/degr.rb
+++ b/Casks/d/degr.rb
@@ -1,0 +1,25 @@
+cask "degr" do
+  version "1.3"
+  sha256 "bf85de7ef5b5c2d0d809edd516741dbac3b35b4c7513195b3debdf54a45f8cf6"
+
+  url "https://degr.app/downloads/v#{version}/degr-mac.zip"
+  name "degr"
+  desc "Temperature and clock screensaver"
+  homepage "https://degr.app/"
+
+  livecheck do
+    url "https://degr.app/version.json"
+    strategy :json do |json|
+      json["mac"]
+    end
+  end
+
+  depends_on macos: :ventura
+
+  screen_saver "manual-install/degr.saver"
+
+  zap trash: [
+    "~/Library/Application Support/degr",
+    "~/Library/Preferences/app.degr.degr.plist",
+  ]
+end


### PR DESCRIPTION
degr is a free temperature and clock screensaver for macOS. It shows the current local temperature, or a clock, as large digits on a black background. Homepage: https://degr.app/

The download is served from the vendor domain and pinned to the release tag, so the `sha256` stays valid. `livecheck` reads the same version feed the app itself uses for its update notice.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

**AI disclosure:** this cask was drafted with Claude (Anthropic) acting on my instruction, and the verification commands above were run on my machine. I am the author of the application itself. I have left the checkbox above unticked until I have personally re-read the cask, because part of that item is a commitment about how I will handle review — I will confirm it in a comment rather than have it ticked on my behalf.

The `zap` paths were checked against what the app actually writes: `~/Library/Preferences/app.degr.degr.plist` is its `UserDefaults` suite (bundle identifier `app.degr.degr`), and `~/Library/Application Support/degr` holds only backups the optional manual installer makes of the macOS wallpaper store. Neither path is shared with any other software.

Verification performed:

- `brew audit --cask --online degr` — exit 0
- `brew audit --cask --new --online degr` — exit 0
- `brew style --fix --cask degr` — no offenses, file unchanged
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask degr` — installs `degr.saver` to `~/Library/Screen Savers`
- `brew uninstall --cask degr` — removes it cleanly
- `brew livecheck --cask degr` — resolves 1.3, matching the cask
- The installed screensaver reports version 1.3 and `spctl` verifies it as `Notarized Developer ID`
