### PR TITLE
exifcleaner: add Gatekeeper recovery caveats

### DIFF
--- a/Casks/e/exifcleaner.rb
+++ b/Casks/e/exifcleaner.rb
@@ -18,6 +18,15 @@ cask "exifcleaner" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
+  depends_on macos: :big_sur
+
+  app "ExifCleaner.app"
+
+  zap trash: [
+    "~/Library/Application Support/ExifCleaner",
+    "~/Library/Saved Application State/com.exifcleaner.savedState",
+  ]
+
   caveats <<~EOS
     ExifCleaner is unsigned. To open it on macOS 14 (Sonoma) and earlier,
     right-click (or Control-click) ExifCleaner, choose Open, then click Open
@@ -27,13 +36,4 @@ cask "exifcleaner" do
     macOS to block it. Then open System Settings > Privacy & Security and
     click Open Anyway next to the ExifCleaner message.
   EOS
-
-  depends_on macos: :big_sur
-
-  app "ExifCleaner.app"
-
-  zap trash: [
-    "~/Library/Application Support/ExifCleaner",
-    "~/Library/Saved Application State/com.exifcleaner.savedState",
-  ]
 end

--- a/Casks/e/exifcleaner.rb
+++ b/Casks/e/exifcleaner.rb
@@ -18,6 +18,16 @@ cask "exifcleaner" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
+  caveats <<~EOS
+    ExifCleaner is unsigned. To open it on macOS 14 (Sonoma) and earlier,
+    right-click (or Control-click) ExifCleaner, choose Open, then click Open
+    in the dialog.
+
+    On macOS 15 (Sequoia) and later, first double-click ExifCleaner and allow
+    macOS to block it. Then open System Settings > Privacy & Security and
+    click Open Anyway next to the ExifCleaner message.
+  EOS
+
   depends_on macos: :big_sur
 
   app "ExifCleaner.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online exifcleaner` is error-free.
- [x] `brew style --fix exifcleaner` reports no offenses.

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

-----

Codex/GPT assisted with preparing the caveat wording and contribution workflow. The one-file cask diff, including the existing `zap` stanza, was reviewed. `brew style --fix Casks/e/exifcleaner.rb` reported no offenses. An exact online audit of fork commit `298a15e2` passed from a temporary official-user tap path; the temporary detached worktree was removed after completion.

ExifCleaner is currently unsigned and retains `disable! date: "2026-09-01", because: :fails_gatekeeper_check`. This PR adds only bounded, version-specific Gatekeeper recovery instructions:

- macOS 14 and earlier: right-click or Control-click, then Open.
- macOS 15 and later: allow the first blocked launch, then use System Settings > Privacy & Security > Open Anyway.

No version, checksum, URL, dependency, or release behavior is changed.