### PR TITLE
replit 1.1.6

### DIFF
--- a/Casks/r/replit.rb
+++ b/Casks/r/replit.rb
@@ -1,18 +1,22 @@
 cask "replit" do
-  arch intel: "-Intel"
+  version "1.1.6"
+  sha256 :no_check
 
-  version "1.0.14"
-  sha256 arm:   "193c4282d69c0b49bc4d3780c4db102b2602bfb6d3f7cd7322957cde5ff6cb41",
-         intel: "4d2bbec2d40060f97b3140a8390ac2ae8baf7bb4e769783550748a5d599a7d6c"
-
-  url "https://github.com/replit/desktop/releases/download/v#{version}/Replit#{arch}.dmg",
-      verified: "github.com/replit/desktop/"
+  url "https://desktop.replit.com/download/mac"
   name "Replit"
   desc "Software development and deployment platform"
   homepage "https://replit.com/"
 
+  livecheck do
+    url "https://desktop.replit.com/latest"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
   auto_updates true
-  depends_on :macos
+  depends_on macos: :monterey
+  depends_on arch: :arm64
 
   app "Replit.app"
 


### PR DESCRIPTION
Follows up on [the automated report in #172732](https://github.com/Homebrew/homebrew-cask/issues/172732#issuecomment-5148889205),

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Used OpenAI Codex to investigate the upstream download and version metadata endpoints and to draft the `url` and 
`livecheck` changes.I reviewed the output and verified the changes by running the relevant `brew` commands and comparing the `livecheck` implementation with those of existing casks.

-----
