### PR TITLE
Add cask for Trader Workstation (Stable) version 10.45.1i

### DIFF
--- a/Casks/t/trader-workstation@stable.rb
+++ b/Casks/t/trader-workstation@stable.rb
@@ -1,0 +1,54 @@
+cask "trader-workstation@stable" do
+  arch arm: "-arm", intel: "x-x64"
+
+  version "10.45.1i"
+  sha256 :no_check
+
+  url "https://download2.interactivebrokers.com/installers/tws/stable/tws-stable-macos#{arch}.dmg"
+  name "Trader Workstation (Stable)"
+  desc "Trading software"
+  homepage "https://www.interactivebrokers.com/"
+
+  livecheck do
+    url "https://download2.interactivebrokers.com/installers/tws/stable/version.json"
+    regex(/callback\((.+)\)/i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      json = Homebrew::Livecheck::Strategy::Json.parse_json(match[1])
+      json["buildVersion"]
+    end
+  end
+
+  auto_updates true
+  depends_on :macos
+
+  installer script: {
+    executable: "#{staged_path}/Trader Workstation Installer.app/Contents/MacOS/JavaApplicationStub",
+    args:       [
+      "-dir", "#{appdir}/Trader Workstation",
+      "-q"
+    ],
+  }
+
+  uninstall_preflight_steps do
+    terminate_process "{{appdir}}/Trader Workstation/Trader Workstation.app",
+                      match: :full, must_succeed: false,
+                      notices: ["Stopping all running instances of Trader Workstation prior to uninstall"],
+                      failure_message: "No running instances of Trader Workstation found"
+  end
+
+  uninstall quit:   "com.install4j.5889-6375-8446-2021",
+            script: {
+              executable: "#{appdir}/Trader Workstation/Trader Workstation Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              args:       ["-q"],
+            }
+
+  zap trash: [
+    "#{appdir}/Trader Workstation",
+    "~/Applications/Trader Workstation",
+    "~/Jts",
+    "~/Library/Application Support/Trader Workstation",
+  ]
+end


### PR DESCRIPTION
Creating the ability to install the stable version of trader-workstation instead of the latest. IMO this should be the default, because a trading platform should be more focused on stability - not on the latest feature.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
