### PR TITLE
rockxy 0.32.0,49

### DIFF
--- a/Casks/r/rockxy.rb
+++ b/Casks/r/rockxy.rb
@@ -1,6 +1,6 @@
 cask "rockxy" do
-  version "0.31.0,48"
-  sha256 "a480fa9e0e62c8a95c00153df697851f678dbd4b4f0e821da01f8a0a11c0b4ff"
+  version "0.32.0,49"
+  sha256 "f9a1f88b1a52ab53ffc88541e74052bf528a6f5d6969559f7e945611200a9578"
 
   url "https://github.com/RockxyApp/Rockxy/releases/download/v#{version.csv.first}/Rockxy-#{version.tr(",", "-")}.dmg",
       verified: "github.com/RockxyApp/Rockxy/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

OpenAI Codex (GPT-5) was used to update the existing `rockxy` cask version and SHA and to run/review release verification commands. I manually verified the cask diff, version `0.32.0,49`, SHA-256, download URL, livecheck result, `HOMEBREW_NO_INSTALL_FROM_API=1 brew fetch --cask rockxy --force`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --dry-run --cask rockxy`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --cask --online rockxy`, and `brew style --fix rockxy`. The existing `zap` stanza paths were reviewed and left unchanged.

-----

Updates Rockxy to 0.32.0 build 49.

Release artifact:

- Download: https://github.com/RockxyApp/Rockxy/releases/download/v0.32.0/Rockxy-0.32.0-49.dmg
- SHA-256: f9a1f88b1a52ab53ffc88541e74052bf528a6f5d6969559f7e945611200a9578
- Notarized: true

Additional local checks run:

- `HOMEBREW_NO_INSTALL_FROM_API=1 brew fetch --cask rockxy --force`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --dry-run --cask rockxy`
- `brew lgtm --online`
