### PR TITLE
typora: update sha256

### DIFF
--- a/Casks/t/typora.rb
+++ b/Casks/t/typora.rb
@@ -1,6 +1,6 @@
 cask "typora" do
   version "1.14.8"
-  sha256 "048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527"
+  sha256 "5d55df98a4ec2aea2e82b05a79c2566ad3f883dddb974a7cc445336e37f8dfbe"
 
   url "https://downloads.typora.io/mac/Typora-#{version}.dmg"
   name "Typora"


### PR DESCRIPTION
The Typora vendor re-released the 1.14.8 dmg after #278333 was merged, so the declared sha256 no longer matches the artifact served at https://downloads.typora.io/mac/Typora-1.14.8.dmg. Fresh downloads from two independent machines on separate days are byte-identical and hash to `5d55df98a4ec2aea2e82b05a79c2566ad3f883dddb974a7cc445336e37f8dfbe`; the cask currently declares `048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527` and fails checksum verification on install. The re-released app bundle is signed and notarized (`spctl --assess` accepts it). This PR updates only the sha256 to match the currently served artifact.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: this PR was prepared with assistance from Claude (Anthropic). The change is a single sha256 line; I reviewed it and verified the new hash by downloading the artifact independently on two machines on separate days (byte-identical results). `brew audit --cask --online typora` (which re-downloads and verifies the artifact) and `brew style` were both run against the edited cask and pass clean. The zap stanza is untouched.

-----
