### PR TITLE
Add diskraptor

### DIFF
--- a/Casks/d/diskraptor.rb
+++ b/Casks/d/diskraptor.rb
@@ -1,0 +1,18 @@
+cask "diskraptor" do
+  version "1.0.9"
+  sha256 "d444aebdb1f68b5105332b6340406024b98752b821bf132e4c7fcb03604b70d7"
+
+  url "https://github.com/SunMe1977/DiskRaptor/releases/download/v#{version}/DiskRaptor-#{version}-macos.dmg"
+  name "DiskRaptor"
+  desc "Ultra-fast cross-platform disk space analyzer"
+  homepage "https://github.com/SunMe1977/DiskRaptor"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :monterey
+
+  app "DiskRaptor.app"
+end


### PR DESCRIPTION
Adds DiskRaptor v1.0.9, an ultra-fast cross-platform disk space analyzer (Rust + Qt).

- [x] The submission is for a stable version (tagged v1.0.9 release).
- [ ] `brew audit --cask --online diskraptor` is error-free.
- [x] `brew style diskraptor` reports no offenses.
- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [ ] `brew audit --cask --new diskraptor` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask diskraptor` worked successfully.
- [ ] `brew uninstall --cask diskraptor` worked successfully.

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output.

Note: `brew audit` currently reports two known blockers: the GitHub repository has low visibility (0 stars) and the binary is signed but not yet notarized (no Developer ID certificate available). Happy to revisit once those are resolved.