### PR TITLE
superduper 4.0.0

### DIFF
--- a/Casks/s/superduper.rb
+++ b/Casks/s/superduper.rb
@@ -17,6 +17,8 @@ cask "superduper" do
 
   app "SuperDuper!.app"
 
+  uninstall launchctl: "com.shirtpocket.SuperDuper4.menu"
+
   zap trash: [
     "~/Library/Application Support/CrashReporter/SuperDuper!_*.plist",
     "~/Library/Application Support/SuperDuper!",

--- a/Casks/s/superduper.rb
+++ b/Casks/s/superduper.rb
@@ -1,8 +1,8 @@
 cask "superduper" do
   version "4.0.0"
-  sha256 :no_check
+  sha256 "c7fdb821817869056cdc7adef1b11adc8deed01ccf2d666c0bc507239cdd8964"
 
-  url "https://www.shirt-pocket.com/downloads/SuperDuper.dmg"
+  url "https://www.shirt-pocket.com/downloads/SuperDuper-#{version}.dmg"
   name "SuperDuper!"
   desc "Backup, recovery and cloning software"
   homepage "https://www.shirt-pocket.com/superduper4.php"

--- a/Casks/s/superduper.rb
+++ b/Casks/s/superduper.rb
@@ -8,7 +8,7 @@ cask "superduper" do
   homepage "https://www.shirt-pocket.com/superduper4.php"
 
   livecheck do
-    url "https://www.shirt-pocket.com/SuperDuper4/appcast.xml"
+    url "https://www.shirt-pocket.com/SuperDuper#{version.major}/appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/s/superduper.rb
+++ b/Casks/s/superduper.rb
@@ -1,36 +1,29 @@
 cask "superduper" do
-  version "3.11,136"
+  version "4.0.0"
   sha256 :no_check
 
-  url "https://shirtpocket.s3.amazonaws.com/SuperDuper/SuperDuper!.dmg",
-      verified: "shirtpocket.s3.amazonaws.com/SuperDuper/"
+  url "https://www.shirt-pocket.com/downloads/SuperDuper.dmg"
   name "SuperDuper!"
   desc "Backup, recovery and cloning software"
-  homepage "https://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html"
+  homepage "https://www.shirt-pocket.com/superduper4.php"
 
   livecheck do
-    url "https://shirtpocket.s3.amazonaws.com/SuperDuper/superduperinfo.rtf"
-    regex(/v?(\d+(?:\.\d+)+)\s*\(v?(\d+)\)/i)
-    strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
+    url "https://www.shirt-pocket.com/SuperDuper4/appcast.xml"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true
-  depends_on :macos
+  depends_on macos: :sonoma
 
   app "SuperDuper!.app"
 
   zap trash: [
+    "~/Library/Application Support/CrashReporter/SuperDuper!_*.plist",
     "~/Library/Application Support/SuperDuper!",
-    "~/Library/Caches/com.blacey.SuperDuper",
-    "~/Library/Preferences/com.blacey.SuperDuper.plist",
-    "~/Library/Preferences/com.paradigmasoft.VStudio",
-    "~/Library/Preferences/com.paradigmasoft.vstudio.plist",
-    "~/Library/Saved Application State/com.blacey.SuperDuper.savedState",
-    "~/Library/Services/Run SuperDuper! Settings.workflow",
+    "~/Library/Caches/com.shirtpocket.SuperDuper4",
+    "~/Library/HTTPStorages/com.shirtpocket.SuperDuper4",
+    "~/Library/Preferences/com.shirtpocket.SuperDuper4.menu.plist",
+    "~/Library/Preferences/com.shirtpocket.SuperDuper4.plist",
+    "~/Library/Preferences/com.shirtpocket.SuperDuper4.shared.plist",
   ]
 end


### PR DESCRIPTION
SuperDuper 4 update moves to Sparkle, hence requiring a manual bump. Also locations of preferences, etc. have changed.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
