### PR TITLE
uu-booster 2.8.19

### DIFF
--- a/Casks/u/uu-booster.rb
+++ b/Casks/u/uu-booster.rb
@@ -1,18 +1,21 @@
 cask "uu-booster" do
-  version "2.8.14"
-  sha256 "7db0797d9499145404f25a7a27bfdc8f7defd5e6f230d3d7097a22298124cfda"
+  version "2.8.19"
+  sha256 "f722e97e3ba23b3b5e0420effb80365df6744b986517391e8971c3710f22470d"
 
-  url "https://uu.gdl.netease.com/UU-macOS-#{version}.dmg",
-      verified: "uu.gdl.netease.com/"
+  url "https://adl.netease.com/d/g/uu/c/gw?type=mac&direct=1",
+      verified: "adl.netease.com/d/g/uu/"
   name "UU Booster"
   desc "Network accelerator"
-  homepage "https://uu.163.com/down/mac/"
+  homepage "https://uu.163.com/download/"
 
   livecheck do
-    url "https://adl.netease.com/d/g/uu/c/uumac?type=pc"
-    regex(%r{pc_link.*?/UU[._-]macOS[._-]v?(\d+(?:\.\d+)+).dmg}i)
+    url "https://uu.163.com/json/download_info.json"
+    strategy :json do |json|
+      json.dig("mac", "version")
+    end
   end
 
+  auto_updates true
   depends_on :macos
 
   app "UUBooster.app"

--- a/Casks/u/uu-booster.rb
+++ b/Casks/u/uu-booster.rb
@@ -1,6 +1,6 @@
 cask "uu-booster" do
   version "2.8.19"
-  sha256 "f722e97e3ba23b3b5e0420effb80365df6744b986517391e8971c3710f22470d"
+  sha256 :no_check
 
   url "https://adl.netease.com/d/g/uu/c/gw?type=mac&direct=1",
       verified: "adl.netease.com/d/g/uu/"


### PR DESCRIPTION
## Problem

The cask still reported an outdated version because its previous livecheck source remained at 2.8.14, while NetEase's official macOS download metadata and the application itself report 2.8.19. The old versioned CDN URL also returns HTTP 403, causing `brew upgrade` to fail when Homebrew tries to fetch the artifact.

## Changes

- Update `uu-booster` to 2.8.19.
- Use NetEase's official download endpoint, which returns a valid signed redirect to the current macOS DMG.
- Use `sha256 :no_check`, as required by Homebrew for this unversioned dynamic download URL.
- Read the current version from NetEase's official JSON metadata.
- Declare `auto_updates true` because the application updates itself.
- Point the homepage to the official download page.

Validation completed successfully on macOS 27.0 with Command Line Tools 27.0 and Xcode 27.0:

- `brew audit --cask --online noahhhi/uu-booster-pr/uu-booster`
- `brew style --fix Casks/u/uu-booster.rb`
- `brew livecheck --cask noahhhi/uu-booster-pr/uu-booster`
- `brew readall noahhhi/uu-booster-pr`
- `brew fetch --cask noahhhi/uu-booster-pr/uu-booster --force`

The downloaded DMG was also mounted and verified to contain UUBooster 2.8.19 with a valid Developer ID signature from Hangzhou Bobo Technology Co Ltd (PU9BNSBJW7).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: OpenAI Codex (GPT-5) investigated the download flow, prepared the cask changes, and ran the validations described above. The submitter personally reviewed the resulting diff and the unchanged `zap` paths before requesting this update.

-----
