### PR TITLE
regexpilot 1.0.2 (new cask)

### DIFF
--- a/Casks/r/regexpilot.rb
+++ b/Casks/r/regexpilot.rb
@@ -1,0 +1,28 @@
+cask "regexpilot" do
+  version "1.0.2"
+  sha256 "ce0d406c59a1ec795a97c0c2a82cca0d09a98548d05c0e22e39bfcf6cd123a2b"
+
+  url "https://pub-013d2816deaa41b0b7403efaa3d9a6e9.r2.dev/RegexPilot-#{version}-universal.dmg",
+      verified: "pub-013d2816deaa41b0b7403efaa3d9a6e9.r2.dev/"
+  name "RegexPilot"
+  desc "Visual regex builder that runs patterns against 21 language engines"
+  homepage "https://regexpilot.com/"
+
+  livecheck do
+    url "https://regexpilot.com/"
+    regex(/v?(\d+(?:\.\d+)+)(?:<!--\s*-->)?\s*·\s*out now/i)
+    strategy :page_match
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "RegexPilot.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.regexpilot.app",
+    "~/Library/Caches/com.regexpilot.app",
+    "~/Library/Preferences/com.regexpilot.app.plist",
+    "~/Library/WebKit/com.regexpilot.app",
+  ]
+end


### PR DESCRIPTION
RegexPilot is a visual regex builder for macOS. It renders a pattern as an editable railroad diagram and runs it against bundled native engines for 21 language flavors (CPython, MRI Ruby, GraalVM Java, .NET, PCRE, and others), so results match the target language rather than approximating with JavaScript.

- Homepage: https://regexpilot.com/
- Signed with a Developer ID certificate and notarized by Apple; no Gatekeeper bypass required.
- Also distributed on the Mac App Store, so the app is under active Apple review as well.
- Free tier works indefinitely; paid features are optional. The same download activates as the full version without re-downloading.

### Verification

- `brew audit --cask --new --online regexpilot` exits 0
- `brew style --cask regexpilot` reports no offenses
- `brew livecheck --cask regexpilot` reports `1.0.2 ==> 1.0.2`
- `brew fetch --cask regexpilot` downloads and verifies the checksum

The download URL is version-pinned (not a rolling `latest` alias), so the `sha256` refers to an immutable artifact, and `livecheck` tracks the released version from the homepage.