### PR TITLE
unity-cli 1.0.0-beta.3 (new cask)

### DIFF
--- a/Casks/u/unity-cli.rb
+++ b/Casks/u/unity-cli.rb
@@ -1,0 +1,35 @@
+cask "unity-cli" do
+  arch arm: "arm64", intel: "x64"
+  os macos: "darwin", linux: "linux"
+
+  version "1.0.0-beta.3"
+  sha256 arm:          "adfb6dbd4bc2015052a63d2097ec535b5408f585e2e35f3754b995e1541eef48",
+         intel:        "d0d3b356d107f333e866f72b96ff440f810976715df93dd79ea2a6b777c3b50f",
+         arm64_linux:  "21da2bf98d16dbad55dd3bb187a01008acfe08396075e491880d97d818a9ef11",
+         x86_64_linux: "9b89aaa5a676e8e5bd6a3844a9398defb963bd3495186445a464a47057e54ea3"
+
+  on_macos do
+    zap trash: "~/Library/Application Support/UnityHub"
+  end
+  on_linux do
+    zap trash: [
+      "~/.cache/unityhub",
+      "~/.config/unityhub",
+    ]
+  end
+
+  url "https://public-cdn.cloud.unity3d.com/hub/prod/cli/#{version}/unity-#{os}-#{arch}"
+  name "Unity CLI"
+  desc "Command-line interface for Unity"
+  homepage "https://docs.unity.com/en-us/cli"
+
+  livecheck do
+    url "https://public-cdn.cloud.unity3d.com/hub/prod/cli/latest-beta.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  # The extension-less download is staged under the version directory's name
+  binary version.to_s, target: "unity"
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+unity-cli&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: drafted with Claude Code (same setup as my previous casks, #278065 / #278232). I reviewed the cask and ran every command above locally myself (macOS arm64: style, online+new audit, livecheck, install, `unity --version` on the installed binary, uninstall). I will answer review comments personally.

-----

Adds the Unity CLI (`unity` command) as a new cask. Notes for review:

- **Prerelease version**: upstream has no stable release yet — the CLI is distributed as beta only (`1.0.0-beta.3` is the newest release on every channel), which is the documented no-stable-version exception. The livecheck feed (`latest-beta.json`) is the vendor's release manifest and is rolled forward to the GA version when a stable release ships, so the cask follows upstream to stable automatically.
- **Four-way binary**: bare, extension-less executables per OS/arch (`unity-{darwin,linux}-{arm64,x64}`), Developer ID-signed and notarized on macOS. Because the URL's last path component has no extension, Homebrew stages the download under the version directory's name — hence `binary version.to_s, target: "unity"`.
- **Self-update is brew-aware**: the CLI detects a Caskroom/Homebrew install at runtime and refuses to self-update, pointing users at `brew upgrade` instead.
- **No `zap` stanza**: the CLI shares its data directory (`~/Library/Application Support/UnityHub`) with the Unity Hub app (separate `unity-hub` cask); zapping it here would destroy Hub state.
- I work at Unity, on the team that ships this CLI.
