### PR TITLE
intellij-idea: run idea executable directly

### DIFF
--- a/Casks/i/intellij-idea.rb
+++ b/Casks/i/intellij-idea.rb
@@ -29,8 +29,7 @@ cask "intellij-idea" do
 
   app "IntelliJ IDEA.app"
   command_wrapper "idea",
-                  executable: "/usr/bin/open",
-                  args:       ["-na", "IntelliJ IDEA.app", "--args"]
+                  executable: "#{appdir}/IntelliJ IDEA.app/Contents/MacOS/idea"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/IntelliJIdea#{version.major_minor}",


### PR DESCRIPTION
Built and tested locally on macOS 26.6 (arm64).

Runs the app's own `idea` launcher instead of `open -na`, so the command
stays attached to the terminal and `--wait`, `diff` and `merge` behave as
documented. Matches `intellij-idea-ce`, `webstorm`, `phpstorm`, `clion`,
`datagrip`, `pycharm` and `rider`, which already point `command_wrapper`
at the in-app executable.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: Claude Code (claude-opus-5) was used to compare this cask against the other JetBrains casks and to run the validation commands. The `zap` stanza is untouched by this PR. Verified locally with `brew style --fix`, `brew audit --cask --online`, and `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --cask intellij-idea`, after which `idea --help` runs from the generated wrapper.

-----
