### PR TITLE
android-studio-preview@beta: improve version detection

### DIFF
--- a/Casks/a/android-studio-preview@beta.rb
+++ b/Casks/a/android-studio-preview@beta.rb
@@ -1,7 +1,7 @@
 cask "android-studio-preview@beta" do
   arch arm: "mac_arm", intel: "mac"
 
-  version "2026.1.3.6,quail3-rc2"
+  version "2026.1.3.6,quail3-rc2,AI-261.26222.65.2613.15882241"
   sha256 arm:   "e522664d047078578026c656bf4bc780af99b521eed20a7e6a5f220c610083e1",
          intel: "00917f8adcc2cab9416d1b4daf23d55e4d6eb580c273f6a4a45616c1c8be3934"
 
@@ -12,11 +12,18 @@ cask "android-studio-preview@beta" do
   homepage "https://developer.android.com/studio/preview/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/android[._-]studio(?:[._-]([^"' >]+))?[._-]#{arch}\.dmg[^>]*?beta}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+    url "https://jb.gg/android-studio-releases-list.json"
+    strategy :json do |json|
+      json.dig("content", "item")&.filter_map do |release|
+        next unless %w[Beta RC].include?(release["channel"])
+
+        version = release["version"]
+        build = release["build"]
+        download = release["download"]&.find { |item| item["link"]&.end_with?("-#{arch}.dmg") }
+        match = download&.dig("link")&.match(%r{/android-studio-([^/]+)-#{arch}\.dmg\z}i)
+        next if version.blank? || build.blank? || match.blank?
+
+        "#{version},#{match[1]},#{build}"
       end
     end
   end


### PR DESCRIPTION
Same change as #275872, applied to the beta preview channel.

Android Studio's app bundle reports a short version of just `2026.1`, which never matches the four-segment cask version, so Homebrew's `auto_updates_bundle_outdated?` check has no usable version to compare against and a stale install is invisible to `brew outdated`. Adding the IDE build ID (`CFBundleVersion`) as a third CSV component gives it an exact match, and switching livecheck from scraping the preview homepage to JetBrains' release feed is what makes that build ID available in the first place.

The feed's `Beta` channel has been dormant since 2024.3.2.9 — current beta-track builds are published under `RC` — so the filter accepts both. Older `Beta` entries lose the version comparison, so including them is harmless and keeps the cask working if JetBrains resumes using that label.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI-assisted (Claude Opus 5 via Copilot CLI) for adapting the livecheck block from #275872 and cross-checking the release feed's channel labels. I reviewed and tested everything myself:

- `brew livecheck --cask --autobump` reports the current version unchanged, with no spurious bump.
- `brew audit --cask --online` and `brew style` are clean.
- Mounted the DMG and confirmed `CFBundleVersion` is exactly `AI-261.26222.65.2613.15882241`.
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask` and `brew uninstall --cask` both succeeded.
- Verified the fix actually does something: with the real app installed and the cask version faked forward, `brew outdated` reports it outdated only when the build component is present and newer, stays quiet when the build matches, and — under the old scheme without a build component — never detects it at all.
- The `zap` paths are unchanged; `version.major_minor` still resolves to `2026.1` with the third CSV component added.