### PR TITLE
work-louder-input 0.18.0 (new cask)

### DIFF
--- a/Casks/w/work-louder-input.rb
+++ b/Casks/w/work-louder-input.rb
@@ -1,0 +1,33 @@
+cask "work-louder-input" do
+  arch arm: "-arm64"
+
+  version "0.18.0"
+  sha256 arm:   "d56bf36a2dd733bc7f32a38ce178d0ea4bce0d8f0af47e48f5b7d5facfe27132",
+         intel: "65533dc60bb5908f68b73d68ce704653b57b3c77d8b34a1173bdab0c4c804232"
+
+  url "https://github.com/worklouder/input-releases/releases/download/v#{version}/input-#{version}#{arch}.dmg",
+      verified: "github.com/worklouder/input-releases/"
+  name "Input"
+  desc "Keyboard configurator for Work Louder devices"
+  homepage "https://worklouder.cc/input"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "input.app"
+
+  uninstall quit: "it.focusense.input-app"
+
+  zap trash: [
+    "~/Library/Application Support/input",
+    "~/Library/Caches/input-updater",
+    "~/Library/Caches/it.focusense.input-app",
+    "~/Library/Logs/input",
+    "~/Library/Preferences/it.focusense.input-app.plist",
+  ]
+end


### PR DESCRIPTION
Adds a cask for [Input](https://worklouder.cc/input), Work Louder’s keyboard configurator.

-----

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

-----
AI/LLM Usage:

I used 5.6 Sol Medium to help draft the cask, and then manually reviewed each stanza, confirmed that they were [ordered correctly](https://docs.brew.sh/Cask-Cookbook#stanza-order), and verified the cask via the commands above. I also confirmed the zap paths against files that `Input` created on my Mac to make sure they are correct.