### PR TITLE
altersend 1.8.0

### DIFF
--- a/Casks/a/altersend.rb
+++ b/Casks/a/altersend.rb
@@ -1,15 +1,16 @@
 cask "altersend" do
-  arch arm: "arm64", intel: "x86_64"
   os macos: "dmg", linux: "AppImage"
 
-  version "1.7.0"
-  sha256 arm:          "0df4ea9407b71a7efe11f1b12e38f3f9034b21ecdb881d33f4e8f22d02642df4",
-         intel:        "8235ae3ebd25832292faed53ee3da4cef25198f5097e2b6817c01598ad348ec4",
-         arm64_linux:  "526d17c8fd58fac6dbb7da12524ca544aba5419ec1b3b5f73fcc0b2342c0aa26",
-         x86_64_linux: "52d7245103f8a8f2e05ed6b62a39d19303c68bf45d6aadb07bc7abb2b77c23e4"
+  version "1.8.0"
+  sha256 arm:          "f7ba7bf25eec22321f8433161c840e9f4a68ed3363433584aae7699b81c3d040",
+         intel:        "5d36979b04d95ae3c82f9e317366fab2c0ca009c036337550275e1400ea6777b",
+         arm64_linux:  "404106991daf9baac204d15e5343f1ffeed22d5e44bd0151cc84ba35166a209a",
+         x86_64_linux: "2b429aedad7bf96aa693d544715bfc582f1c90fde47e8b503aa9b8157d613656"
 
   on_macos do
-    url "https://github.com/denislupookov/altersend/releases/download/v#{version}/AlterSend-#{version}-#{arch}.#{os}"
+    arch arm: "-arm64"
+
+    url "https://github.com/denislupookov/altersend/releases/download/v#{version}/AlterSend-#{version}#{arch}.#{os}"
 
     depends_on macos: :monterey
 
@@ -21,6 +22,8 @@ cask "altersend" do
     ]
   end
   on_linux do
+    arch arm: "arm64", intel: "x86_64"
+
     url "https://github.com/denislupookov/altersend/releases/download/v#{version}/AlterSend-#{arch}.#{os}"
 
     app_image "AlterSend-#{arch}.AppImage", target: "AlterSend.AppImage"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`altersend` is autobumped but the workflow failed to update to version 1.8.0 because the Intel dmg file name doesn't contain an `-x86_64` suffix (this appears to be the case for all past releases). This updates the version and adjusts the cask setup accordingly.