### PR TITLE
klayout 0.30.10

### DIFF
--- a/Casks/k/klayout.rb
+++ b/Casks/k/klayout.rb
@@ -1,5 +1,5 @@
 cask "klayout" do
-  on_monterey :or_older do
+  on_ventura :or_older do
     on_catalina :or_older do
       version "0.27.13"
       sha256 "25d38cba66f4009f8ed19a755ec73863721a6f2e3b2d57257f077bf71ec5beba"
@@ -21,28 +21,23 @@ cask "klayout" do
       url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Monterey-1-qt5MP-RsysPhb311.dmg",
           verified: "klayout.org/downloads/MacOS/"
     end
+    on_ventura do
+      version "0.30.4"
+      sha256 "5c432cecff49a27cbad8097bcf6a3169bebfec32ce87b13e92af19440b4a87f7"
+
+      url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Ventura-1-qt5MP-RsysPhb311.dmg",
+          verified: "klayout.org/downloads/MacOS/"
+    end
 
     livecheck do
       skip "Legacy version"
     end
   end
-  on_ventura do
-    version "0.30.4"
-    sha256 "5c432cecff49a27cbad8097bcf6a3169bebfec32ce87b13e92af19440b4a87f7"
-
-    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Ventura-1-qt5MP-RsysPhb311.dmg",
-        verified: "klayout.org/downloads/MacOS/"
-
-    livecheck do
-      url "https://www.klayout.de/build.html"
-      regex(/href=.*?HW[._-]klayout[._-](\d+(?:\.\d+)+)[._-]macOS[._-]Ventura.*?\.dmg/i)
-    end
-  end
   on_sonoma do
-    version "0.30.9"
-    sha256 "a918431645627ac5bdb5a407448cb67e3bca6fdbe3384027e2bfa8c2b6bbbe6a"
+    version "0.30.10"
+    sha256 "6c51fe01c9c4d6ef0b52e7df534403b131ae1e8be330993f04baa007beb3788a"
 
-    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Sonoma-1-qt5MP-RsysPhb311.dmg",
+    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Sonoma-C32-1-qt5MP-RsysPhb311.dmg",
         verified: "klayout.org/downloads/MacOS/"
 
     livecheck do
@@ -51,10 +46,10 @@ cask "klayout" do
     end
   end
   on_sequoia do
-    version "0.30.9"
-    sha256 "73fcd98f74b563f232e1eae9866bc52957b0d198f02a4570e77f4c9be05d89c5"
+    version "0.30.10"
+    sha256 "65bb64339cc9a1b53b0329656182bcd359ca3958efededfe133b71ce93301412"
 
-    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Sequoia-1-qt5MP-RsysPhb311.dmg",
+    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Sequoia-C32-1-qt5MP-RsysPhb311.dmg",
         verified: "klayout.org/downloads/MacOS/"
 
     livecheck do
@@ -64,10 +59,10 @@ cask "klayout" do
   end
   on_tahoe :or_newer do
     on_arm do
-      version "0.30.9"
-      sha256 "5b2807b2e522760535a84fb83828de768995c9b68914b75be14c961d1ea0bc49"
+      version "0.30.10"
+      sha256 "903d44aa707a38cfc464d43b3f26b59be6ef27c84b5289b6ecbd155a5b02e827"
 
-      url "https://www.klayout.org/downloads/MacOS/ARM64/arm64ST-klayout-#{version}-macOS-Tahoe-1-qt5MP-RsysPsys.dmg",
+      url "https://www.klayout.org/downloads/MacOS/ARM64/arm64ST-klayout-#{version}-macOS-Tahoe-C32-1-qt5MP-RsysPsys.dmg",
           verified: "klayout.org/downloads/MacOS/ARM64/"
 
       livecheck do
@@ -76,10 +71,10 @@ cask "klayout" do
       end
     end
     on_intel do
-      version "0.30.9"
-      sha256 "73fcd98f74b563f232e1eae9866bc52957b0d198f02a4570e77f4c9be05d89c5"
+      version "0.30.10"
+      sha256 "65bb64339cc9a1b53b0329656182bcd359ca3958efededfe133b71ce93301412"
 
-      url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Sequoia-1-qt5MP-RsysPhb311.dmg",
+      url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Sequoia-C32-1-qt5MP-RsysPhb311.dmg",
           verified: "klayout.org/downloads/MacOS/"
 
       livecheck do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`klayout` is autobumped but the workflow failed to update to version 0.30.10 because the file names now include a `-C32` suffix after the macOS version name. This updates the version and URLs accordingly. This also moves the `on_ventura` block into the on_os block with the other legacy versions, as it seems fairly clear that there won't be new versions for Ventura.