### PR TITLE
android-cli 1.0.15985488 (new cask)

### DIFF
--- a/Casks/a/android-cli.rb
+++ b/Casks/a/android-cli.rb
@@ -1,14 +1,24 @@
 cask "android-cli" do
-  arch arm: "arm64", intel: "x86_64"
-  os macos: "darwin", linux: "linux"
-
   version "1.0.15985488"
-  sha256 arm:          "0fa343fda9433b7c74e4eb91d3a18cec60477a29c015a018dd189222a3d0d020",
-         intel:        "f23a02c5c11dda6fd6aaa1dbaf572be8525119f46f6493e01c3e91f9f5b4817c",
-         x86_64_linux: "7d0f4b41e6511ab6eeeaec4b885442f02aded270cf83cb75f521aca2c03d593d"
 
-  url "https://dl.google.com/android/cli/#{version}/#{os}_#{arch}/android",
-      verified: "dl.google.com/android/cli/"
+  on_macos do
+    arch arm: "arm64", intel: "x86_64"
+
+    sha256 arm:   "0fa343fda9433b7c74e4eb91d3a18cec60477a29c015a018dd189222a3d0d020",
+           intel: "f23a02c5c11dda6fd6aaa1dbaf572be8525119f46f6493e01c3e91f9f5b4817c"
+
+    url "https://dl.google.com/android/cli/#{version}/darwin_#{arch}/android",
+        verified: "dl.google.com/android/cli/"
+  end
+  on_linux do
+    sha256 "7d0f4b41e6511ab6eeeaec4b885442f02aded270cf83cb75f521aca2c03d593d"
+
+    url "https://dl.google.com/android/cli/#{version}/linux_x86_64/android",
+        verified: "dl.google.com/android/cli/"
+
+    depends_on arch: :x86_64 # no linux_arm64 build is published upstream
+  end
+
   name "Android CLI"
   desc "Command-line interface for Android app development with AI agents"
   homepage "https://developer.android.com/tools/agents/android-cli"

--- a/Casks/a/android-cli.rb
+++ b/Casks/a/android-cli.rb
@@ -1,38 +1,31 @@
 cask "android-cli" do
+  arch arm: "arm64", intel: "x86_64"
+  os macos: "darwin", linux: "linux"
+
   version "1.0.15985488"
 
   on_macos do
-    arch arm: "arm64", intel: "x86_64"
-
     sha256 arm:   "0fa343fda9433b7c74e4eb91d3a18cec60477a29c015a018dd189222a3d0d020",
            intel: "f23a02c5c11dda6fd6aaa1dbaf572be8525119f46f6493e01c3e91f9f5b4817c"
-
-    url "https://dl.google.com/android/cli/#{version}/darwin_#{arch}/android",
-        verified: "dl.google.com/android/cli/"
   end
   on_linux do
     sha256 "7d0f4b41e6511ab6eeeaec4b885442f02aded270cf83cb75f521aca2c03d593d"
 
-    url "https://dl.google.com/android/cli/#{version}/linux_x86_64/android",
-        verified: "dl.google.com/android/cli/"
-
-    depends_on arch: :x86_64 # no linux_arm64 build is published upstream
+    depends_on arch: :x86_64
   end
 
+  url "https://dl.google.com/android/cli/#{version}/#{os}_#{arch}/android",
+      verified: "dl.google.com/android/cli/"
   name "Android CLI"
   desc "Command-line interface for Android app development with AI agents"
   homepage "https://developer.android.com/tools/agents/android-cli"
 
   livecheck do
-    url "https://dl.google.com/android/cli/latest/darwin_arm64/METADATA"
-    regex(/version=([\d.]+)/i)
+    url "https://dl.google.com/android/cli/latest/#{os}_#{arch}/METADATA"
+    regex(/version=v?(\d+(?:\.\d+)+)/i)
   end
 
   binary "android"
-
-  postflight_steps do
-    set_permissions "android", "0755"
-  end
 
   zap trash: [
     "~/.android",

--- a/Casks/a/android-cli.rb
+++ b/Casks/a/android-cli.rb
@@ -1,0 +1,31 @@
+cask "android-cli" do
+  arch arm: "arm64", intel: "x86_64"
+  os macos: "darwin", linux: "linux"
+
+  version "1.0.15985488"
+  sha256 arm:          "0fa343fda9433b7c74e4eb91d3a18cec60477a29c015a018dd189222a3d0d020",
+         intel:        "f23a02c5c11dda6fd6aaa1dbaf572be8525119f46f6493e01c3e91f9f5b4817c",
+         x86_64_linux: "7d0f4b41e6511ab6eeeaec4b885442f02aded270cf83cb75f521aca2c03d593d"
+
+  url "https://dl.google.com/android/cli/#{version}/#{os}_#{arch}/android",
+      verified: "dl.google.com/android/cli/"
+  name "Android CLI"
+  desc "Command-line interface for Android app development with AI agents"
+  homepage "https://developer.android.com/tools/agents/android-cli"
+
+  livecheck do
+    url "https://dl.google.com/android/cli/latest/darwin_arm64/METADATA"
+    regex(/version=([\d.]+)/i)
+  end
+
+  binary "android"
+
+  postflight_steps do
+    set_permissions "android", "0755"
+  end
+
+  zap trash: [
+    "~/.android",
+    "~/Library/Android",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Claude to draft the cask; I verified all `sha256` values, ran every command above myself, and generated `zap` paths via `brew generate-zap` (temp-renamed token to `android` since `generate-zap` doesn't match `android-cli`).

Note: no `linux_arm64` build is published upstream, so this cask only supports Linux on x86_64 (`depends_on`/no `arm64_linux` sha256 key restricts it accordingly).