### PR TITLE
zcode 3.6.5 (new cask)

### DIFF
--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -11,8 +11,8 @@ cask "zcode" do
   homepage "https://zcode.z.ai/en/"
 
   livecheck do
-    url "https://zcode.z.ai/en"
-    regex(%r{href="https://cdn-zcode\.z\.ai/.*?ZCode[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg"}i)
+    url :homepage
+    regex(/href=.*?ZCode[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg/i)
   end
 
   auto_updates true

--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -8,7 +8,7 @@ cask "zcode" do
   url "https://cdn-zcode.z.ai/zcode/electron/releases/#{version}/macos-#{arch}/ZCode-#{version}-mac-#{arch}.dmg"
   name "ZCode"
   desc "AI-assisted development environment"
-  homepage "https://zcode.z.ai/"
+  homepage "https://zcode.z.ai/en/"
 
   livecheck do
     url "https://zcode.z.ai/en"

--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -24,8 +24,10 @@ cask "zcode" do
 
   zap trash: [
     "~/Library/Application Support/ZCode",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/dev.zcode.app.sfl*",
     "~/Library/Caches/@zcodedesktop-updater",
     "~/Library/Preferences/dev.zcode.app.plist",
     "~/Library/Services/Open in ZCode.workflow",
-  ]
+  ],
+      rmdir: "~/.zcode"
 end

--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -1,0 +1,29 @@
+cask "zcode" do
+  arch arm: "arm64", intel: "x64"
+
+  version "3.6.5"
+  sha256 arm:   "e4f93eb3fa51825fc3a443b3307dc52eda98c018d9ac326a22d254f8aa77ac8b",
+         intel: "8f496426828411940a03e757f9a9f56ee684f9b59274351f7f7b96e4c55c4df8"
+
+  url "https://cdn-zcode.z.ai/zcode/electron/releases/#{version}/macos-#{arch}/ZCode-#{version}-mac-#{arch}.dmg"
+  name "ZCode"
+  desc "AI-assisted development environment"
+  homepage "https://zcode.z.ai/"
+
+  livecheck do
+    url "https://zcode.z.ai/en"
+    regex(%r{href="https://cdn-zcode\.z\.ai/.*?ZCode[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg"}i)
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "ZCode.app"
+
+  zap trash: [
+    "~/Library/Application Support/ZCode",
+    "~/Library/Caches/@zcodedesktop-updater",
+    "~/Library/Preferences/dev.zcode.app.plist",
+    "~/Library/Services/Open in ZCode.workflow",
+  ]
+end

--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -23,11 +23,11 @@ cask "zcode" do
   uninstall quit: "dev.zcode.app"
 
   zap trash: [
-    "~/Library/Application Support/ZCode",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/dev.zcode.app.sfl*",
-    "~/Library/Caches/@zcodedesktop-updater",
-    "~/Library/Preferences/dev.zcode.app.plist",
-    "~/Library/Services/Open in ZCode.workflow",
-  ],
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/dev.zcode.app.sfl*",
+        "~/Library/Application Support/ZCode",
+        "~/Library/Caches/@zcodedesktop-updater",
+        "~/Library/Preferences/dev.zcode.app.plist",
+        "~/Library/Services/Open in ZCode.workflow",
+      ],
       rmdir: "~/.zcode"
 end

--- a/Casks/z/zcode.rb
+++ b/Casks/z/zcode.rb
@@ -20,6 +20,8 @@ cask "zcode" do
 
   app "ZCode.app"
 
+  uninstall quit: "dev.zcode.app"
+
   zap trash: [
     "~/Library/Application Support/ZCode",
     "~/Library/Caches/@zcodedesktop-updater",


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online zcode` is error-free.
- [x] `brew style --fix zcode` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests). The previous unmerged submission was #272910 and targeted the now-stale 3.2.4 release.
- [x] `brew audit --cask --new zcode` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask zcode` worked successfully.
- [x] `brew uninstall --cask zcode` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

-----

This adds the current stable ZCode 3.6.5 release and supersedes #272910. Since that submission, upstream has changed the macOS download layout to include architecture-specific `macos-arm64` and `macos-x64` directories.

Draft preparation verified:

- ZCode's official download page advertises 3.6.5 for both macOS architectures.
- Both versioned DMGs download successfully from the official `cdn-zcode.z.ai` host.
- The Apple Silicon SHA-256 is `e4f93eb3fa51825fc3a443b3307dc52eda98c018d9ac326a22d254f8aa77ac8b`.
- The Intel SHA-256 is `8f496426828411940a03e757f9a9f56ee684f9b59274351f7f7b96e4c55c4df8`.
- Both DMGs contain `ZCode.app` version 3.6.5 with bundle ID `dev.zcode.app`.
- Both applications are accepted by Gatekeeper as notarized Developer ID builds signed by `Beijing Knowledge Atlas Technology Joint Stock Company Limited (8A5X4JJ39T)`.
- The app declares macOS 12.0 as its minimum system version.
- The `livecheck` expression resolves 3.6.5 for both `arm64` and `x64` on `https://zcode.z.ai/en`.
- `brew style --fix --cask zcode` inspected the cask with no offenses detected.
- Both `brew audit --cask --online zcode` and `brew audit --cask --new zcode` completed successfully.
- Installation and uninstallation completed successfully. The install used an isolated `--appdir` to avoid overwriting an existing manually installed ZCode 3.6.5 application; the existing application was preserved.
- All four `zap` paths were observed on the existing ZCode 3.6.5 installation.

AI/LLM disclosure: OpenAI Codex was used to research the previous submission, update the cask for 3.6.5, calculate and cross-check download checksums, inspect the signed application bundles, and draft this pull-request text. I personally reviewed the cask and pull-request text, including the `zap` paths, and verified the checklist before submission. I will answer all maintainer questions and review comments myself without AI/LLM.