### PR TITLE
Use install-step template tokens

### DIFF
--- a/Casks/a/airtool.rb
+++ b/Casks/a/airtool.rb
@@ -18,7 +18,7 @@ cask "airtool" do
   pkg "Airtool_#{version}.pkg"
 
   uninstall_preflight_steps do
-    set_ownership "/Library/Application Support/Airtool #{version.major}"
+    set_ownership "/Library/Application Support/Airtool {{version.major}}"
   end
 
   uninstall launchctl:  "com.intuitibits.airtool#{version.major}.airtool-bpf",

--- a/Casks/j/j.rb
+++ b/Casks/j/j.rb
@@ -48,17 +48,17 @@ cask "j" do
 
   postflight_steps do
     # Use `readlink` to get full path of symlinked commands.
-    inreplace "j#{version.major_minor}/bin/jbrk.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
-    inreplace "j#{version.major_minor}/bin/jhs.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
-    inreplace "j#{version.major_minor}/bin/jqt.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
+    inreplace "j{{version.major_minor}}/bin/jbrk.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
+    inreplace "j{{version.major_minor}}/bin/jhs.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
+    inreplace "j{{version.major_minor}}/bin/jqt.command", "$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")'
 
     # Fix relative paths inside App bundles.
     inreplace "jbrk.app/Contents/MacOS/apprun", %r{`dirname "\$0"`.*?/bin},
-              "{{staged_path}}/j#{version.major_minor}/bin", base: :appdir
+              "{{staged_path}}/j{{version.major_minor}}/bin", base: :appdir
     inreplace "jcon.app/Contents/MacOS/apprun", %r{`dirname "\$0"`.*?/bin},
-              "{{staged_path}}/j#{version.major_minor}/bin", base: :appdir
+              "{{staged_path}}/j{{version.major_minor}}/bin", base: :appdir
     inreplace "jqt.app/Contents/MacOS/apprun", %r{`dirname "\$0"`.*?/bin},
-              "{{staged_path}}/j#{version.major_minor}/bin", base: :appdir
+              "{{staged_path}}/j{{version.major_minor}}/bin", base: :appdir
   end
 
   # Not actually necessary, since it would be deleted anyway.

--- a/Casks/m/miniconda.rb
+++ b/Casks/m/miniconda.rb
@@ -41,15 +41,15 @@ cask "miniconda" do
   binary "#{caskroom_path}/base/condabin/conda"
 
   postflight_steps do
-    if_path_exists "{{temp}}/#{token}-envs" do
+    if_path_exists "{{temp}}/{{token}}-envs" do
       remove "base/envs", base: :caskroom_path, recursive: true
-      move "{{temp}}/#{token}-envs", "base/envs", target_base: :caskroom_path
+      move "{{temp}}/{{token}}-envs", "base/envs", target_base: :caskroom_path
     end
   end
 
   uninstall_preflight_steps do
     if_path_exists "{{caskroom_path}}/base/envs" do
-      move "base/envs", "{{temp}}/#{token}-envs", source_base: :caskroom_path
+      move "base/envs", "{{temp}}/{{token}}-envs", source_base: :caskroom_path
     end
   end
 

--- a/Casks/m/miniforge.rb
+++ b/Casks/m/miniforge.rb
@@ -29,15 +29,15 @@ cask "miniforge" do
   binary "#{caskroom_path}/base/condabin/mamba"
 
   postflight_steps do
-    if_path_exists "{{temp}}/#{token}-envs" do
+    if_path_exists "{{temp}}/{{token}}-envs" do
       remove "base/envs", base: :caskroom_path, recursive: true
-      move "{{temp}}/#{token}-envs", "base/envs", target_base: :caskroom_path
+      move "{{temp}}/{{token}}-envs", "base/envs", target_base: :caskroom_path
     end
   end
 
   uninstall_preflight_steps do
     if_path_exists "{{caskroom_path}}/base/envs" do
-      move "base/envs", "{{temp}}/#{token}-envs", source_base: :caskroom_path
+      move "base/envs", "{{temp}}/{{token}}-envs", source_base: :caskroom_path
     end
   end
 

--- a/Casks/m/mplabx-ide.rb
+++ b/Casks/m/mplabx-ide.rb
@@ -36,14 +36,14 @@ cask "mplabx-ide" do
   # is changed.
   postflight_steps do
     set_ownership "."
-    run "/bin/mkdir", args: ["-p", "{{appdir}}/microchip/mplabx/#{version}"], sudo: true
+    run "/bin/mkdir", args: ["-p", "{{appdir}}/microchip/mplabx/{{version}}"], sudo: true
     run "/bin/cp", args: [
       "-pR",
-      "{{staged_path}}/MPLAB IPE v#{version}.app",
-      "{{staged_path}}/MPLAB X IDE v#{version}.app",
-      "{{appdir}}/microchip/mplabx/#{version}/",
+      "{{staged_path}}/MPLAB IPE v{{version}}.app",
+      "{{staged_path}}/MPLAB X IDE v{{version}}.app",
+      "{{appdir}}/microchip/mplabx/{{version}}/",
     ], sudo: true
-    set_ownership "microchip/mplabx/#{version}", base: :appdir
+    set_ownership "microchip/mplabx/{{version}}", base: :appdir
   end
 
   uninstall script: {

--- a/Casks/n/ncar-ncl.rb
+++ b/Casks/n/ncar-ncl.rb
@@ -20,7 +20,7 @@ cask "ncar-ncl" do
   artifact "lib", target: "#{HOMEBREW_PREFIX}/ncl-#{version}/lib"
 
   preflight_steps do
-    run "/bin/mkdir", args: ["-p", "{{HOMEBREW_PREFIX}}/ncl-#{version}"], sudo: true
+    run "/bin/mkdir", args: ["-p", "{{HOMEBREW_PREFIX}}/ncl-{{version}}"], sudo: true
   end
 
   uninstall delete: "#{HOMEBREW_PREFIX}/ncl-#{version}"

--- a/Casks/p/parallels@14.rb
+++ b/Casks/p/parallels@14.rb
@@ -26,10 +26,10 @@ cask "parallels@14" do
   container type: :naked
 
   preflight_steps do
-    run "/usr/bin/hdiutil", args: ["attach", "-nobrowse", "{{staged_path}}/ParallelsDesktop-#{version}.dmg"]
-    run "/Volumes/Parallels Desktop #{version.major}/Parallels Desktop.app/Contents/MacOS/inittool",
+    run "/usr/bin/hdiutil", args: ["attach", "-nobrowse", "{{staged_path}}/ParallelsDesktop-{{version}}.dmg"]
+    run "/Volumes/Parallels Desktop {{version.major}}/Parallels Desktop.app/Contents/MacOS/inittool",
         args: ["install", "-t", "{{appdir}}/Parallels Desktop.app", "-s"], sudo: true
-    run "/usr/bin/hdiutil", args: ["detach", "/Volumes/Parallels Desktop #{version.major}"]
+    run "/usr/bin/hdiutil", args: ["detach", "/Volumes/Parallels Desktop {{version.major}}"]
   end
 
   postflight_steps do

--- a/Casks/p/pd.rb
+++ b/Casks/p/pd.rb
@@ -17,7 +17,7 @@ cask "pd" do
   app "Pd-#{version}.app"
 
   postflight_steps do
-    set_permissions "Pd-#{version}.app", "u+w", base: :appdir
+    set_permissions "Pd-{{version}}.app", "u+w", base: :appdir
   end
 
   zap trash: [

--- a/Casks/s/squirrelsql.rb
+++ b/Casks/s/squirrelsql.rb
@@ -71,7 +71,7 @@ cask "squirrelsql" do
 
   postflight_steps do
     run "/usr/bin/java",
-        args: ["-jar", "{{staged_path}}/squirrel-sql-#{version}-MACOSX-install.jar",
+        args: ["-jar", "{{staged_path}}/squirrel-sql-{{version}}-MACOSX-install.jar",
                "{{staged_path}}/install-options.xml"]
   end
 


### PR DESCRIPTION
Nine casks use compatibility Ruby interpolation inside structured install steps.

- replace identity and version interpolation with explicit install-time tokens
- keep staged and temporary paths deferred through the JSON API
- preserve existing install, permission and move behaviour
- avoid serialising installation-specific values

Needs https://github.com/Homebrew/brew/pull/23347

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
