### PR TITLE
fix(autogram): reenable intel

### DIFF
--- a/Casks/a/autogram.rb
+++ b/Casks/a/autogram.rb
@@ -1,8 +1,10 @@
 cask "autogram" do
   version "2.7.5"
-  sha256 "2e225c212377157a4500ef8485772d7a0187dd515575cff33ab24a3cd3c6ab71"
+  sha256 arm64: "2e225c212377157a4500ef8485772d7a0187dd515575cff33ab24a3cd3c6ab71",
+         intel: "2e225c212377157a4500ef8485772d7a0187dd515575cff33ab24a3cd3c6ab71",
 
-  url "https://github.com/slovensko-digital/autogram/releases/download/v#{version}/Autogram-#{version}-MacOs.pkg",
+  url arm64: "https://github.com/slovensko-digital/autogram/releases/download/v#{version}/autogram-#{version}-macos.pkg",
+      intel: "https://github.com/slovensko-digital/autogram/releases/download/v#{version}/autogram-#{version}-macos-intel.pkg"
       verified: "github.com/slovensko-digital/autogram/"
   name "autogram"
   desc "Application for electronic signing of signatures"
@@ -14,7 +16,6 @@ cask "autogram" do
   end
 
   depends_on :macos
-  depends_on arch: :arm64
 
   pkg "Autogram-#{version}-MacOs.pkg"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
