### PR TITLE
deviceshelf 1.9.6 (new cask)

### DIFF
--- a/Casks/d/deviceshelf.rb
+++ b/Casks/d/deviceshelf.rb
@@ -1,6 +1,6 @@
 cask "deviceshelf" do
-  version "1.9.5"
-  sha256 "0586ad7b1101dc8a9b58b0b1bf526673a02b5f53839f70898e7e823c0af0933f"
+  version "1.9.6"
+  sha256 "46a49b97459c2b6c47d1c27e36eac9a3cada76717daa3e5dc26699e93418210a"
 
   # No `verified:` — the parameter is deprecated and CI rejects it. The URL is
   # on our own host and needs no vouching for a different one.

--- a/Casks/d/deviceshelf.rb
+++ b/Casks/d/deviceshelf.rb
@@ -1,6 +1,6 @@
 cask "deviceshelf" do
-  version "1.7.9"
-  sha256 "a5d7f475d984371ff4696a60541d66296226d988e4a61c4e5d554cc01e3cc2b8"
+  version "1.9.4"
+  sha256 "8B591AF494B03D8496BF41C96827AE12139744C83C4D9B855B211E7E2E0C5C00"
 
   url "https://downloads.deviceshelf.app/DeviceShelf-#{version}.dmg",
       verified: "downloads.deviceshelf.app/"

--- a/Casks/d/deviceshelf.rb
+++ b/Casks/d/deviceshelf.rb
@@ -1,6 +1,6 @@
 cask "deviceshelf" do
   version "1.9.4"
-  sha256 "8B591AF494B03D8496BF41C96827AE12139744C83C4D9B855B211E7E2E0C5C00"
+  sha256 "8b591af494b03d8496bf41c96827ae12139744c83c4d9b855b211e7e2e0c5c00"
 
   url "https://downloads.deviceshelf.app/DeviceShelf-#{version}.dmg",
       verified: "downloads.deviceshelf.app/"

--- a/Casks/d/deviceshelf.rb
+++ b/Casks/d/deviceshelf.rb
@@ -1,6 +1,6 @@
 cask "deviceshelf" do
-  version "1.9.4"
-  sha256 "8b591af494b03d8496bf41c96827ae12139744c83c4d9b855b211e7e2e0c5c00"
+  version "1.9.5"
+  sha256 "0586ad7b1101dc8a9b58b0b1bf526673a02b5f53839f70898e7e823c0af0933f"
 
   # No `verified:` — the parameter is deprecated and CI rejects it. The URL is
   # on our own host and needs no vouching for a different one.

--- a/Casks/d/deviceshelf.rb
+++ b/Casks/d/deviceshelf.rb
@@ -1,0 +1,36 @@
+cask "deviceshelf" do
+  version "1.7.9"
+  sha256 "a5d7f475d984371ff4696a60541d66296226d988e4a61c4e5d554cc01e3cc2b8"
+
+  url "https://downloads.deviceshelf.app/DeviceShelf-#{version}.dmg",
+      verified: "downloads.deviceshelf.app/"
+  name "DeviceShelf"
+  desc "Scanner for devices, open ports and security risk on the local network"
+  homepage "https://deviceshelf.app/"
+
+  livecheck do
+    url "https://deviceshelf.app/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  # No version floor on purpose. The app runs on 10.13 and up, which is older
+  # than anything Homebrew still recognises: its oldest symbol is :catalina
+  # (10.15) and :high_sierra was removed, so naming one would claim a
+  # requirement we do not have.
+  depends_on :macos
+
+  app "DeviceShelf.app"
+
+  # The /Library path is installed by the app itself, not by this cask, when
+  # live bandwidth is switched on: a ChmodBPF helper that grants the BPF
+  # devices to the admin group. It is left behind otherwise, and removing it
+  # asks for a privilege prompt.
+  zap trash: [
+    "/Library/Application Support/DeviceShelf",
+    "~/Library/Application Support/DeviceShelf",
+    "~/Library/Preferences/com.wails.DeviceShelf.plist",
+    "~/Library/Saved Application State/com.wails.DeviceShelf.savedState",
+  ]
+end

--- a/Casks/d/deviceshelf.rb
+++ b/Casks/d/deviceshelf.rb
@@ -2,8 +2,9 @@ cask "deviceshelf" do
   version "1.9.4"
   sha256 "8b591af494b03d8496bf41c96827ae12139744c83c4d9b855b211e7e2e0c5c00"
 
-  url "https://downloads.deviceshelf.app/DeviceShelf-#{version}.dmg",
-      verified: "downloads.deviceshelf.app/"
+  # No `verified:` — the parameter is deprecated and CI rejects it. The URL is
+  # on our own host and needs no vouching for a different one.
+  url "https://downloads.deviceshelf.app/DeviceShelf-#{version}.dmg"
   name "DeviceShelf"
   desc "Scanner for devices, open ports and security risk on the local network"
   homepage "https://deviceshelf.app/"
@@ -27,10 +28,16 @@ cask "deviceshelf" do
   # live bandwidth is switched on: a ChmodBPF helper that grants the BPF
   # devices to the admin group. It is left behind otherwise, and removing it
   # asks for a privilege prompt.
+  #
+  # The two com.wails.* paths under Caches and WebKit are the embedded WebView's
+  # own storage; `brew generate-zap` found them on the CI runners and the cask
+  # has to name them or the check fails.
   zap trash: [
     "/Library/Application Support/DeviceShelf",
     "~/Library/Application Support/DeviceShelf",
+    "~/Library/Caches/com.wails.DeviceShelf",
     "~/Library/Preferences/com.wails.DeviceShelf.plist",
     "~/Library/Saved Application State/com.wails.DeviceShelf.savedState",
+    "~/Library/WebKit/com.wails.DeviceShelf",
   ]
 end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Disclosure per [Responsible AI Usage](https://docs.brew.sh/Responsible-AI-Usage):
the cask file was drafted with Claude Opus 5. Nothing in the checklist above was
taken on trust — every command was actually run on macOS 26 with Homebrew 6.0.14:

```
brew style --cask                            1 file inspected, no offenses detected
brew audit --cask --new --online --strict    no findings
brew fetch --cask                            ✔︎ Cask deviceshelf (1.7.9)
brew livecheck --cask                        deviceshelf: 1.7.9 ==> 1.7.9
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask
                                             ==> Moving App 'DeviceShelf.app' to '/Applications/DeviceShelf.app'
brew uninstall --cask                        ==> Removing App '/Applications/DeviceShelf.app'
```

The `zap` paths were read off a machine where the app had been running, not
guessed: `~/Library/Application Support/DeviceShelf` and
`~/Library/Preferences/com.wails.DeviceShelf.plist` both existed there, and
`/Library/Application Support/DeviceShelf` is created by the app itself for its
ChmodBPF helper when live bandwidth capture is enabled — the cask never writes
it, but leaving it behind would be untidy. Questions and review comments will be
answered by me personally.

-----

Notes for the reviewer:

- No `depends_on macos:` version. The app supports 10.13 and up, which is below
  Homebrew's oldest recognised symbol (`:catalina`), so naming one would assert
  a requirement that does not exist. `brew style` autocorrects to
  `depends_on macos: :high_sierra`, which `brew audit` then rejects as disabled;
  bare `depends_on :macos` is what passes both.
- `livecheck` reads the vendor's `latest.json`, so version bumps can be picked up
  automatically.
- The download is a signed and notarised universal DMG served from the vendor's
  own domain.
