### PR TITLE
8bitdo-ultimate-software-v2 1.0.19

### DIFF
--- a/Casks/8/8bitdo-ultimate-software-v2.rb
+++ b/Casks/8/8bitdo-ultimate-software-v2.rb
@@ -1,8 +1,8 @@
 cask "8bitdo-ultimate-software-v2" do
-  version "1.0.17"
-  sha256 "470164410de7a0ecd81e5d171bf497114721c11fabf2df42ffe880104762a5db"
+  version "1.0.19"
+  sha256 "a700ba073d84fb9ba3a8254b2542ebedd3aa6dfb9ce86f2e2dec48b75153bce7"
 
-  url "https://support.8bitdo.com/upfiles/Ultimate-Software-V2/8BitDo_Ultimate_Software_V2_macOS_V#{version}.zip"
+  url "https://support.8bitdo.com/bd-uploads/files/ultimate_soft/8BitDo_Ultimate_Software_V2_macOS_V#{version}.zip"
   name "8BitDo Ultimate Software V2"
   desc "Control every piece of your controller"
   homepage "https://app.8bitdo.com/Ultimate-Software-V2/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`8bitdo-ultimate-software-v2` is autobumped but the workflow failed to update to version 1.0.19 because the asset URL path is different for this version. This updates the version and `url` accordingly.