### PR TITLE
fredm-fuse 1.9.1

### DIFF
--- a/Casks/f/fredm-fuse.rb
+++ b/Casks/f/fredm-fuse.rb
@@ -1,6 +1,6 @@
 cask "fredm-fuse" do
-  version "1.9.0"
-  sha256 "461a61cdc1f83577433bcdd96b002216202420fcc559ff0c9bd5a580eababe9b"
+  version "1.9.1"
+  sha256 "5102f43a447bb805092ae80741b79b6c07a96e1076bea07430905ccfd880325e"
 
   url "https://downloads.sourceforge.net/fuse-for-macosx/fuse-for-macosx/#{version}/FuseForMacOS-#{version}.zip",
       verified: "downloads.sourceforge.net/fuse-for-macosx/"
@@ -10,7 +10,7 @@ cask "fredm-fuse" do
 
   depends_on macos: :ventura
 
-  app "Fuse for MacOS/Fuse.app"
+  app "Fuse for macOS/Fuse.app"
 
   zap trash: "~/Library/Preferences/net.sourceforge.fuse-for-macosx.Fuse.plist"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`fredm-fuse` is autobumped but the workflow failed to update to version 1.9.1 because the capitalization in the directory name is different in this version. This updates the version and `app` value accordingly.