### PR TITLE
diversion (new cask)

### DIFF
--- a/Casks/d/diversion.rb
+++ b/Casks/d/diversion.rb
@@ -1,18 +1,23 @@
 cask "diversion" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "arm64", intel: "amd64"
 
-  # Diversion publishes one "latest" binary per platform and the agent updates
-  # itself, so there is no pinned version or checksum. version :latest already
-  # tells Homebrew not to manage versions, so auto_updates is omitted.
-  version :latest
-  sha256 :no_check
+  version "1.0.943"
+  sha256 arm:   "f4f6e292ae30fb585a252734efdda2b388176c759f131e1cd0f2a36d28f1fbcc",
+         intel: "5b4ab239f779fa3165b0a4f322453ad103e051a87eeb01a995a3cfd24c047170"
 
-  url "https://dv-binaries.s3.us-east-2.amazonaws.com/darwin_#{arch}/dv"
+  url "https://get.diversion.dev/update/dv/v#{version}/darwin-#{arch}.gz"
   name "Diversion CLI"
   desc "Cloud-native version control CLI and agent"
   homepage "https://www.diversion.dev/"
 
-  binary "dv"
+  livecheck do
+    url "https://get.diversion.dev/update/dv/darwin-arm64.json"
+    strategy :json do |json|
+      json["Version"]&.sub(/^v/, "")
+    end
+  end
+
+  binary "darwin-#{arch}", target: "dv"
 
   uninstall launchctl: "diversion.dv.agent"
 

--- a/Casks/d/diversion.rb
+++ b/Casks/d/diversion.rb
@@ -17,9 +17,15 @@ cask "diversion" do
     end
   end
 
+  depends_on macos: :big_sur
+
   binary "darwin-#{arch}", target: "dv"
 
   uninstall launchctl: "diversion.dv.agent"
 
-  zap trash: "~/Library/LaunchAgents/diversion.dv.agent.plist"
+  zap trash: [
+    "~/.diversion",
+    "~/Library/Caches/diversion",
+    "~/Library/LaunchAgents/diversion.dv.agent.plist",
+  ]
 end

--- a/Casks/d/diversion.rb
+++ b/Casks/d/diversion.rb
@@ -1,0 +1,20 @@
+cask "diversion" do
+  arch arm: "arm64", intel: "x86_64"
+
+  # Diversion publishes one "latest" binary per platform and the agent updates
+  # itself, so there is no pinned version or checksum. version :latest already
+  # tells Homebrew not to manage versions, so auto_updates is omitted.
+  version :latest
+  sha256 :no_check
+
+  url "https://dv-binaries.s3.us-east-2.amazonaws.com/darwin_#{arch}/dv"
+  name "Diversion CLI"
+  desc "Cloud-native version control CLI and agent"
+  homepage "https://www.diversion.dev/"
+
+  binary "dv"
+
+  uninstall launchctl: "diversion.dv.agent"
+
+  zap trash: "~/Library/LaunchAgents/diversion.dv.agent.plist"
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.


- [X] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.
