### PR TITLE
unnaturalscrollwheels: update to 1.4.2

### DIFF
--- a/Casks/u/unnaturalscrollwheels.rb
+++ b/Casks/u/unnaturalscrollwheels.rb
@@ -1,6 +1,6 @@
 cask "unnaturalscrollwheels" do
   version "1.4.2"
-  sha256 "a79900a08f02405a1f90eb701058f86e60726f682cf82bd51ee07932d258b0f8"
+  sha256 "b75c3e5ebb13f94053e593d33f4e1019327d7cb60342214beae65aab7843eb88"
 
   url "https://github.com/ther0n/UnnaturalScrollWheels/releases/download/#{version}/UnnaturalScrollWheels-#{version}.dmg"
   name "UnnaturalScrollWheels"


### PR DESCRIPTION
---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version.
- [x] brew audit --cask --online unnaturalscrollwheels is error-free (verified locally).
- [x] brew style --fix Casks/u/unnaturalscrollwheels.rb reports no offenses.

---

Update checksum for UnnaturalScrollWheels 1.4.2 to match the DMG signed with the new certificate.

The previous checksum (a79900a...) was for the DMG signed with the old certificate. This update ensures Homebrew installs the correct DMG.

Verified:
- Checksum matches the 1.4.2 DMG from GitHub releases.
- brew style --fix passes.
