### PR TITLE
unity-cli: fix homepage URL

### DIFF
--- a/Casks/u/unity-cli.rb
+++ b/Casks/u/unity-cli.rb
@@ -21,7 +21,7 @@ cask "unity-cli" do
   url "https://public-cdn.cloud.unity3d.com/hub/prod/cli/#{version}/unity-#{os}-#{arch}"
   name "Unity CLI"
   desc "Command-line interface for Unity"
-  homepage "https://docs.unity.com/en-us/cli"
+  homepage "https://docs.unity.com/en-us/unity-cli"
 
   livecheck do
     url "https://public-cdn.cloud.unity3d.com/hub/prod/cli/latest-beta.json"


### PR DESCRIPTION
Important: *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

In the following questions `<cask>` is the name of the cask you submitted.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
- [ ] Checked there are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same cask.
- [ ] Checked the cask was not already refused (add the word "cask" after the name of the software when searching [closed issues](https://github.com/Homebrew/homebrew-cask/issues?q=is%3Aissue+is%3Aclosed) and [rejected pull requests](https://github.com/Homebrew/homebrew-cask/prs?q=is%3Apr+is%3Aclosed)).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).

---

The homepage pointed at `https://docs.unity.com/en-us/cli`, which renders "Page not found". The correct documentation path is `https://docs.unity.com/en-us/unity-cli`. I maintain this software at Unity.