### PR TITLE
tentacle-sync-studio: fix download URL

### DIFF
--- a/Casks/t/tentacle-sync-studio.rb
+++ b/Casks/t/tentacle-sync-studio.rb
@@ -2,7 +2,7 @@ cask "tentacle-sync-studio" do
   version "1.37"
   sha256 "383cd519b647594254ffc6deb744e47c5f939932d96711a60158e6e40d2fe16e"
 
-  url "https://cms.tentaclesync.com/assets/ttsyncstudio-v#{version.dots_to_underscores}.dmg"
+  url "https://cms.tentaclesync.com/assets/downloads/download-files/ttsyncstudio-v#{version.dots_to_underscores}.dmg"
   name "Tentacle Sync Studio"
   desc "Automatically synchronise video and audio via timecode"
   homepage "https://tentaclesync.com/"


### PR DESCRIPTION
Upstream moved the DMG from `/assets/` to `/assets/downloads/download-files/`; the old URL now returns 404. Same version (1.37) and unchanged sha256.

Built and tested locally on macOS 15.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: URL fix found and drafted with Claude Code (Fable 5); I verified the new URL, matching sha256, and a successful `brew install` locally.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----