### PR TITLE
unnaturalscrollwheels: update checksum

### DIFF
--- a/Casks/u/unnaturalscrollwheels.rb
+++ b/Casks/u/unnaturalscrollwheels.rb
@@ -1,6 +1,6 @@
 cask "unnaturalscrollwheels" do
   version "1.4.2"
-  sha256 "a79900a08f02405a1f90eb701058f86e60726f682cf82bd51ee07932d258b0f8"
+  sha256 "b75c3e5ebb13f94053e593d33f4e1019327d7cb60342214beae65aab7843eb88"
 
   url "https://github.com/ther0n/UnnaturalScrollWheels/releases/download/#{version}/UnnaturalScrollWheels-#{version}.dmg"
   name "UnnaturalScrollWheels"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

---

### Description
Update checksum for UnnaturalScrollWheels 1.4.2 to match the DMG signed with the new certificate.

**Why?**
The previous checksum (a79900a...) was for the DMG signed with the old certificate. This update ensures Homebrew installs the correct DMG for version 1.4.2.

**Verification:**
1. Downloaded the 1.4.2 DMG from GitHub releases:
   curl -L https://github.com/ther0n/UnnaturalScrollWheels/releases/download/1.4.2/UnnaturalScrollWheels-1.4.2.dmg -o UnnaturalScrollWheels-1.4.2.dmg
2. Confirmed the new SHA-256:
   shasum -a 256 UnnaturalScrollWheels-1.4.2.dmg
   Output: b75c3e5ebb13f94053e593d33f4e1019327d7cb60342214beae65aab7843eb88
3. Verified brew style --fix Casks/u/unnaturalscrollwheels.rb passes.
4. Temporarily added the cask to a local tap and ran brew audit --cask --online unnaturalscrollwheels (no errors).
