### PR TITLE
dynotable 1.4.3 (new cask)

### DIFF
--- a/Casks/d/dynotable.rb
+++ b/Casks/d/dynotable.rb
@@ -1,0 +1,27 @@
+cask "dynotable" do
+  version "1.4.3"
+  sha256 "7a0536b35865e81a607823a690bdcc1e8e35aca519818824f8c7061fdd86bcd9"
+
+  url "https://dynotable.com/api/download/mac/#{version}/DynoTable-darwin-arm64-#{version}.zip"
+  name "DynoTable"
+  desc "GUI client for Amazon DynamoDB with SQL, PartiQL and an AI agent"
+  homepage "https://dynotable.com/"
+
+  livecheck do
+    url "https://dynotable.com/api/version"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  depends_on arch: :arm64
+  depends_on macos: :monterey
+
+  app "DynoTable.app"
+
+  zap trash: [
+    "~/Library/Application Support/DynoTable",
+    "~/Library/Preferences/com.dynotable.app.plist",
+    "~/Library/Saved Application State/com.dynotable.app.savedState",
+  ]
+end


### PR DESCRIPTION
DynoTable is a desktop GUI client for Amazon DynamoDB. Homepage: https://dynotable.com

Closed-source and commercial, with a permanent free tier and a 30-day trial of the paid features. The trial activates in place, so the same download is the full version. Comparable casks already in this repo: `dynobase`, `tableplus`, `datagrip`.

- **Signing** — Developer ID, hardened runtime, notarized and stapled. `spctl -a -vvv -t exec` reports `accepted / source=Notarized Developer ID`.
- **Architecture** — Apple Silicon only, hence `depends_on arch: :arm64`. `LSMinimumSystemVersion` in the bundle is 12.0.
- **`url`** — the vendor domain, which 302s to the GitHub release asset. Its SHA256 matches the `SHA256SUMS-macos.txt` published with the release.
- **`livecheck`** — a JSON version endpoint the vendor serves. The release repository is private, so `:github_latest` cannot read it.

Verified locally against the live artifact before submitting:

```
brew style --cask               1 file inspected, no offenses detected
brew audit --cask --new --online   exit 0, no output
brew livecheck --cask           dynotable: 1.4.3 ==> 1.4.3
```