### PR TITLE
dynotable 1.4.3 (new cask)

### DIFF
--- a/Casks/d/dynotable.rb
+++ b/Casks/d/dynotable.rb
@@ -1,0 +1,27 @@
+cask "dynotable" do
+  version "1.4.3"
+  sha256 "7a0536b35865e81a607823a690bdcc1e8e35aca519818824f8c7061fdd86bcd9"
+
+  url "https://dynotable.com/api/download/mac/#{version}/DynoTable-darwin-arm64-#{version}.zip"
+  name "DynoTable"
+  desc "GUI client for Amazon DynamoDB with SQL, PartiQL and an AI agent"
+  homepage "https://dynotable.com/"
+
+  livecheck do
+    url "https://dynotable.com/api/version"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  depends_on arch: :arm64
+  depends_on macos: :monterey
+
+  app "DynoTable.app"
+
+  zap trash: [
+    "~/Library/Application Support/DynoTable",
+    "~/Library/Preferences/com.dynotable.app.plist",
+    "~/Library/Saved Application State/com.dynotable.app.savedState",
+  ]
+end


### PR DESCRIPTION
DynoTable is a desktop GUI client for Amazon DynamoDB. Homepage: https://dynotable.com

Closed-source and commercial, with a permanent free tier and a 30-day trial of the paid features. The trial activates in place, so the same download is the full version. Comparable casks already here: `dynobase`, `tableplus`, `datagrip`.

- **Signing** - Developer ID, hardened runtime, notarized and stapled. `spctl -a -vvv -t exec` reports `accepted / source=Notarized Developer ID`.
- **Architecture** - Apple Silicon only, hence `depends_on arch: :arm64`. `LSMinimumSystemVersion` in the bundle is 12.0.
- **url** - the vendor domain, which 302s to the GitHub release asset. Its SHA256 matches the `SHA256SUMS-macos.txt` published with the release.
- **livecheck** - a JSON version endpoint the vendor serves. The release repository is private, so `:github_latest` cannot read it.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

<details>
<summary>Verification output</summary>

```
$ brew style --cask dynotable
1 file inspected, no offenses detected

$ brew audit --cask --new --online dynotable
(exit 0, no output)

$ brew livecheck --cask dynotable
dynotable: 1.4.3 ==> 1.4.3

$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask dynotable
==> Moving App 'DynoTable.app' to '/Applications/DynoTable.app'
dynotable was successfully installed!

$ brew uninstall --cask dynotable
==> Removing App '/Applications/DynoTable.app'
==> Purging files for version 1.4.3 of Cask dynotable
```

`--new --online` is a superset of `--online`, and `--fix` is a no-op when style reports no
offenses. `zap` paths were checked against the installed app: bundle id `com.dynotable.app`,
Electron `productName` `DynoTable`.

</details>
