### PR TITLE
Update ray from 2.8.2 to 3.2.10

### DIFF
--- a/Casks/r/ray.rb
+++ b/Casks/r/ray.rb
@@ -1,19 +1,12 @@
 cask "ray" do
+  arch arm: "arm64", intel: "x64"
+
   version "3.2.10"
+  sha256 arm:   "8965569f043c36bd7e12decfbb12db1511962b4e7edf423d05599d65c5ccc25a",
+         intel: "dc7a6fbfcfd6029180dfd0181c834124b714ebb249e0472a9ca0de4060dcbfe1"
 
-  on_arm do
-    sha256 "8965569f043c36bd7e12decfbb12db1511962b4e7edf423d05599d65c5ccc25a"
-
-    url "https://ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/stable/ray-#{version}-latest-darwin-arm64.dmg",
-        verified: "ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/"
-  end
-  on_intel do
-    sha256 "dc7a6fbfcfd6029180dfd0181c834124b714ebb249e0472a9ca0de4060dcbfe1"
-
-    url "https://ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/stable/ray-#{version}-latest-darwin-x64.dmg",
-        verified: "ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/"
-  end
-
+  url "https://ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/stable/ray-#{version}-latest-darwin-#{arch}.dmg",
+      verified: "ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/"
   name "Ray"
   desc "Debug with Ray to fix problems faster"
   homepage "https://myray.app/"

--- a/Casks/r/ray.rb
+++ b/Casks/r/ray.rb
@@ -19,8 +19,8 @@ cask "ray" do
   homepage "https://myray.app/"
 
   livecheck do
-    url "https://amazonaws.com"
-    skip "Upstream tracking file is hardcoded to obsolete 2.x stream"
+    url "https://spatie.be/products/ray/v3/download/macos-#{arch}/latest"
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/r/ray.rb
+++ b/Casks/r/ray.rb
@@ -1,20 +1,26 @@
 cask "ray" do
-  arch arm: "-arm64"
-  folder = on_arch_conditional arm: "arm64/"
+  version "3.2.10"
 
-  version "2.8.2"
-  sha256 arm:   "9557ecc4e9758a499b71b324466659a7e1a42d996edf0e1d4353cd2dd6494cee",
-         intel: "f6d9fb9a2721ec72146cc43967f17714a9c0bf9bf1d4744fb930de4b82e50e00"
+  on_arm do
+    sha256 "8965569f043c36bd7e12decfbb12db1511962b4e7edf423d05599d65c5ccc25a"
 
-  url "https://ray-app.s3.amazonaws.com/#{folder}Ray-#{version}#{arch}.dmg",
-      verified: "ray-app.s3.amazonaws.com/"
+    url "https://ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/stable/ray-#{version}-latest-darwin-arm64.dmg",
+        verified: "ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/"
+  end
+  on_intel do
+    sha256 "dc7a6fbfcfd6029180dfd0181c834124b714ebb249e0472a9ca0de4060dcbfe1"
+
+    url "https://ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/stable/ray-#{version}-latest-darwin-x64.dmg",
+        verified: "ray-app.s3.eu-west-1.amazonaws.com/ray-app-updates-v3/"
+  end
+
   name "Ray"
   desc "Debug with Ray to fix problems faster"
   homepage "https://myray.app/"
 
   livecheck do
-    url "https://ray-app.s3.amazonaws.com/latest-mac.yml"
-    strategy :electron_builder
+    url "https://amazonaws.com"
+    skip "Upstream tracking file is hardcoded to obsolete 2.x stream"
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

i did not use AI to create this file directly, but in full disclosure i did use AI to assist me in researching the steps to fixing the Ray cask, which was broken by the 3.x changeover, as i'm new to this process. i left the zap trash stanza alone as i'm not the original developer and am not sure which are used by 3.x (i did verify a number of them, but being a new installation i'm not sure if all of them still apply). the Spatie/Ray team will likely get around to updating this later; they should update the `livecheck` file/url at some point as well, which i don't have access to. if/when this is accepted.

this is an update to an existing cask, but i still did verify that the install/uninstall process worked.