### PR TITLE
cisco-jabber: add homepage browser check

### DIFF
--- a/Casks/c/cisco-jabber.rb
+++ b/Casks/c/cisco-jabber.rb
@@ -5,7 +5,7 @@ cask "cisco-jabber" do
   url "https://binaries.webex.com/jabberclientmac/#{version}/Install_Cisco-Jabber-Mac.pkg"
   name "Cisco Jabber"
   desc "Jabber client from Cisco"
-  homepage "https://www.webex.com/downloads/jabber.html"
+  homepage "https://www.webex.com/downloads/jabber.html", browsed: "2026-08-05"
 
   livecheck do
     url :homepage, user_agent: :browser


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free. (Tested with vpn)
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

~~OpenAI Codex (GPT-5) assisted with diagnosing the installer failures. I reviewed the changes and manually verified successful installation and uninstallation.~~

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The homepage is accessible in a browser but blocks automated requests, causing the [autobump workflow](https://github.com/Homebrew/homebrew-cask/actions/runs/30941028352) to fail.

As introduced in [Homebrew/brew#23307](https://github.com/Homebrew/brew/pull/23307), this adds `browsed:` to the  `homepage` stanza to avoid a homepage audit failure.

Reference: https://docs.brew.sh/Cask-Cookbook#required-stanzas