### PR TITLE
diversion-app: new cask

### DIFF
--- a/Casks/d/diversion-app.rb
+++ b/Casks/d/diversion-app.rb
@@ -1,0 +1,33 @@
+cask "diversion-app" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "0.8.0"
+  sha256 :no_check
+
+  url "https://get.diversion.dev/desktop/mac/#{arch}"
+  name "Diversion Desktop"
+  desc "Desktop app for Diversion version control"
+  homepage "https://www.diversion.dev/"
+
+  livecheck do
+    url "https://download.todesktop.com/240506tnendbebc/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+  depends_on cask: "diversion"
+
+  app "Diversion Desktop.app"
+
+  uninstall quit: "com.todesktop.240506tnendbebc"
+
+  zap trash: [
+    "~/Library/Application Support/Diversion Desktop",
+    "~/Library/Caches/com.todesktop.240506tnendbebc",
+    "~/Library/Caches/com.todesktop.240506tnendbebc.ShipIt",
+    "~/Library/Caches/diversiondesktop-updater",
+    "~/Library/Logs/Diversion Desktop",
+    "~/Library/Preferences/com.todesktop.240506tnendbebc.plist",
+  ]
+end

--- a/Casks/d/diversion-app.rb
+++ b/Casks/d/diversion-app.rb
@@ -1,10 +1,11 @@
 cask "diversion-app" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "arm64", intel: "x64"
 
   version "0.8.0"
-  sha256 :no_check
+  sha256 arm:   "bfee67bdc52f5a47b9d912fbbb14b69453409044ff6ffff87dedc39565add00c",
+         intel: "5a4f1209a991ded636e73d81c2010251bdcf0af0f46339e18cf8bd20bb109d0d"
 
-  url "https://get.diversion.dev/desktop/mac/#{arch}"
+  url "https://download.todesktop.com/240506tnendbebc/Diversion%20Desktop%20#{version}-#{arch}.dmg"
   name "Diversion Desktop"
   desc "Desktop app for Diversion version control"
   homepage "https://www.diversion.dev/"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

-----

- [X] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.
