### PR TITLE
kirocrew 0.1.2 (new cask)

### DIFF
--- a/Casks/k/kirocrew.rb
+++ b/Casks/k/kirocrew.rb
@@ -1,0 +1,26 @@
+cask "kirocrew" do
+  version "0.1.2"
+  sha256 "97197198ef5a569055aaac8fdfccb2f7240f563fdb2272ce48bfe77d50eb0882"
+
+  url "https://download.crew.kiro.dev/desktop/stable/#{version}/KiroCrew.dmg"
+  name "Kiro Crew"
+  desc "Persistent AI development workspace with multi-agent support"
+  homepage "https://kiro.dev/docs/crew/"
+
+  livecheck do
+    url "https://updates.crew.kiro.dev/feed/stable/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+
+  app "KiroCrew.app"
+
+  zap trash: [
+    "~/.kirocrew.breadcrumb",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.amazon.kiro.crew.sfl*",
+    "~/Library/Application Support/kirocrew-electron-mac",
+    "~/Library/Preferences/com.amazon.kiro.crew.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Kiro (w/ Sonnet 5) to implement this cask. However, I found `electron-updater` feed from the app, and also verified zap paths by actually installing, launching, and inspecting `~/Library`.


-----
