### PR TITLE
font-nexon-lv1-gothic (new cask)

### DIFF
--- a/Casks/font/font-n/font-nexon-lv1-gothic.rb
+++ b/Casks/font/font-n/font-nexon-lv1-gothic.rb
@@ -1,0 +1,15 @@
+cask "font-nexon-lv1-gothic" do
+  version :latest
+  sha256 :no_check
+
+  url "https://brand.nexon.com/resources/NEXON_Lv1_Gothic.zip"
+  name "NEXON Lv.1 Gothic"
+  name "넥슨 Lv.1 고딕"
+  homepage "https://brand.nexon.com/ci-brand-guidelines/typeface"
+
+  font "NEXON Lv1 Gothic_OTF_TTF/OTF/NEXON Lv1 Gothic OTF Bold.otf"
+  font "NEXON Lv1 Gothic_OTF_TTF/OTF/NEXON Lv1 Gothic OTF Light.otf"
+  font "NEXON Lv1 Gothic_OTF_TTF/OTF/NEXON Lv1 Gothic OTF.otf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted: Used OpenCode (Claude Opus) for cask file generation. Manually reviewed, tested, and verified all changes including font paths.

-----

Nexon publishes no version number for this typeface, so the cask uses `version :latest`.
