### PR TITLE
upm: remove redundant line continuation

### DIFF
--- a/Casks/u/upm.rb
+++ b/Casks/u/upm.rb
@@ -14,7 +14,7 @@ cask "upm" do
 
   app "upm-mac-#{version}/UPM.app"
 
-  zap trash: "~/Library/Saved Application State/com._17od.upm.gui.MainWindow.savedState" \
+  zap trash: "~/Library/Saved Application State/com._17od.upm.gui.MainWindow.savedState"
 
   caveats do
     requires_rosetta


### PR DESCRIPTION
The `zap` stanza in `upm` ends with a `\` followed by a blank line, so the continuation joins nothing and is a no-op:

```ruby
  zap trash: "~/Library/Saved Application State/com._17od.upm.gui.MainWindow.savedState" \

  caveats do
```

RuboCop 1.89.0 catches this as `Style/RedundantLineContinuation`, where 1.88.2 did not. It is currently the only offense across all 7706 cask files, and it fails the `brew style homebrew/cask` CI job on Homebrew/brew#23452, which bumps RuboCop to 1.89.0.

Removing the `\` does not change what the cask does.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) found this while running `brew style homebrew/cask` against RuboCop 1.89.0 for Homebrew/brew#23452, and applied the `brew style --fix` autocorrect. I reviewed the change and the surrounding `zap` stanza. Verified with `brew style homebrew/cask` (7706 files, no offenses) and `brew audit --cask --online upm`.

-----
