### PR TITLE
muse 0.1.0-R708.1 (new cask)

### DIFF
--- a/Casks/m/muse-code.rb
+++ b/Casks/m/muse-code.rb
@@ -1,0 +1,38 @@
+cask "muse-code" do
+  arch arm: "aarch64", intel: "x86"
+  os macos: "macos", linux: "linux"
+
+  version "0.1.0-R708.1"
+  sha256 arm:          "4290bfafa5bbb81a6fd493aaea12f848c789b1d22edfa0c4b849151deba3e70c",
+         x86_64:       "f76010944413938215134d45198b3fe891c24b8aa4f83001ede0d9273cc85fa1",
+         arm64_linux:  "fa673ab874c25456644574ac52cbb43f23149c0584a46d5a2996ec43081ca262",
+         x86_64_linux: "50937b6470cd0edf28eb683c352a5e7af3bcb1b015cd9a3b21dbf79d22af8182"
+
+  on_macos do
+    depends_on macos: :monterey
+  end
+
+  url "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version=#{version}&file=muse-#{arch}-#{os}",
+      verified: "lookaside.facebook.com/lookaside/muse/"
+  name "Muse Code"
+  desc "Interactive terminal coding agent"
+  homepage "https://dev.meta.ai/"
+
+  livecheck do
+    url "https://api.meta.ai/muse-code/channels/muse-stable"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  container type: :naked
+
+  rename "download", "muse-#{arch}-#{os}"
+
+  binary "muse-#{arch}-#{os}", target: "muse"
+
+  zap trash: [
+    "~/.config/muse",
+    "~/.local/share/muse",
+  ]
+end

--- a/Casks/m/muse.rb
+++ b/Casks/m/muse.rb
@@ -1,4 +1,4 @@
-cask "muse-code" do
+cask "muse" do
   arch arm: "aarch64", intel: "x86"
   os macos: "macos", linux: "linux"
 
@@ -12,8 +12,7 @@ cask "muse-code" do
     depends_on macos: :monterey
   end
 
-  url "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version=#{version}&file=muse-#{arch}-#{os}",
-      verified: "lookaside.facebook.com/lookaside/muse/"
+  url "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version=#{version}&file=muse-#{arch}-#{os}"
   name "Muse Code"
   desc "Interactive terminal coding agent"
   homepage "https://dev.meta.ai/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

OpenAI GPT-5 assisted with release metadata research and the initial cask draft. I manually verified all four artifact checksums, the configuration and data paths in the `zap` stanza, livecheck output, installation, version output, and uninstallation.

-----

Built and tested `muse` locally on macOS 27.0.