### PR TITLE
breakdown 0.9.17

### DIFF
--- a/Casks/b/breakdown.rb
+++ b/Casks/b/breakdown.rb
@@ -1,0 +1,40 @@
+cask "breakdown" do
+  version "0.9.17,550"
+  sha256 "5b63533a12a1d2145bcd76caaf9c5346e5c2cd2f39e56d05c5c9cdf44b93e705"
+
+  url "https://updates.breakdown.live/releases/#{version.csv.first}/#{version.csv.second}/5b63533a12a1d2145bcd76caaf9c5346e5c2cd2f39e56d05c5c9cdf44b93e705-Breakdown-#{version.csv.first}.pkg"
+  name "Breakdown"
+  desc "Diagnoses whether connection trouble is on LAN, ISP path, or app"
+  homepage "https://breakdown.live/"
+
+  livecheck do
+    url "https://updates.breakdown.live/appcast/macos/stable.xml"
+    strategy :sparkle
+  end
+
+  depends_on macos: :ventura
+
+  pkg "Breakdown-#{version.csv.first}.pkg"
+
+  uninstall launchctl: [
+              "com.breakdown.capture-helper",
+              "com.breakdown.menu.autostart",
+            ],
+            quit:      "com.breakdown.menu",
+            pkgutil:   "com.breakdown.menu",
+            delete:    [
+              "/Applications/Breakdown",
+              "/Library/Application Support/Breakdown",
+              "/Library/LaunchAgents/com.breakdown.menu.autostart.plist",
+              "/Library/LaunchDaemons/com.breakdown.capture-helper.plist",
+              "/Library/PrivilegedHelperTools/breakdown_capture_helper",
+              "/var/log/breakdown-capture-helper.log",
+              "/var/run/breakdown-capture-helper.sock",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/Breakdown",
+    "~/Library/LaunchAgents/com.breakdown.menu.autostart.plist",
+    "~/Library/Preferences/com.breakdown.menu.plist",
+  ]
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: I used Hermes Agent with OpenAI GPT-5.6 to draft the cask and troubleshoot CI. I reviewed the package signature, SHA-256, appcast metadata, package identifier, installed paths, vendor uninstall script, `uninstall` stanza, and `zap` paths. `brew style Casks/b/breakdown.rb` reports no offenses. The local online audit cannot run because this Mac's installed Xcode is below Homebrew's current required version, so the audit/install/uninstall boxes remain unchecked until CI verifies them.

Follow-up fixes preserve the original PR commit and correct the downloaded package artifact name and livecheck appcast.

-----
