### PR TITLE
azure-cli 2.89.0 (new cask)

### DIFF
--- a/Casks/a/azure-cli.rb
+++ b/Casks/a/azure-cli.rb
@@ -1,0 +1,28 @@
+cask "azure-cli" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "2.89.0"
+  sha256 arm:   "ac5e8ce16b2355a55a3bea20afee9d3d2dbc1289a18e8aa3625d0b62910124ba",
+         intel: "9b94be70fe95b547b1208c07f3018e8880a5676aaff3335005ab445ab5044792"
+
+  url "https://github.com/Azure/azure-cli/releases/download/azure-cli-#{version}/azure-cli-#{version}-macos-#{arch}.tar.gz",
+      verified: "github.com/Azure/azure-cli/"
+  name "Azure CLI"
+  desc "Microsoft Azure CLI 2.0"
+  homepage "https://docs.microsoft.com/cli/azure/overview"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on :macos
+  depends_on formula: "python@3.14"
+
+  binary "bin/az"
+  bash_completion "completions/bash/az"
+  fish_completion "completions/fish/az.fish"
+  zsh_completion "completions/zsh/_az"
+
+  zap trash: "~/.azure"
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,5 +1,4 @@
 {
-  "azure-cli": "homebrew/core",
   "basex": "homebrew/core",
   "borgbackup": "homebrew/core",
   "chronograf": "homebrew/core",


### PR DESCRIPTION
Adds `azure-cli` as a signed & notarized cask, migrating from the `homebrew-core` formula.

### Why
This cask lets `azure-cli` distribute its official pre-built, Microsoft-signed and Apple-notarized release ([Azure/azure-cli releases](https://github.com/Azure/azure-cli/releases)). The migration is in preparation for broker-based authentication, which will depend on a closed-source component (`pymsalruntime` / `msal[broker]`) that can't be built from source and therefore can't ship via `homebrew-core`. This cask does not bundle that component yet — it ships the same official binary users already receive today.

### Changes
- Add `Casks/a/azure-cli.rb` (version 2.89.0, token `azure-cli`).
- Delete the stale `"azure-cli": "homebrew/core"` entry from `tap_migrations.json`
  (a historical reverse migration that would otherwise shadow this cask and make the `azure-cli` token unreachable).

### Paired PR (must merge together)
This is one half of a coordinated pair. The other half deletes the formula and adds the forward migration:
- homebrew-core: **https://github.com/Homebrew/homebrew-core/pull/297367**

⚠️ **Please coordinate the merge of both PRs together** so the `azure-cli` token has no downtime — as offered by maintainers in #257931.

### Prior maintainer guidance
This approach was confirmed by @bevanjkay in [Homebrew/homebrew-cask#257931](https://github.com/Homebrew/homebrew-cask/pull/257931#issuecomment-4204198281):

> "Yes this is correct. The PR in `homebrew-core` should also add the correct
> migration to the `tap_migrations.json` file. Homebrew maintainers will help to
> coordinate the merging of the PRs to ensure there isn't any downtime for the
> `azure-cli` token."

The interim preview cask lived at [Azure/homebrew-azure-cli](https://github.com/Azure/homebrew-azure-cli).

<hr>

> **Note on audits:**
>
> `brew style` is clean.
> `brew install --cask` / `az version` / `brew uninstall --cask` all pass for 2.89.0.
> `brew audit --cask --new` currently reports only the expected
> `cask token conflicts with an existing homebrew/core formula`, which clears
> once the paired homebrew-core PR (#297367) removes the formula.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI assistance (GitHub Copilot) was used to help prepare the cask file, the tap_migrations.json edit, and this description. All changes were reviewed and validated locally (brew style clean; brew install --cask / az version / brew uninstall --cask verified for 2.89.0). The zap stanza trashes ~/.azure (Azure CLI's user config/cache directory). Commits are not attributed to AI, and I will answer all maintainer questions myself.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
