### PR TITLE
tidelift: undeprecate on Linux

### DIFF
--- a/Casks/t/tidelift.rb
+++ b/Casks/t/tidelift.rb
@@ -8,6 +8,10 @@ cask "tidelift" do
          arm64_linux:  "77b8a890486f0fec45fc306f8ec53f7e8850316969d7577438f5e3d822701bfd",
          x86_64_linux: "6504af5d9ffea4b05325662fa763dc72a3aa549d1b7edafeaa2eff6b6f5580ba"
 
+  on_macos do
+    disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  end
+
   url "https://download.tidelift.com/cli/#{version}/#{os}#{arch}/tidelift"
   name "Tidelift CLI"
   desc "Tool to interact with the Tidelift system"
@@ -17,8 +21,6 @@ cask "tidelift" do
     url "https://download.tidelift.com/cli/index.html"
     regex(%r{href=.*?/cli/(\d+(?:\.\d+)+)/#{os}#{arch}/tidelift}i)
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   binary "tidelift"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

It doesn't really make sense to deprecate/disable this on Linux for that reason.