### PR TITLE
eqbase 1.0.4 (new cask)

### DIFF
--- a/Casks/e/eqbase.rb
+++ b/Casks/e/eqbase.rb
@@ -1,0 +1,30 @@
+cask "eqbase" do
+  version "1.0.4"
+  sha256 "059ebfca8d58f83b7b359ef7f1d99e74e98bbff6fc2c464b15a0f6960c2ffa34"
+
+  url "https://updates.eqbase.app/EQBase-#{version}.dmg"
+  name "EQBase"
+  desc "System-wide audio equalizer and effects"
+  homepage "https://eqbase.app/"
+
+  livecheck do
+    url "https://updates.eqbase.app/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "EQBase.app"
+
+  uninstall launchctl: "com.boldbiscuit.eqbase.helper",
+            delete:    "/Library/Audio/Plug-Ins/HAL/EQBaseDriver.driver"
+
+  zap trash: [
+    "~/Library/Application Support/EQBase",
+    "~/Library/Caches/com.boldbiscuit.eqbase",
+    "~/Library/HTTPStorages/com.boldbiscuit.eqbase",
+    "~/Library/Preferences/com.boldbiscuit.eqbase.plist",
+    "~/Library/WebKit/com.boldbiscuit.eqbase",
+  ]
+end


### PR DESCRIPTION
EQBase is a system-wide equalizer and audio-effects app for macOS (https://eqbase.app). I am the developer. The app ships as a notarized Developer ID DMG with Sparkle auto-updates (hence `auto_updates true`); download URLs are versioned and the Sparkle appcast backs the `livecheck` block. The `uninstall`/`zap` paths match the app's actual install locations and bundle ids (HAL driver, SMAppService helper daemon, user-level state).

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: the cask was drafted with Claude Code (Anthropic, Claude model), using the existing `eqmac` cask as the structural reference. As the app's developer I verified every stanza against the real app: the versioned URL and sha256, the appcast for livecheck, the helper daemon label for `launchctl`, the driver path in `uninstall delete`, and each `zap` path against the actual files the app creates. Audit and style were run locally as checked above. I will answer review comments myself.
