### PR TITLE
amadeus-pro: add no_autobump!

### DIFF
--- a/Casks/a/amadeus-pro.rb
+++ b/Casks/a/amadeus-pro.rb
@@ -8,10 +8,14 @@ cask "amadeus-pro" do
   desc "Multi-purpose audio recorder, editor and converter"
   homepage "https://www.hairersoft.com/pro.html"
 
+  # The homepage is inaccessible from CI and autobump environments,
+  # so we have to skip it in those instances for now.
   livecheck do
     url :homepage
     regex(/Download\s*Amadeus\s*Pro\s*v?(\d+(?:\.\d+)+)/i)
   end
+
+  no_autobump! because: "Livecheck is unreachable in autobump environment"
 
   depends_on :macos
 


### PR DESCRIPTION
Tested with VPN

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The `livecheck` block works successfully in my local environment without a VPN. However, the homepage is inaccessible  through a VPN in both a browser and curl.

As a result, this PR keeps the working `livecheck` block for local use and adds `no_autobump!` to address the following error reported by autobump:

```sh
==> amadeus-pro
Current cask version:     2.8.14
Latest livecheck version: unable to get versions
```
I also looked for an alternative source of version information. The following plist contains the current version:

https://www.hairersoft.com/Downloads/AmadeusPro2.plist

However, it cannot be used by livecheck because requests return a 403 response:

```sh
$ curl -I https://www.hairersoft.com/Downloads/AmadeusPro2.plist
HTTP/2 403
```

Reference:
https://github.com/Homebrew/homebrew-cask/actions/runs/31071435382/job/92520012131
https://github.com/Homebrew/homebrew-cask/pull/277863