### PR TITLE
speakup 1.0.28 (new cask)

### DIFF
--- a/Casks/s/speakup.rb
+++ b/Casks/s/speakup.rb
@@ -1,0 +1,31 @@
+cask "speakup" do
+  version "1.0.28"
+  sha256 "e396fca53cc8c88f8eab855b58a0e8c728a908c728c2f519ec11cce78f4266ae"
+
+  url "https://getspeakup.app/download/SpeakUp-#{version}.dmg",
+      verified: "getspeakup.app/download/"
+  name "SpeakUp Dictation"
+  desc "On-device dictation that types your words into any app"
+  homepage "https://getspeakup.app/"
+
+  livecheck do
+    url "https://getspeakup.app/download/appcast.xml"
+    # The appcast carries both sparkle:shortVersionString (1.0.28) and
+    # sparkle:version (38, the build number), so the default strategy returns
+    # "1.0.28,38". The download URL is keyed on the marketing version alone.
+    strategy :sparkle, &:short_version
+  end
+
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "SpeakUp.app"
+
+  zap trash: [
+    "~/Library/Application Support/SpeakUp",
+    "~/Library/Caches/com.nedelcu.SpeakUp",
+    "~/Library/HTTPStorages/com.nedelcu.SpeakUp",
+    "~/Library/Preferences/com.nedelcu.SpeakUp.plist",
+    "~/Library/Saved Application State/com.nedelcu.SpeakUp.savedState",
+  ]
+end

--- a/Casks/s/speakup.rb
+++ b/Casks/s/speakup.rb
@@ -21,9 +21,16 @@ cask "speakup" do
 
   app "SpeakUp.app"
 
+  # SpeakUp is sandboxed, so nearly all user data lives in the container —
+  # measured at 2.5 GB on a machine with several Whisper models downloaded.
+  # The bare Application Support paths are from older, non-sandboxed builds
+  # and are kept so upgraders are cleaned up too.
   zap trash: [
+    "~/Library/Application Scripts/com.nedelcu.SpeakUp",
+    "~/Library/Application Support/com.nedelcu.SpeakUp",
     "~/Library/Application Support/SpeakUp",
     "~/Library/Caches/com.nedelcu.SpeakUp",
+    "~/Library/Containers/com.nedelcu.SpeakUp",
     "~/Library/HTTPStorages/com.nedelcu.SpeakUp",
     "~/Library/Preferences/com.nedelcu.SpeakUp.plist",
     "~/Library/Saved Application State/com.nedelcu.SpeakUp.savedState",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

**AI disclosure:** the initial cask was drafted with Claude (Opus 5) and I reviewed and verified its output. I checked the `zap` paths against a real install on my machine and corrected them — SpeakUp is sandboxed, so the first draft wrongly targeted the bare `~/Library/Application Support` paths and missed `~/Library/Containers/com.nedelcu.SpeakUp` (2.5 GB of downloaded Whisper models) and `~/Library/Application Support/com.nedelcu.SpeakUp` (547 MB). I deliberately excluded `~/Library/Group Containers/group.com.nedelcu.SpeakUp`: the shipped binary declares no `com.apple.security.application-groups` entitlement (`codesign -d --entitlements`), so the sandboxed Mac app cannot write there at all — that directory belongs to our separate iOS app. I am the developer of SpeakUp and will answer any maintainer questions myself.

SpeakUp Dictation — on-device dictation for macOS that types transcribed speech into any text field. Apple Silicon, macOS 14.6+, signed and notarized Developer ID build (`spctl -a -t install` reports `Notarized Developer ID`). Homepage: https://getspeakup.app/

**Trialware.** SpeakUp runs a 14-day trial and is then unlocked with a license key entered in-app. Per [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks), *"A time-limited trial is eligible only when the same download can be activated as the full version without being downloaded again."* That is the case here — the same DMG is activated in place, nothing is re-downloaded and no separate build exists.

**livecheck.** The Sparkle appcast carries both `sparkle:shortVersionString` (`1.0.28`) and `sparkle:version` (`38`, the build number), so the default strategy returns `1.0.28,38`. The download URL is keyed on the marketing version alone, hence `&:short_version`.

**Arch.** Apple Silicon only — inference runs on the Neural Engine via CoreML, so there is no Intel build.
