### PR TITLE
neon-vision-editor: correct 1.2.3 checksum

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -14,7 +14,7 @@ cask "neon-vision-editor" do
 
   zap trash: [
     "~/Library/Application Scripts/group.h3p.Neon-Vision-Editor",
-    "~/Library/Application Scripts/h3p.Neon-Neon-Vision-Editor*",
+    "~/Library/Application Scripts/h3p.Neon-Vision-Editor*",
     "~/Library/Application Support/NeonVisionEditor",
     "~/Library/Caches/h3p.Neon-Vision-Editor",
     "~/Library/Containers/h3p.Neon-Vision-Editor",

--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,0 +1,25 @@
+cask "neon-vision-editor" do
+  version "1.2.3"
+  sha256 "30da044ccf3e195442e7ba53743024e119fe84788253e71c3d2bd9a613eca478"
+
+  url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
+  name "Neon Vision Editor"
+  desc "Native code and text editor"
+  homepage "https://github.com/h3pdesign/Neon-Vision-Editor"
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Neon Vision Editor.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/group.h3p.Neon-Vision-Editor",
+    "~/Library/Application Scripts/h3p.Neon-Neon-Vision-Editor*",
+    "~/Library/Application Support/NeonVisionEditor",
+    "~/Library/Caches/h3p.Neon-Vision-Editor",
+    "~/Library/Containers/h3p.Neon-Vision-Editor",
+    "~/Library/Group Containers/group.h3p.Neon-Vision-Editor",
+    "~/Library/Logs/NeonVisionEditorUpdater.log",
+    "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
+  ]
+end


### PR DESCRIPTION
## Summary

Correct the SHA-256 for the `neon-vision-editor` 1.2.3 cask.

The original 1.2.3 bump was merged in #279389 with checksum `54dc937c1586152711d362bd99b5afdfed51df43ff873785da8aabe739fbf247`. The GitHub release asset was subsequently replaced by the release workflow, and the currently published `Neon.Vision.Editor.app.zip` has digest `30da044ccf3e195442e7ba53743024e119fe84788253e71c3d2bd9a613eca478`.

This is a checksum-only correction; the version, URL, metadata, artifacts, and zap paths are unchanged. It restores Homebrew install verification for the currently published release asset.

## Validation

- Confirmed the current release asset digest from GitHub: `30da044ccf3e195442e7ba53743024e119fe84788253e71c3d2bd9a613eca478`.
- Confirmed the cask parses and changes only the checksum.