### PR TITLE
neon-vision-editor: correct 1.2.3 checksum

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,6 +1,6 @@
 cask "neon-vision-editor" do
   version "1.2.3"
-  sha256 "54dc937c1586152711d362bd99b5afdfed51df43ff873785da8aabe739fbf247"
+  sha256 "30da044ccf3e195442e7ba53743024e119fe84788253e71c3d2bd9a613eca478"
 
   url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
   name "Neon Vision Editor"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you’re editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online neon-vision-editor` is error-free.
- [ ] `brew style --fix neon-vision-editor` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask’s name to the end of the search field).
- [ ] `brew audit --cask --new neon-vision-editor` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask neon-vision-editor` worked successfully.
- [ ] `brew uninstall --cask neon-vision-editor` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

This PR was prepared with AI assistance using Codex (GPT-5.6). I reviewed the output against the current official cask and published release asset; the diff changes only the checksum and leaves zap paths unchanged. I will personally review and answer maintainer questions.

-----

## Summary

Correct the SHA-256 for neon-vision-editor 1.2.3. The original bump in #279389 used a checksum for an earlier ZIP; the currently published GitHub release asset has digest 30da044ccf3e195442e7ba53743024e119fe84788253e71c3d2bd9a613eca478.

## Validation

- Confirmed the current GitHub release asset digest: 30da044ccf3e195442e7ba53743024e119fe84788253e71c3d2bd9a613eca478.
- Confirmed the diff changes only the SHA-256.