### PR TITLE
mutedeck 4.9.3

### DIFF
--- a/Casks/m/mutedeck.rb
+++ b/Casks/m/mutedeck.rb
@@ -1,7 +1,7 @@
 cask "mutedeck" do
   arch arm: "-arm"
 
-  version "2.8.1"
+  version "4.9.3"
   sha256 :no_check
 
   url "https://releases.mutedeck.com/macos#{arch}/mutedeck-mac#{arch}.dmg"
@@ -10,8 +10,10 @@ cask "mutedeck" do
   homepage "https://mutedeck.com/"
 
   livecheck do
-    url "https://mutedeck.canny.io/api/changelog/feed.rss"
-    regex(/<title>\s*v?(\d+(?:\.\d+)+)[ <"]/i)
+    url "https://releases.r2.mutedeck.com/updates/macos#{arch}/Updates.xml"
+    strategy :xml do |xml|
+      xml.elements["/Updates/PackageUpdate[Name='com.mutedeck.client']/Version"]&.text&.strip
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used OpenAI Codex (GPT-5) for procedural guidance and assistance diagnosing the stale livecheck source. I independently noticed the version mismatch, personally reviewed the version and livecheck changes, and ran livecheck, online audit, and style validation locally. No zap stanza changes were made.

Updates MuteDeck to 4.9.3 and replaces the stale Canny RSS livecheck feed.

The installed app checks both patch-update.json and Updates.xml. This change uses the structured Updates.xml repository metadata because it represents the current full application release, whereas the patch manifest is conditional on an installed minimum version and may not be available for every release.

-----
