### PR TITLE
headroom 0.7.6 (new cask)

### DIFF
--- a/Casks/h/headroom.rb
+++ b/Casks/h/headroom.rb
@@ -1,6 +1,6 @@
 cask "headroom" do
-  version "0.7.5"
-  sha256 "6c31a0511430e2a7b235ca290c4ada1b7de2f8051ccad35c84bc18ecb46abad2"
+  version "0.7.6"
+  sha256 "750b50900964cc3817c6fc9b828b768daba3003f138d9668cd3aa6452a4215e1"
 
   url "https://github.com/gglucass/headroom-desktop/releases/download/v#{version}/Headroom_#{version}_mac.dmg",
       verified: "github.com/gglucass/headroom-desktop/"
@@ -23,12 +23,18 @@ cask "headroom" do
             quit:      "com.extraheadroom.headroom"
 
   zap trash: [
+    "~/.cache/huggingface/hub/.locks/models--chopratejas--kompress-v2-base",
+    "~/.cache/huggingface/hub/models--chopratejas--kompress-v2-base",
     "~/.headroom",
     "~/Library/Application Support/Headroom",
     "~/Library/Caches/com.extraheadroom.headroom",
+    "~/Library/HTTPStorages/com.extraheadroom.headroom",
+    "~/Library/HTTPStorages/com.extraheadroom.headroom.binarycookies",
     "~/Library/LaunchAgents/com.extraheadroom.headroom.plist",
     "~/Library/LaunchAgents/Headroom.plist",
+    "~/Library/Logs/Headroom",
     "~/Library/Preferences/com.extraheadroom.headroom.plist",
     "~/Library/Saved Application State/com.extraheadroom.headroom.savedState",
+    "~/Library/WebKit/com.extraheadroom.headroom",
   ]
 end

--- a/Casks/h/headroom.rb
+++ b/Casks/h/headroom.rb
@@ -23,8 +23,6 @@ cask "headroom" do
             quit:      "com.extraheadroom.headroom"
 
   zap trash: [
-    "~/.cache/huggingface/hub/.locks/models--chopratejas--kompress-v2-base",
-    "~/.cache/huggingface/hub/models--chopratejas--kompress-v2-base",
     "~/.headroom",
     "~/Library/Application Support/Headroom",
     "~/Library/Caches/com.extraheadroom.headroom",

--- a/Casks/h/headroom.rb
+++ b/Casks/h/headroom.rb
@@ -1,0 +1,34 @@
+cask "headroom" do
+  version "0.7.5"
+  sha256 "6c31a0511430e2a7b235ca290c4ada1b7de2f8051ccad35c84bc18ecb46abad2"
+
+  url "https://github.com/gglucass/headroom-desktop/releases/download/v#{version}/Headroom_#{version}_mac.dmg",
+      verified: "github.com/gglucass/headroom-desktop/"
+  name "Headroom"
+  desc "Reduce token usage for Claude Code and Codex"
+  homepage "https://extraheadroom.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  app "Headroom.app"
+
+  uninstall launchctl: "com.extraheadroom.headroom",
+            quit:      "com.extraheadroom.headroom"
+
+  zap trash: [
+    "~/.headroom",
+    "~/Library/Application Support/Headroom",
+    "~/Library/Caches/com.extraheadroom.headroom",
+    "~/Library/LaunchAgents/com.extraheadroom.headroom.plist",
+    "~/Library/LaunchAgents/Headroom.plist",
+    "~/Library/Preferences/com.extraheadroom.headroom.plist",
+    "~/Library/Saved Application State/com.extraheadroom.headroom.savedState",
+  ]
+end

--- a/Casks/h/headroom.rb
+++ b/Casks/h/headroom.rb
@@ -2,8 +2,7 @@ cask "headroom" do
   version "0.7.6"
   sha256 "750b50900964cc3817c6fc9b828b768daba3003f138d9668cd3aa6452a4215e1"
 
-  url "https://github.com/gglucass/headroom-desktop/releases/download/v#{version}/Headroom_#{version}_mac.dmg",
-      verified: "github.com/gglucass/headroom-desktop/"
+  url "https://github.com/gglucass/headroom-desktop/releases/download/v#{version}/Headroom_#{version}_mac.dmg"
   name "Headroom"
   desc "Reduce token usage for Claude Code and Codex"
   homepage "https://extraheadroom.com/"


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

**AI/LLM disclosure.** The cask file and this description were drafted with Claude Code (Claude Opus 5). I reviewed the output rather than taking it as given, and the `zap` paths specifically were checked against a real install on a clean macOS VM instead of being accepted as generated. That check is what found the four paths that were missing, and what confirmed each remaining path actually exists after real use. No commit on this branch attributes authorship to AI. Maintainer questions and review comments I answer myself.

-----

## Notes for reviewers

**Version.** Now 0.7.6, bumped from the 0.7.5 in the original PR title. `brew audit --cask --new --strict --online` fails when `version` differs from what `livecheck` resolves, so the cask tracks the current release.

**Token.** Originally submitted as `headroom-desktop` after the upstream repo name. Renamed to `headroom` for the token reference rule against tokens ending in `desktop`. Worth noting for other submitters: that rule is `--new`-only, so a plain `brew audit --cask --strict` run does not catch it.

**How the install/uninstall checks were run.** The literal `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask headroom` cannot resolve a cask that is not yet in the tap, so both checks were run against a scratch tap on a clean macOS VM with no prior Headroom install:

```
brew tap-new <user>/casktest --no-git
cp headroom.rb "$(brew --repo <user>/casktest)/Casks/h/headroom.rb"
brew install --cask <user>/casktest/headroom     # launched, no Gatekeeper prompt
brew uninstall --cask <user>/casktest/headroom   # clean
```

**On the `uninstall` and `zap` stanzas.** These were verified empirically rather than guessed, by snapshotting the filesystem, `launchctl`, listening ports, keychain, and the app's config-file edits on the VM before install, after install and first launch, and again after uninstall.

Two results worth stating explicitly, since neither is visible from the cask alone:

1. `quit: "com.extraheadroom.headroom"` is doing real work, not just closing a window. The app's quit handler reverts its own routing changes, so a plain `brew uninstall --cask` leaves no stale `ANTHROPIC_BASE_URL` in the user's agent config and no dangling shell-rc block or hook script. Without the `quit:` directive those would survive and point at a proxy that no longer exists.
2. Every `zap` path was confirmed to actually exist after real use. Four were added after the VM test showed them surviving uninstall: `~/Library/Logs/Headroom`, `~/Library/WebKit/...`, and the two `~/Library/HTTPStorages/...` entries.

**On the removed HuggingFace paths** (`ae4ef57`, in response to @bevanjkay's review). The VM test also found the app's model snapshot under `~/.cache/huggingface/hub/`, and two entries for it were briefly listed. They have been removed, because the objection holds on two counts: that directory belongs to `huggingface_hub` and is shared with every other tool the user runs, and `huggingface_hub` honours `$HF_HUB_CACHE`, which this app does not set — so the hardcoded path is correct only by default and would silently miss for anyone who has relocated their cache. For what it is worth, no cask in this repo currently deletes a path inside another tool's cache namespace; the 24 that zap under `~/.cache` all use their own. The app's own uninstall still removes the model, where it can resolve the real cache location at runtime instead of hardcoding a guess.

`depends_on macos: :sonoma` and `depends_on arch: :arm64` match the shipped build: `minimumSystemVersion` is 14.0 and only an `aarch64-apple-darwin` bundle is published.

`auto_updates true` is accurate. The app has a built-in updater, so it can move ahead of the cask between bumps. The `livecheck` block with `strategy :github_latest` is there so BrewTestBot can keep `version` and `sha256` current.

**Trial and eligibility.** The app has a 7-day trial and then requires a paid subscription. Per [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks), this is the eligible shape: one signed, notarized DMG that activates in place, with no second download or separate "full version" artifact. Happy to point at whatever specific wording is most useful if that needs confirming.
