### PR TITLE
awesun 16.6.0.32198

### DIFF
--- a/Casks/a/awesun.rb
+++ b/Casks/a/awesun.rb
@@ -2,11 +2,11 @@ cask "awesun" do
   arch arm: "arm64", intel: "x86_64"
   livecheck_id = on_arch_conditional arm: "_ARM"
 
-  version "16.5.0.30905"
-  sha256 arm:   "1265c59faa0e66d66b4504495b38506d7a9628be63ec577f50ea3332cfd9748e",
-         intel: "14ef421eb76593f4034bb5c50a2ce35c29b69c10a55f34641de47f1d195d5661"
+  version "16.6.0.32198"
+  sha256 arm:   "77620f879d6b1b325d75afac647cb94dc0b74d6b0f4d1348794e1a27875c7c2b",
+         intel: "a51362ff9791e0542dccd75de917e85ce5ac6a77dcf2d89a74aa38797c578f75"
 
-  url "https://dw.oray.com/sl/mac/AweSun_v#{version}_#{arch}.dmg"
+  url "https://d-cdn.oray.com/sl/mac/AweSun_#{version}_#{arch}.dmg"
   name "Sunlogin Client"
   name "向日葵个人版"
   desc "Remote desktop control and monitoring tool"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`awesun` is autobumped but the workflow failed to update to version 16.6.0.32198 because the subdomain for the asset URL changed. This updates the version and switches the `url` to the one referenced in the JSON data from the `livecheck` block URL.