### PR TITLE
orcasheets 26.8.1

### DIFF
--- a/Casks/o/orcasheets.rb
+++ b/Casks/o/orcasheets.rb
@@ -1,9 +1,9 @@
 cask "orcasheets" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "26.7.1"
-  sha256 arm:   "9c0a1602cc16b34742e3dfcf296583bed20343cf680dbe0a93c42e6733b7e6a9",
-         intel: "548c2ba2bcbd2dff3522828226ba8d97d9fa5faea2b5f57c384b8a71ca584c47"
+  version "26.8.1"
+  sha256 arm:   "82d68c8ed64bd83359ccc7cfd19760a1e0ac3b7d793e29b4891bfe86338ed807",
+         intel: "7ac6674a85c67b9101a0623a5fc5173ac94727fafb615eb6e72ea3d57001c30c"
 
   url "https://github.com/dataorchestration/homebrew-orcasheets/releases/download/#{version}/orcasheets_#{version}_#{arch}.dmg",
       verified: "github.com/dataorchestration/homebrew-orcasheets/"
@@ -18,7 +18,7 @@ cask "orcasheets" do
 
   depends_on macos: :big_sur
 
-  app "OrcaSheets.app"
+  app "orcasheets.app"
 
   zap trash: "~/Library/Application Support/OrcaSheets"
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`orcasheets` is autobumped but the workflow failed to update to version 26.8.1 because the app name in the dmg is "orcasheets.app" (e.g., when listing the files in the mounted volume in a terminal), though the app visually appears as "OrcaSheets.app" when viewing the app in the Finder. This updates the version and `app` value accordingly.