### PR TITLE
osaurus 0.22.17

### DIFF
--- a/Casks/o/osaurus.rb
+++ b/Casks/o/osaurus.rb
@@ -1,6 +1,6 @@
 cask "osaurus" do
-  version "0.22.15"
-  sha256 "93368bd8da9d356973148db09b2b75375a8c59dda494b58f22d500b669dfadd1"
+  version "0.22.17"
+  sha256 "e4f031f00ab4d41a9fa2d6f629910476b39659d5189b243bd00fda3fa21a1a52"
 
   url "https://github.com/osaurus-ai/osaurus/releases/download/#{version}/Osaurus-#{version}.dmg",
       verified: "github.com/osaurus-ai/osaurus/"
@@ -16,8 +16,8 @@ cask "osaurus" do
   depends_on macos: :sequoia
   depends_on arch: :arm64
 
-  app "Osaurus.app"
-  binary "#{appdir}/Osaurus.app/Contents/Helpers/osaurus"
+  app "osaurus.app"
+  binary "#{appdir}/osaurus.app/Contents/Helpers/osaurus"
 
   uninstall quit: "com.dinoki.osaurus"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`osaurus` is autobumped but the workflow failed to update to version 0.22.17 because the app name in the dmg is "osaurus.app" (e.g., when listing the files in the mounted volume in a terminal), though the app visually appears as "Osaurus.app" when viewing it in the Finder. This updates the version and `app` value accordingly.