### PR TITLE
pally 0.1.14,181.1

### DIFF
--- a/Casks/p/pally.rb
+++ b/Casks/p/pally.rb
@@ -1,26 +1,29 @@
 cask "pally" do
-  version "1.99.1"
-  sha256 :no_check
+  version "0.1.14,181.1"
+  sha256 "7ef44a98e3fd4685d5a024173da38b4dab3d45cb2b9698129e8801500d2c722f"
 
-  url "https://pally.com/sparkle/Pally-Installer-Latest.dmg"
-  name "Pally"
-  desc "AI Relationship Management"
+  url "https://downloads.pally.com/companion/Pally-#{version.csv.first}-#{version.csv.second}.dmg"
+  name "Pally Companion"
+  desc "Companion app for the Pally personal assistant"
   homepage "https://pally.com/"
 
   livecheck do
-    url "https://sparkle-pally-updates.pages.dev/appcast.xml"
-    strategy :sparkle, &:short_version
+    url "https://downloads.pally.com/companion/appcast.xml"
+    strategy :sparkle do |item|
+      "#{item.short_version},#{item.version}"
+    end
   end
 
   auto_updates true
-  depends_on macos: :sonoma
+  depends_on macos: :ventura
 
-  app "Pally.app"
+  app "PallyCompanion.app"
 
   zap trash: [
-    "~/Library/Application Support/Pally",
-    "~/Library/Caches/pally.Pally",
-    "~/Library/Preferences/pally.Pally.plist",
-    "~/Library/Saved Application State/pally.Pally.savedState",
+    "~/Library/Application Support/pallykit",
+    "~/Library/Caches/com.pally.companion-kit",
+    "~/Library/Logs/pallykit",
+    "~/Library/Preferences/com.pally.companion-kit.plist",
+    "~/Library/Saved Application State/com.pally.companion-kit.savedState",
   ]
 end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: this PR was prepared with Claude (Anthropic) assistance under my direction; I work at Pally, the vendor of this app. Every stanza was verified against the real artifact: the DMG at the new URL was downloaded and its `sha256` computed from the file; the DMG was mounted to confirm the `app` bundle name (`PallyCompanion.app`), bundle id (`com.pally.companion-kit`), and `LSMinimumSystemVersion` (13.0 → `:ventura`); the `zap` paths come from the app's source (it writes `~/Library/Application Support/pallykit` and `~/Library/Logs/pallykit`) plus the standard per-bundle-id preferences/caches/saved-state locations; `brew style` and `brew audit --cask --online` both pass clean. I will answer review comments myself.

-----

**Context (I work at Pally, the vendor):** the app this cask previously pointed at was replaced by the current Pally Companion app for Mac. The old download URL (`pally.com/sparkle/Pally-Installer-Latest.dmg`) 404'd for a while; we've restored it as a 301 to the current installer, but this PR points the cask at the canonical versioned artifact instead, which also upgrades it from `sha256 :no_check` on a mutable URL to a pinned checksum on an immutable per-version URL.

Changes:
- Versioned URL `downloads.pally.com/companion/Pally-<version>-<build>.dmg` (same registrable domain as the homepage) with a real `sha256`, replacing the unversioned `:no_check` URL. The version string changes from `1.99.1` to `0.1.14,181.1` (short version + Sparkle build number) because this is a different app line from the vendor — not a downgrade of the old app.
- `livecheck` against the app's production Sparkle appcast (`downloads.pally.com/companion/appcast.xml`), emitting `short_version,version` to match.
- `app "PallyCompanion.app"`; `zap` paths updated to the new app's actual locations.
- `depends_on macos: :ventura` per the app's `LSMinimumSystemVersion` of 13.0.

The DMG and app are Developer ID signed and notarized (stapled).
