### PR TITLE
kotlin-lsp: use current server executable

### DIFF
--- a/Casks/k/kotlin-lsp.rb
+++ b/Casks/k/kotlin-lsp.rb
@@ -19,7 +19,7 @@ cask "kotlin-lsp" do
     strategy :github_latest
   end
 
-  binary "kotlin-server-#{version}/kotlin-lsp.sh", target: "kotlin-lsp"
+  binary "kotlin-server-#{version}/bin/intellij-server", target: "kotlin-lsp"
 
   # No zap stanza required
 end


### PR DESCRIPTION
The existing cask links to the deprecated `kotlin-lsp.sh` launcher, which prints:

```log
WARNING: kotlin-lsp.sh is deprecated and will be removed in a future release. Use bin/intellij-server instead.
```

This PR follows that suggestion and links `bin/intellij-server` as `kotlin-lsp`.

AI disclosure: OpenCode with GPT-5.6-sol assisted with this PR. I reviewed and tested the change.