### PR TITLE
kotlin-lsp: use current server executable

### DIFF
--- a/Casks/k/kotlin-lsp.rb
+++ b/Casks/k/kotlin-lsp.rb
@@ -19,7 +19,7 @@ cask "kotlin-lsp" do
     strategy :github_latest
   end
 
-  binary "kotlin-server-#{version}/kotlin-lsp.sh", target: "kotlin-lsp"
+  binary "kotlin-server-#{version}/bin/intellij-server", target: "kotlin-lsp"
 
   # No zap stanza required
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

AI disclosure: OpenCode with GPT-5.6-sol assisted with this PR. I reviewed and tested the change.

-----

The existing cask links to the deprecated `kotlin-lsp.sh` launcher, which prints:

```log
WARNING: kotlin-lsp.sh is deprecated and will be removed in a future release. Use bin/intellij-server instead.
```

This PR follows that suggestion and links bin/intellij-server as kotlin-lsp.