### PR TITLE
space-rabbit 2.2.3 (new cask)

### DIFF
--- a/Casks/s/space-rabbit.rb
+++ b/Casks/s/space-rabbit.rb
@@ -1,0 +1,19 @@
+cask "space-rabbit" do
+  version "2.2.3"
+  sha256 "d25e661b589270b06d741ddf1c53ce1ea41272823b1c49fffcd2d28efd77b741"
+
+  url "https://github.com/Tahul/space-rabbit/releases/download/v#{version}/Space-Rabbit.dmg"
+  name "Space Rabbit"
+  desc "Removes animations when switching between Spaces"
+  homepage "https://space-rabbit.app/"
+
+  auto_updates true
+  depends_on macos: :sequoia
+
+  app "Space Rabbit.app"
+
+  uninstall quit:       "app.spacerabbit",
+            login_item: "Space Rabbit"
+
+  zap trash: "~/Library/Preferences/app.spacerabbit.plist"
+end


### PR DESCRIPTION
New cask for [Space Rabbit](https://space-rabbit.app/), a menu bar utility that removes the animation when switching macOS Spaces. Source: https://github.com/Tahul/space-rabbit (MPL-2.0, 274 stars).

A few notes on the stanzas:

- Signed and notarized by `Developer ID Application: Prose Foundation (48D3M857Z7)`.
- `LSMinimumSystemVersion` in the bundle is `15.0`, hence `depends_on macos: :sequoia`.
- The app has its own updater: it polls `api.github.com/repos/Tahul/space-rabbit/releases/latest` and installs on confirmation, so `auto_updates true`.
- For the `zap` stanza I installed the cask, launched the app, used it, quit it, and diffed `~/Library`. The only thing it creates is `~/Library/Preferences/app.spacerabbit.plist`, so that is the only path I listed. It also writes `com.apple.dock autohide-time-modifier` if you enable "Instant Dock hide", but I deliberately left that out of `zap` since it is Apple's domain, not the app's.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Disclosure: I used Claude Code (Opus 5) to draft the cask file. I reviewed every stanza myself and verified each one on my own machine rather than taking the draft at face value:

- `sha256` checked against the `digest` GitHub reports for the release asset.
- `depends_on` checked against `LSMinimumSystemVersion` in the app's `Info.plist`.
- `auto_updates` checked by finding the update endpoint in the binary and the update strings in `Localizable.strings`.
- `zap` paths checked empirically as described above; the draft had originally suggested `~/Library/Caches/app.spacerabbit` and `~/Library/HTTPStorages/app.spacerabbit` as well, and I removed both because the app never creates them.
- Ran the full audit/style/install/uninstall cycle locally.

This is my only AI-assisted PR open. The commit is authored by me, with no AI attribution, and I will handle review comments myself.

-----
