### PR TITLE
dehelper: fix url and update zap stanza

### DIFF
--- a/Casks/d/dehelper.rb
+++ b/Casks/d/dehelper.rb
@@ -2,16 +2,16 @@ cask "dehelper" do
   version :latest
   sha256 :no_check
 
-  url "https://static.eudic.net/pkg/dhmac.dmg",
+  url "https://static.eudic.net/pkg/dhmac.dmg?version",
       user_agent: :fake
   name "Dehelper"
   name "德语助手"
   desc "Chinese-German dictionary"
   homepage "https://www.eudic.net/v4/de/app/dehelper"
 
-  depends_on :macos
+  depends_on macos: :big_sur
 
-  app "dehelper.app"
+  app "Dehelper.app"
 
   uninstall quit: [
     "com.eusoft.dehelper",
@@ -19,16 +19,19 @@ cask "dehelper" do
   ]
 
   zap trash: [
-    "~/Library/Application Scripts/com.eusoft.dehelper.QuickLook",
+    "~/Library/Application Scripts/7L3ARZ2SN3.com.eusoft.dehelper",
     "~/Library/Caches/com.eusoft.dehelper",
     "~/Library/Caches/com.eusoft.dehelper.LightPeek",
     "~/Library/Containers/com.eusoft.dehelper.QuickLook",
     "~/Library/Eudb_de",
+    "~/Library/Group Containers/7L3ARZ2SN3.com.eusoft.dehelper",
     "~/Library/HTTPStorages/com.eusoft.dehelper",
-    "~/Library/HTTPStorages/com.eusoft.dehelper.binarycookies",
+    "~/Library/HTTPStorages/com.eusoft.dehelper.LightPeek",
+    "~/Library/Mobile Documents/iCloud~com~eusoft~dehelper~Document",
     "~/Library/Preferences/com.eusoft.dehelper.LightPeek.plist",
     "~/Library/Preferences/com.eusoft.dehelper.plist",
     "~/Library/Preferences/group.com.eusoft.dehelper.plist",
     "~/Library/WebKit/com.eusoft.dehelper",
+    "~/Library/WebKit/com.eusoft.dehelper.LightPeek",
   ]
 end


### PR DESCRIPTION
Fixes HTTP 410 by adding `?version` to the download URL, consistent with the `eudic` cask from the same vendor.

Also updates `zap` paths based on the actual files created by the current version of the app.
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
