### PR TITLE
neon-vision-editor: update 1.2.5

### DIFF
--- a/Casks/n/neon-vision-editor.rb
+++ b/Casks/n/neon-vision-editor.rb
@@ -1,0 +1,25 @@
+cask "neon-vision-editor" do
+  version "1.2.5"
+  sha256 "24755972145d1fc4a299fd02788da878265a2c64712cf9cc2c51bcc4505685ff"
+
+  url "https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v#{version}/Neon.Vision.Editor.app.zip"
+  name "Neon Vision Editor"
+  desc "Native code and text editor"
+  homepage "https://github.com/h3pdesign/Neon-Vision-Editor"
+
+  auto_updates true
+  depends_on macos: :sonoma
+
+  app "Neon Vision Editor.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/group.h3p.Neon-Vision-Editor",
+    "~/Library/Application Scripts/h3p.Neon-Vision-Editor*",
+    "~/Library/Application Support/NeonVisionEditor",
+    "~/Library/Caches/h3p.Neon-Vision-Editor",
+    "~/Library/Containers/h3p.Neon-Vision-Editor",
+    "~/Library/Group Containers/group.h3p.Neon-Vision-Editor",
+    "~/Library/Logs/NeonVisionEditorUpdater.log",
+    "~/Library/Preferences/h3p.Neon-Vision-Editor.plist",
+  ]
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you are editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online neon-vision-editor` is error-free.
- [x] `brew style --fix neon-vision-editor` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+neon-vision-editor&type=pullrequests).
- [x] `brew audit --cask --new neon-vision-editor` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask neon-vision-editor` worked successfully.
- [x] `brew uninstall --cask neon-vision-editor` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI was used to prepare the version and SHA-256 update from the verified Neon Vision Editor v1.2.5 GitHub release. I reviewed that the change only adds the cask with the published ZIP URL and SHA-256. The Homebrew audit, style, installation, and uninstall commands have not yet been performed.

-----