### PR TITLE
aionui 2.1.52

### DIFF
--- a/Casks/a/aionui.rb
+++ b/Casks/a/aionui.rb
@@ -1,18 +1,18 @@
 cask "aionui" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.1.46"
-  sha256 arm:   "f8d8de8e627b27e90e80baf1c8c21015843f214b0793235dbb81186bcb359242",
-         intel: "a8c61f04787515fbe6257a6b4639eb6edba1b8ccf5c5d17f359dedf5fbcb5b9e"
+  version "2.1.52"
+  sha256 arm:   "69ac50f5fba5e4061527fa95b42b9c41d56244b2a0771a89cbb7f282412816d9",
+         intel: "a70250149de3c70bc8c07792855a612949ef71a838f6b8aaef7a70d3abc228f8"
 
-  url "https://github.com/iOfficeAI/AionUi/releases/download/v#{version}/AionUi-#{version}-mac-#{arch}.dmg"
+  url "https://static.aionui.com/releases/#{version}/AionUi-#{version}-mac-#{arch}.dmg"
   name "AionUi"
   desc "Unified GUI for command-line AI agents"
-  homepage "https://github.com/iOfficeAI/AionUi"
+  homepage "https://www.aionui.com/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://static.aionui.com/releases/latest-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

**AI disclosure:** Draft assistance from Grok (xAI). I reviewed the cask diff, verified URLs/checksums, and ran the brew checks myself (or under my direction). I will answer maintainer questions myself.

-----

### Summary

`aionui` **2.1.46 → 2.1.52**.

AionUi stopped publishing installers on GitHub Releases after [v2.1.47-final](https://github.com/iOfficeAI/AionUi/releases/tag/v2.1.47-final). Official packages and electron-builder metadata are on their CDN used by https://www.aionui.com/download:

- URL: `https://static.aionui.com/releases/#{version}/AionUi-#{version}-mac-#{arch}.dmg`
- livecheck: `https://static.aionui.com/releases/latest-mac.yml` with `strategy :electron_builder`
- homepage: `https://www.aionui.com/`

Verified locally:

- `brew style --cask aionui` — no offenses  
- `brew audit --cask --online aionui`  
- `brew livecheck --cask aionui` → `2.1.52 ==> 2.1.52`  
- `brew fetch --cask --force aionui` (arm64 + intel sha256)  
- `brew reinstall --cask --force aionui` → app reports `2.1.52`

Note: flat paths like `…/releases/AionUi-….dmg` return 403; versioned directory layout is required (same as the website download page).