### PR TITLE
captin 2.0.1

### DIFF
--- a/Casks/c/captin.rb
+++ b/Casks/c/captin.rb
@@ -9,7 +9,7 @@ cask "captin" do
   # https://captin.mystrikingly.com/ got redirected to some phishing site
   homepage "https://github.com/cool8jay/public"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "Captin.app"
 

--- a/Casks/c/captin.rb
+++ b/Casks/c/captin.rb
@@ -1,6 +1,6 @@
 cask "captin" do
   version "2.0.1"
-  sha256 "a56ee238b94f21d99c250ca95d11aba41f270ac68d6e888a4bff6628a361890a"
+  sha256 :no_check
 
   url "https://raw.githubusercontent.com/cool8jay/public/master/captin/Captin.zip",
       verified: "raw.githubusercontent.com/cool8jay/public/master/captin/"
@@ -9,7 +9,7 @@ cask "captin" do
   # https://captin.mystrikingly.com/ got redirected to some phishing site
   homepage "https://github.com/cool8jay/public"
 
-  depends_on :macos
+  depends_on macos: ">= :big_sur"
 
   app "Captin.app"
 

--- a/Casks/c/captin.rb
+++ b/Casks/c/captin.rb
@@ -1,6 +1,6 @@
 cask "captin" do
-  version "1.3.1"
-  sha256 :no_check
+  version "2.0.1"
+  sha256 "a56ee238b94f21d99c250ca95d11aba41f270ac68d6e888a4bff6628a361890a"
 
   url "https://raw.githubusercontent.com/cool8jay/public/master/captin/Captin.zip",
       verified: "raw.githubusercontent.com/cool8jay/public/master/captin/"
@@ -8,9 +8,6 @@ cask "captin" do
   desc "Tool to show caps lock status"
   # https://captin.mystrikingly.com/ got redirected to some phishing site
   homepage "https://github.com/cool8jay/public"
-
-  deprecate! date: "2025-11-30", because: :discontinued
-  disable! date: "2026-11-30", because: :discontinued
 
   depends_on :macos
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI assistance: Cursor agent helped draft the cask version bump to 2.0.1 (update `version`/`sha256`, remove `deprecate!`/`disable!`, set `depends_on macos: ">= :big_sur"`) and push the branch. I am the Captin author; I reviewed the cask diff and `zap` paths (unchanged), and will respond to maintainer review myself.

-----

I'm the author of Captin. Captin is actively maintained again (2.0.1). Download URL unchanged. Removing `deprecate!`/`disable!` because it is no longer discontinued.
