### PR TITLE
Corrected biglybt sha256 value

### DIFF
--- a/Casks/b/biglybt.rb
+++ b/Casks/b/biglybt.rb
@@ -1,6 +1,6 @@
 cask "biglybt" do
   version "4.1.0.0"
-  sha256 "0e57accd9e8efa7198ea909342bce4ac5597df76960516d683e559a5ebbb8df2"
+  sha256 "2e20642b6fda147ee7fd3e523235359355a07e753e5c7961e27d005a72753b0d"
 
   url "https://github.com/BiglySoftware/BiglyBT/releases/download/v#{version}/GitHub_BiglyBT_Mac_Universal_Installer.dmg",
       verified: "github.com/BiglySoftware/BiglyBT/"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This PR modifies the SHA256 value for BiglyBT. It's the same SHA value as mentioned on [GitHub Releases](https://github.com/BiglySoftware/BiglyBT/releases/tag/v4.1.0.0). Installs get the following error
```
Error: Cask reports different checksum:     0e57accd9e8efa7198ea909342bce4ac5597df76960516d683e559a5ebbb8df2
       SHA-256 checksum of downloaded file: 2e20642b6fda147ee7fd3e523235359355a07e753e5c7961e27d005a72753b0d
```