### PR TITLE
font-nexon-bazzi (new cask)

### DIFF
--- a/Casks/font/font-n/font-nexon-bazzi.rb
+++ b/Casks/font/font-n/font-nexon-bazzi.rb
@@ -1,0 +1,13 @@
+cask "font-nexon-bazzi" do
+  version :latest
+  sha256 :no_check
+
+  url "https://brand.nexon.com/resources/NEXON_Bazzi.zip"
+  name "NEXON Bazzi"
+  name "넥슨 배찌체"
+  homepage "https://brand.nexon.com/ci-brand-guidelines/typeface"
+
+  font "OFT/Bazzi OTF.otf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted: Used Claude for cask file generation. Manually reviewed, tested, and verified all changes including font paths.

-----

Nexon publishes no version number for this typeface, so the cask uses `version :latest`.


The `OFT/` directory in the `font` stanza is not a typo in the cask: the upstream ZIP itself contains a top-level folder literally named `OFT` (misspelled by Nexon), so the path must match the archive as-is.
