### PR TITLE
nomachine-enterprise-client 10.0.57_2

### DIFF
--- a/Casks/n/nomachine-enterprise-client.rb
+++ b/Casks/n/nomachine-enterprise-client.rb
@@ -1,17 +1,15 @@
 cask "nomachine-enterprise-client" do
-  version "9.8.2_1"
-  sha256 "9d32efc99f1371bd5410f0c93f29254917f136fe6cca0528a6c1b7f0bd4a5a3a"
+  version "10.0.57_2"
+  sha256 "f1790375fa52decdc691bc26d10afa71e2ed8720823c2418a33416ccb5f7fb0b"
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine-enterprise-client_#{version}.dmg"
   name "NoMachine Enterprise Client"
   desc "Remote desktop software"
   homepage "https://www.nomachine.com/"
 
-  # We couldn't find a checkable source of Enterprise-specific version
-  # information but it seems to generally follow the `nomachine` version, so
-  # aligning the versions is better than nothing.
   livecheck do
-    cask "nomachine"
+    url "https://download.nomachine.com/download/?id=7&platform=mac"
+    regex(/nomachine[._-]enterprise[._-]client[._-]?v?(\d+(?:[._]\d+)+)\.dmg/i)
   end
 
   depends_on :macos


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`nomachine-enterprise-client` is autobumped but the workflow failed to update to version 10.0.57_2 because the `livecheck` block uses the check from the `nomachine` cask and that's returning an "Unable to get versions" error. This updates the version and reworks the `livecheck` block to try to check the download page again. We had to move away from that approach in the past because it requires a [short-lived] cookie but it works locally, so let's try it again.

For what it's worth, this is also a precursor to deprecating the `nomachine` cask (due to the free edition being discontinued). There may be something to be said for introducing a `nomachine-personal-edition` cask (the [paid] replacement for the free edition) if/when there's user demand.