### PR TITLE
hey-desktop 1.3.6

### DIFF
--- a/Casks/h/hey-desktop.rb
+++ b/Casks/h/hey-desktop.rb
@@ -1,17 +1,21 @@
 cask "hey-desktop" do
   arch arm: "-arm64"
 
-  version "1.3.3"
-  sha256 arm:   "dd20814f404850484721db5af932b1ef7e5335b4208a9e8e42421703096f049c",
-         intel: "bad2af93086131b56289965556ab52ffa2d1fafbe2262fa2dbcc96e2acbf8eaa"
+  version "1.3.6"
+  sha256 arm:   "81a10fc4901c7f402d583eaf2fc71c0b4cc2fbd42287d434b4b1ba43037c5a2b",
+         intel: "bff544af4559384b1780c9090b5da9972b6b96e54c3376c764ab116fd9139f6e"
 
   url "https://hey.com/desktop/HEY-#{version}#{arch}-mac.zip"
   name "HEY"
   desc "Access the HEY email service"
   homepage "https://hey.com/"
 
+  # This file is served with a `Content-Encoding: aws-chunked` header when
+  # compression is requested but that causes curl to error because it doesn't
+  # understand what decompression to apply.
   livecheck do
-    url "https://hey.com/desktop/latest-mac.yml"
+    url "https://hey.com/desktop/latest-mac.yml",
+        compressed: false
     strategy :electron_builder
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

`hey-desktop` is autobumped but the workflow failed to update to version 1.3.6 because the `livecheck` block is encountering a curl error due to the `Content-Encoding: aws-chunked` response header: "(56) Unrecognized content encoding type. libcurl understands deflate, gzip content encodings." This updates the version and disables response compression in the `livecheck` block, which avoids the `aws-chunked` issue.