### PR TITLE
lobehub: update livecheck

### DIFF
--- a/Casks/l/lobehub.rb
+++ b/Casks/l/lobehub.rb
@@ -10,22 +10,13 @@ cask "lobehub" do
   desc "AI chat framework"
   homepage "https://github.com/lobehub/lobe-chat"
 
-  # Not every release on GitHub has assets, so we have to find the newest one
-  # with the files the cask uses.
   livecheck do
     url :url
     regex(/LobeHub[._-]v?(\d+(?:\.\d+)+)#{arch}[._-]mac\.zip/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-
-        release["assets"]&.map do |asset|
-          match = asset["browser_download_url"]&.match(regex)
-          next if match.blank?
-
-          match[1]
-        end
-      end.flatten
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        asset["browser_download_url"]&.[](regex, 1)
+      end
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The `livecheck` block for `lobehub` is producing an "Unable to get versions" error, as there have been enough unstable releases on GitHub to push the latest stable version out of the first page of API data, causing the `GithubReleases` strategy to fail. We switched away from the `GithubLatest` strategy because upstream wasn't consistent about uploading assets for every release but this hasn't been an issue since the 2.1.37 release (2026-03-05) and there have been ~35 releases in that time, so this switches the check back to the `GithubLatest` strategy. The alternative is to check the [arch-specific] redirecting URLs on the upstream download page but we can put that off until neither of the GitHub strategies work (or migrating the cask to first-party assets is seen as preferable).