### PR TITLE
mplab-xc8 4.00

### DIFF
--- a/Casks/m/mplab-xc8.rb
+++ b/Casks/m/mplab-xc8.rb
@@ -29,7 +29,6 @@ cask "mplab-xc8" do
   binary "#{staged_path}/bin/xc8-ar"
   binary "#{staged_path}/bin/xc8-cc"
   binary "#{staged_path}/bin/xc8-clangd"
-  binary "#{staged_path}/bin/xclm"
 
   postflight_steps do
     set_ownership "."

--- a/Casks/m/mplab-xc8.rb
+++ b/Casks/m/mplab-xc8.rb
@@ -19,10 +19,7 @@ cask "mplab-xc8" do
     executable: "xc8-v#{version}-full-install-macos-x64-installer.app/Contents/MacOS/installbuilder.sh",
     args:       [
       "--mode", "unattended",
-      "--unattendedmodeui", "none",
       "--ModifyAll", "0",
-      "--netservername", '""',
-      "--LicenseType", "WorkstationMode",
       "--prefix", staged_path.to_s
     ],
     input:      ["y"],

--- a/Casks/m/mplab-xc8.rb
+++ b/Casks/m/mplab-xc8.rb
@@ -1,11 +1,11 @@
 cask "mplab-xc8" do
-  version "3.10"
-  sha256 "42569224273f43ae3f6a4d14d675766df17b0e99044c316e0b3b49d2d1a14145"
+  version "4.00"
+  sha256 "b3a95dbbb95a3d02648cb796a45f7a8687827d9eb10eadb36b5645af0d623025"
 
   url "https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/xc8-v#{version}-full-install-macos-x64-installer.dmg"
   name "MPLab XC8 Compiler"
   desc "Compiler for 8-bit PIC and SAM MCUs and MPUs"
-  homepage "https://www.microchip.com/mplab/compilers"
+  homepage "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc8"
 
   livecheck do
     url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc8",

--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -24,6 +24,7 @@
   "logmein-client": "https://www.logmein.com/pro",
   "ltspice": "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html",
   "mplab-xc32": "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc32",
+  "mplab-xc8": "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc8",
   "mplabx-ide": "https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide",
   "mysql-shell": [
     "https://dev.mysql.com/downloads/shell/",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 5 with manual review.

-----

We've been getting 403 errors on `mplab-xc8` for a while.

This bumps the version and updates the homepage and adds to the `secure_connection_audit_skiplist` in line with what has been done for `mplab-xc32`.