### PR TITLE
omegat: update livecheck, use notarized version

### DIFF
--- a/Casks/o/omegat.rb
+++ b/Casks/o/omegat.rb
@@ -1,23 +1,21 @@
 cask "omegat" do
   version "6.0.1"
-  sha256 "458cfd1508cfe7e73fc193b800f40c533a3191adddc3336769ee4e44fc50b3ae"
+  sha256 "49eb622bdcf32dcb0f4ee7ba2adc43f9837614d7b71435f33f86235c7c75a6bb"
 
-  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}/OmegaT_#{version}_Mac.zip",
-      verified: "downloads.sourceforge.net/omegat/"
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Standard/OmegaT%20#{version.major_minor_patch}/OmegaT_#{version}_macOS_Notarized.dmg"
   name "OmegaT"
   desc "Translation memory tool"
   homepage "https://omegat.org/"
 
   livecheck do
     url "https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard"
+    regex(%r{url=.*?/OmegaT[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]Notarized\.dmg}i)
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   conflicts_with cask: "omegat@latest"
   depends_on :macos
 
-  app "OmegaT_#{version}_Mac/OmegaT.app"
+  app "OmegaT.app"
 
   zap trash: [
     "~/Library/Application Support/OmegaT",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 5 with review.

-----

`omegat` failed to autobump as the latest versions available on Sourceforge don't contain a macOS file.  This updates the livecheck to match their most recent macOS version.

It looks like a separate build for macOS was published in version 6.0.1 that is a notarized build, so let's swap to that while we're here.