### PR TITLE
zen: use command_wrapper, update livecheck

### DIFF
--- a/Casks/z/zen.rb
+++ b/Casks/z/zen.rb
@@ -1,6 +1,8 @@
 cask "zen" do
   arch arm: "aarch64", intel: "x86_64"
-  os macos: ".macos-universal.dmg", linux: "-#{arch}.AppImage"
+  os macos: ".macos-universal", linux: "-#{arch}"
+  livecheck_os = on_system_conditional macos: "Darwin", linux: "Linux"
+  url_end = on_system_conditional macos: "dmg", linux: "AppImage"
 
   version "1.21.13b"
 
@@ -33,13 +35,13 @@ cask "zen" do
     app_image "zen-#{arch}.AppImage", target: "Zen.AppImage"
   end
 
-  url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen#{os}"
+  url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen#{os}.#{url_end}"
   name "Zen Browser"
   desc "Gecko based web browser"
   homepage "https://zen-browser.app/"
 
   livecheck do
-    url "https://updates.zen-browser.app/updates/browser/Darwin_aarch64-gcc3/release/update.xml"
+    url "https://updates.zen-browser.app/updates/browser/#{livecheck_os}_#{arch}-gcc3/release/update.xml"
     strategy :xml do |xml|
       xml.get_elements("//update").map { |item| item.attributes["appVersion"] }
     end

--- a/Casks/z/zen.rb
+++ b/Casks/z/zen.rb
@@ -10,7 +10,7 @@ cask "zen" do
     conflicts_with cask: "zen-privacy"
 
     app "Zen.app"
-    binary "#{appdir}/Zen.app/Contents/MacOS/zen"
+    command_wrapper "zen", executable: "#{appdir}/Zen.app/Contents/MacOS/zen"
 
     uninstall quit: "app.zen-browser.zen"
 

--- a/Casks/z/zen.rb
+++ b/Casks/z/zen.rb
@@ -4,10 +4,10 @@ cask "zen" do
   livecheck_os = on_system_conditional macos: "Darwin", linux: "Linux"
   url_end = on_system_conditional macos: "dmg", linux: "AppImage"
 
-  version "1.21.13b"
+  version "1.21.12b"
 
   on_macos do
-    sha256 "79bcaf03e6faaec08dda50ae42116c59b42be419bfb9c4a1ae8f56c2d098d252"
+    sha256 "dba6a9674d3199ac9b1ea8753c5f08486fe91de36ff113f7339f34423ffe5ea0"
 
     conflicts_with cask: "zen-privacy"
 
@@ -29,8 +29,8 @@ cask "zen" do
         rmdir: "~/Library/Caches/Mozilla"
   end
   on_linux do
-    sha256 arm64_linux:  "d48365d1f0925e62c59f064e1a7ef360ebbf916c8236206c80e61d0ec20a72e1",
-           x86_64_linux: "f9652c2eefb214971dc824937bbb16f7a767a26510d16b430d6803651372bfb4"
+    sha256 arm64_linux:  "390e64fc54a0ee4783052dc4cd099bc8c3835c99af60a98e0c08292c7725c6bd",
+           x86_64_linux: "401a83b89f3d889a2c230b5c350b733a453410401bffbd09f16e421013a5d5f3"
 
     app_image "zen-#{arch}.AppImage", target: "Zen.AppImage"
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The plain binary does not work - a shim script is necessary like other browser casks. The change for the livecheck should allow us to find differences between macOS and Linux if the versions ever differ.

Also reverts to the previous version, as `1.21.13b` was completely pulled out - https://github.com/zen-browser/desktop/releases/download/1.21.13b/zen.macos-universal.dmg and the other AppImage URLs return a 404 error.