### PR TITLE
zen@twilight: use command_wrapper, update livecheck

### DIFF
--- a/Casks/z/zen@twilight.rb
+++ b/Casks/z/zen@twilight.rb
@@ -1,6 +1,8 @@
 cask "zen@twilight" do
   arch arm: "aarch64", intel: "x86_64"
-  os macos: ".macos-universal.dmg", linux: "-#{arch}.AppImage"
+  os macos: ".macos-universal", linux: "-#{arch}"
+  livecheck_os = on_system_conditional macos: "Darwin", linux: "Linux"
+  url_end = on_system_conditional macos: "dmg", linux: "AppImage"
 
   version "1.22t,20260808062813"
   sha256 :no_check
@@ -27,13 +29,13 @@ cask "zen@twilight" do
     app_image "zen-#{arch}.AppImage", target: "Zen Twilight.AppImage"
   end
 
-  url "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen#{os}"
+  url "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen#{os}.#{url_end}"
   name "Zen Twilight"
   desc "Gecko based web browser"
   homepage "https://zen-browser.app/"
 
   livecheck do
-    url "https://updates.zen-browser.app/updates/browser/Darwin_aarch64-gcc3/twilight/update.xml"
+    url "https://updates.zen-browser.app/updates/browser/#{livecheck_os}_#{arch}-gcc3/twilight/update.xml"
     strategy :xml do |xml|
       xml.get_elements("//update").map { |item| "#{item.attributes["appVersion"]},#{item.attributes["buildID"]}" }
     end

--- a/Casks/z/zen@twilight.rb
+++ b/Casks/z/zen@twilight.rb
@@ -7,7 +7,7 @@ cask "zen@twilight" do
 
   on_macos do
     app "Twilight.app"
-    binary "#{appdir}/Twilight.app/Contents/MacOS/zen", target: "zen-twilight"
+    command_wrapper "zen-twilight", executable: "#{appdir}/Twilight.app/Contents/MacOS/zen"
 
     uninstall quit: "app.zen-browser.zen"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The plain binary does not work - a shim script is necessary like other browser casks. The change for the livecheck should allow us to find differences between macOS and Linux if the versions ever differ.