### PR TITLE
psychopy 2026.2.1

### DIFF
--- a/Casks/p/psychopy.rb
+++ b/Casks/p/psychopy.rb
@@ -1,24 +1,21 @@
 cask "psychopy" do
-  version "2026.1.3"
-  sha256 "90cc8d9e9b3a3d02ed149be736686aa834021889d91b0f3a03dcd830a9488fc8"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://github.com/psychopy/psychopy/releases/download/#{version.csv.first.major_minor_patch}/StandalonePsychoPy-#{version.csv.first}-macOS#{"_#{version.csv.second}" if version.csv.second}-3.10.dmg",
-      verified: "github.com/psychopy/psychopy/"
+  version "2026.2.1"
+  sha256 arm:   "0c608e99672640976924a4dd267ddf709a643b8d23dc7e6bb13d4390fd693f3a",
+         intel: "7c87cf8833dd72f2aa00b63edf7ca1746546e0e24ed8abff6552491b607fb887"
+
+  url "https://github.com/psychopy/psychopy/releases/download/#{version}/StandalonePsychoPy-#{version}-macOS-#{arch}-3.11.dmg"
   name "PsychoPy"
   desc "Create experiments in behavioral science"
   homepage "https://www.psychopy.org/"
 
   livecheck do
-    url "https://www.psychopy.org/download.html"
-    regex(/StandalonePsychoPy[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]?(\d+(?:[._-]\d+)+)?[._-](?:py)?3\.10\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
-      end
-    end
+    url :url
+    strategy :github_latest
   end
 
-  depends_on :macos
+  depends_on macos: :big_sur
 
   app "PsychoPy.app"
 
@@ -27,8 +24,4 @@ cask "psychopy" do
     "~/Library/Preferences/org.opensciencetools.psychopy.plist",
     "~/Library/Saved Application State/org.opensciencetools.psychopy.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 5 with manual review.

-----

Updates `psychopy` to add ARM support, and since we're here repoint to GitHub for livecheck since we were already downloading from there anyway.

It appears `psychopy` may be inconsistent in updating their website - last Changelog notes are for `2024.2` with reference to all release notes being on GitHub, and the download page references `2026.1.3` as stable, despite the version in this PR being marked as latest and having a full release cycle.