### PR TITLE
macx*: update livecheck due to 302

### DIFF
--- a/Casks/m/macx-dvd-ripper-pro.rb
+++ b/Casks/m/macx-dvd-ripper-pro.rb
@@ -7,8 +7,9 @@ cask "macx-dvd-ripper-pro" do
   desc "DVD ripping application"
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"
 
+  # https 302-redirects back to http
   livecheck do
-    url "https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro"
+    url "http://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro"
     strategy :xml do |xml|
       # The plist file contains nested "LastestVersion" keys that apply to
       # language variants, so we specifically match the main key

--- a/Casks/m/macx-video-converter-pro.rb
+++ b/Casks/m/macx-video-converter-pro.rb
@@ -7,8 +7,9 @@ cask "macx-video-converter-pro" do
   desc "Tool to convert, edit, download & resize videos"
   homepage "https://www.macxdvd.com/mac-video-converter-pro/"
 
+  # https 302-redirects back to http
   livecheck do
-    url "https://www.macxdvd.com/mac-video-converter-pro/upgrade/video-converter-pro.xml"
+    url "http://www.macxdvd.com/mac-video-converter-pro/upgrade/video-converter-pro.xml"
     strategy :xml do |xml|
       # `LastestVersion` is an upstream typo of `LatestVersion`
       xml.get_elements("//key[text()='LastestVersion']").map { |item| item.next_element&.text&.strip }

--- a/Casks/m/macx-youtube-downloader.rb
+++ b/Casks/m/macx-youtube-downloader.rb
@@ -7,8 +7,9 @@ cask "macx-youtube-downloader" do
   desc "Tool to download videos from YouTube"
   homepage "https://www.macxdvd.com/free-youtube-video-downloader-mac/"
 
+  # https 302-redirects back to http
   livecheck do
-    url "https://www.macxdvd.com/free-youtube-video-downloader-mac/upgrade/macx-youtube-downloader#{version.major}.plist"
+    url "http://www.macxdvd.com/free-youtube-video-downloader-mac/upgrade/macx-youtube-downloader#{version.major}.plist"
     strategy :xml do |xml|
       version = xml.elements["//key[text()='LastestVersion']"]&.next_element&.text
       next if version.blank?


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Opus 5 did some discoverability and troubleshooting, I wrote the updates.

-----

3 casks from macxdvd use livecheck URL's that 302 redirect to http.  While this isn't ideal, it's still on the same domain and follows what we've had to do in a few other places previously.