### PR TITLE
dingtalk 8.5.0

### DIFF
--- a/Casks/d/dingtalk.rb
+++ b/Casks/d/dingtalk.rb
@@ -1,24 +1,32 @@
 cask "dingtalk" do
-  version "8.0.2,48936485"
-  sha256 "d35a0e88d92f9398a76959419864b6399a014dbe13c8a286ad4af2939d3b40b7"
+  version "8.5.0,57245204"
+  sha256 "04c0ebd1b1f408ad9841b452a78650299d85d4f4db5e06139c24064e4cbe5c98"
 
-  url "https://dtapp-pub.dingtalk.com/dingtalk-desktop/mac_dmg/Release/M1-Beta/DingTalk_v#{version.csv.first}_#{version.csv.second}_universal.dmg"
+  url "https://dtapp-pub.dingtalk.com/dingtalk-desktop/mac_dmg/Release/DingTalk_v#{version.csv.first}-Installer_#{version.csv.second}_universal.dmg"
   name "DingTalk"
   name "钉钉"
   desc "Teamwork app by Alibaba Group"
   homepage "https://www.dingtalk.com/"
 
   livecheck do
-    url "https://im.dingtalk.com/manifest/appcast_gray_release.xml"
-    strategy :sparkle
+    url "https://www.dingtalk.com/mac/d/"
+    regex(/DingTalk[._-]v?(\d+(?:\.\d+)+)[._-]installer[._-](\d+)[._-]universal\.dmg/i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
   end
 
   auto_updates true
   depends_on :macos
 
-  app "DingTalk.app"
+  pkg "DingTalkInstaller.pkg"
 
-  uninstall quit: "com.alibaba.DingTalkMac"
+  uninstall quit:    "com.alibaba.DingTalkMac",
+            pkgutil: "com.alibaba.DingTalkInstaller.app",
+            delete:  "/Applications/DingTalk.app"
 
   zap trash: [
     "~/Library/Application Support/DingTalkMac",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
