### PR TITLE
texturepacker: add auto_updates

### DIFF
--- a/Casks/t/texturepacker.rb
+++ b/Casks/t/texturepacker.rb
@@ -12,6 +12,7 @@ cask "texturepacker" do
     strategy :sparkle
   end
 
+  auto_updates true
   depends_on macos: :ventura
 
   app "TexturePacker.app"


### PR DESCRIPTION
Tested locally on macOS 26.5.2

Addresses `texturepacker` in #170994 

`:sparkle` autoupdate feature. Version can be verified [here](https://www.codeandweb.com/texturepacker/download).
<img width="1303" height="822" alt="Screenshot 2026-08-10 at 11 11 34 AM" src="https://github.com/user-attachments/assets/01b4b3ea-fe40-44da-9e82-e0150f068128" />

Used Codex to research the cask. 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
