### PR TITLE
inkdrop 6.0.0

### DIFF
--- a/Casks/i/inkdrop.rb
+++ b/Casks/i/inkdrop.rb
@@ -1,21 +1,18 @@
 cask "inkdrop" do
   arch arm: "arm64", intel: "x64"
 
-  version "5.11.10"
-  sha256 arm:   "821ab3b508de9e93ee76db6612ff52a102dca51f4b46e0ab94ac960a1ae04136",
-         intel: "74be7794ffaa1f15895d85ceb79e629c8e2d04ff85d07e414c3afc5b9e982f35"
+  version "6.0.0"
+  sha256 arm:   "5cbf60a36a04e8a8577bb764590cb57aab4007a2927df38e625c75f75d90d15b",
+         intel: "255811c23183a2abbfb5ef39c462e92dcb1db7ece08cebcc8a8aed4295f14335"
 
-  url "https://d3ip0rje8grhnl.cloudfront.net/v#{version}/Inkdrop-#{version}-#{arch}-Mac.zip",
-      verified: "d3ip0rje8grhnl.cloudfront.net/"
+  url "https://dist.inkdrop.app/releases/inkdrop-#{version}-#{arch}-mac.zip"
   name "Inkdrop"
   desc "Markdown editor"
-  homepage "https://www.inkdrop.info/"
+  homepage "https://www.inkdrop.app/"
 
   livecheck do
-    url "https://api.inkdrop.app/update/links"
-    strategy :json do |json|
-      json["version"]
-    end
+    url "https://dist.inkdrop.app/releases/latest-mac.yml"
+    strategy :electron_builder
   end
 
   depends_on macos: :monterey


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
Inkdrop v6 moved to a new download host with a new artifact naming scheme, and the old livecheck endpoint (api.inkdrop.app/update/links) still reports 5.11.10, so the autobumper could not pick this release up. This PR:

- Bumps the cask to 6.0.0 with new sha256s for both architectures
- Updates url to the new host dist.inkdrop.app and drops verified since the domain now matches the homepage
- Updates homepage to inkdrop.app (the old inkdrop.info now 301-redirects there)
- Switches livecheck to the electron-builder feed at dist.inkdrop.app/releases/latest-mac.yml (strategy :electron_builder), which reports 6.0.0 — this should let the autobumper track future releases again
- App bundle is unchanged (Inkdrop.app, bundle id info.pkpk.inkdrop, LSMinimumSystemVersion 12.0), so app, zap, and depends_on macos: :monterey stay as-is.

I used Claude Code with Fable 5 to help me identify why the original implementation couldn't pick up the latest version and the @BrewTestBot didn't open a PR for it. 
I then reviewed all the changes and ran the commands required in the PR template to verify that everything is working.
