### PR TITLE
aionui: update homepage and livecheck source

### DIFF
--- a/Casks/a/aionui.rb
+++ b/Casks/a/aionui.rb
@@ -8,11 +8,11 @@ cask "aionui" do
   url "https://static.aionui.com/releases/#{version}/AionUi-#{version}-mac-#{arch}.dmg"
   name "AionUi"
   desc "Unified GUI for command-line AI agents"
-  homepage "https://github.com/iOfficeAI/AionUi"
+  homepage "https://www.aionui.com/"
 
   livecheck do
-    url "https://github.com/iOfficeAI/AionUi"
-    strategy :github_latest
+    url "https://static.aionui.com/releases/latest-mac.yml"
+    regex(/^version:\s*v?(\d+(?:\.\d+)+)/i)
   end
 
   auto_updates true


### PR DESCRIPTION
The project's release publishing has moved off the `iOfficeAI/AionUi` GitHub repository (publishing entity change); GitHub releases there will stop, which would freeze the current `:github_latest` livecheck.

- `homepage`: point at the product site https://www.aionui.com/
- `livecheck`: read the version from the vendor's electron-updater feed `https://static.aionui.com/releases/latest-mac.yml`, which lives on the same host as the cask `url` and is updated on every release (currently reports `version: 2.1.53`, matching the cask).

No version/sha256 changes.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: the edit was drafted with assistance from Claude (Claude Code). I reviewed the diff myself; `brew audit --cask --online aionui` (error-free, artifacts downloaded and verified) and `brew style` (no offenses) were run locally in the tapped repo before reopening. The zap stanza is unchanged. I (the human submitter) will answer review comments myself.
