### PR TITLE
worksheet-crafter 2026.2.5

### DIFF
--- a/Casks/w/worksheet-crafter.rb
+++ b/Casks/w/worksheet-crafter.rb
@@ -1,6 +1,6 @@
 cask "worksheet-crafter" do
-  version "2026.2.11"
-  sha256 "c931f890d554c312ea985eccc51bd51e380c2a82d8a3dfb24405f9153dcd0b08"
+  version "2026.2.5"
+  sha256 "591681374f78f55e6c9f1fc258209eebab1a1a0f0d7044588dd7209ae70056f2"
 
   url "https://website.cdn.getschoolcraft.com/downloads/worksheet-crafter_#{version}.pkg",
       verified: "website.cdn.getschoolcraft.com/downloads/"


### PR DESCRIPTION
This is a deliberate version decrease. I'm from SchoolCraft, the vendor.

2026.2.11 was never a real release: the artifact published under that filename is the 2025.2.11 build, uploaded with the wrong name on our side. The current release is 2026.2.5, as stated on our download page under "Hinweise" (German): https://worksheetcrafter.com/de/downloads/vollversion (That page links our mirrored installer for end users; the cask's CDN URL serves the same build.)

The mislabeled file is still available at its old URL, so the currently published cask continues to install correctly. This PR is a correction, not a breakage fix. Once this lands, no cask will reference that file and we intend to remove it.

Why this needs a manual PR: the livecheck block resolves correctly to 2026.2.5:

```
$ curl -sIL "https://worksheetcrafter.com/download/worksheet-crafter/mac/latest"
HTTP/2 302
location: https://website.cdn.getschoolcraft.com/downloads/worksheet-crafter_2026.2.5.pkg
```

But 2026.2.5 sorts below 2026.2.11 token-wise, so autobump finds nothing to upgrade and stays silent, and `brew bump-cask-pr` declines to act on autobumped casks. Only `version` and `sha256` change here; `livecheck` is unchanged and working.

A follow-up PR will propose renaming the token to `worksheetcrafter` to match the application bundle name.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->
AI/LLM usage: Claude (Opus 5) was used to research the Homebrew docs, diagnose why autobump stayed silent and draft this description. I verified the checksum, the redirect behaviour and the audit output myself. The `zap` stanza is unchanged by this PR. I will answer review comments myself.

-----
