### PR TITLE
gcloud-cli: allow virtualenv network access

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -75,13 +75,15 @@ cask "gcloud-cli" do
                                                                         "python@3.14/libexec/bin/python",
                                                  }
       end
-      run "share/google-cloud-sdk/bin/gcloud", base: :homebrew_prefix,
-                                               args: ["config", "virtualenv", "create", "--python-to-use",
-                                                      "{{HOMEBREW_PREFIX}}/opt/python@3.14/libexec/bin/python"],
-                                               env:  {
+      run "share/google-cloud-sdk/bin/gcloud", base:           :homebrew_prefix,
+                                               args:           ["config", "virtualenv", "create", "--python-to-use",
+                                                                "{{HOMEBREW_PREFIX}}/opt/" \
+                                                                "python@3.14/libexec/bin/python"],
+                                               env:            {
                                                  "CLOUDSDK_PYTHON" => "{{HOMEBREW_PREFIX}}/opt/" \
                                                                       "python@3.14/libexec/bin/python",
-                                               }
+                                               },
+                                               network_access: true
       run "share/google-cloud-sdk/bin/gcloud", base: :homebrew_prefix,
                                                args: ["config", "virtualenv", "enable"],
                                                env:  {


### PR DESCRIPTION
The `gcloud config virtualenv create` postflight step downloads a `cryptography` wheel from GitHub when preparing the bundled tools. The cask sandbox blocks DNS without an explicit opt-in, so fresh installs abort during virtualenv creation.

- Opt only the `virtualenv create` run into network access.
- Leave virtualenv deletion, enablement and version reporting on the default network-denied policy.
- Preserve the existing Python interpreter and command arguments.

This depends on Homebrew/brew commit `cb9c1b67cda`, which adds the explicit `network_access:` option for structured cask runs.

Needs https://github.com/Homebrew/brew/pull/23497
Fixes https://github.com/Homebrew/brew/issues/23495

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex 5.6 Sol xhigh with local review and testing.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
