### PR TITLE
worksheetcrafter: renamed from worksheet-crafter

### DIFF
--- a/Casks/w/worksheetcrafter.rb
+++ b/Casks/w/worksheetcrafter.rb
@@ -1,10 +1,9 @@
-cask "worksheet-crafter" do
+cask "worksheetcrafter" do
   version "2026.2.5"
   sha256 "591681374f78f55e6c9f1fc258209eebab1a1a0f0d7044588dd7209ae70056f2"
 
-  url "https://website.cdn.getschoolcraft.com/downloads/worksheet-crafter_#{version}.pkg",
-      verified: "website.cdn.getschoolcraft.com/downloads/"
-  name "Worksheet Crafter"
+  url "https://website.cdn.getschoolcraft.com/downloads/worksheet-crafter_#{version}.pkg"
+  name "WorksheetCrafter"
   desc "Worksheet and lesson material creator"
   homepage "https://worksheetcrafter.com/"
 

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -217,6 +217,7 @@
   "windsurf": "devin-desktop",
   "windsurf@next": "devin-desktop@next",
   "wireshark": "wireshark-app",
+  "worksheet-crafter": "worksheetcrafter",
   "xcodes": "xcodes-app",
   "xournal-plus-plus": "xournal++",
   "xtool-creative-space": "xtool-studio",


### PR DESCRIPTION
Renames `worksheet-crafter` to `worksheetcrafter` to match the application bundle name. I'm from SchoolCraft, the vendor.

The pkg installs `WorksheetCrafter.app` (no space), and the token rules derive from the bundle name on disk:

```
$ "$(brew --repository homebrew/cask)/developer/bin/generate_cask_token" "/Applications/WorksheetCrafter.app"
Proposed token:               worksheetcrafter
Proposed file name:           worksheetcrafter.rb
Cask Header Line:             cask "worksheetcrafter" do
```

Note on the apparent inconsistency: we market the product as "Worksheet Crafter" (with a space) and our preference domain is `com.schoolcraft.Worksheet Crafter`, but the bundle itself has always been `WorksheetCrafter.app`. The `zap` paths are therefore unchanged and still correct. They follow the preference domain, not the bundle name.

Changes: 
1. cask file renamed
2. token in the header line
3. `name` updated to `WorksheetCrafter`
4. mapping added to `cask_renames.json`

`version`, `sha256`, `url`, `pkg`, `livecheck`, `uninstall` and `zap` are unchanged.

Verified locally: install and uninstall both complete cleanly, with the `uninstall pkgutil:` stanza correctly matching `com.schoolcraft.pkg.worksheetcrafter` and leaving no receipts behind.

Follow-up to #280328.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->
AI/LLM usage: Claude (Opus 5) was used to research the Homebrew docs and draft this description. I ran generate_cask_token, the audit and the install/uninstall test myself and verified the results. I will answer review comments myself.

-----