### PR TITLE
sentry-cli 3.6.2 (new cask)

### DIFF
--- a/Casks/s/sentry-cli.rb
+++ b/Casks/s/sentry-cli.rb
@@ -1,0 +1,24 @@
+cask "sentry-cli" do
+  arch arm: on_system_conditional(macos: "arm64", linux: "aarch64"), intel: "x86_64"
+  os macos: "Darwin", linux: "Linux"
+
+  version "3.6.2"
+  sha256 arm:          "5a497deb1e388cc6445c09ddd6d2da4fc2aae8295405d6393c2e0ee635ca3687",
+         intel:        "efe0a5289cdd0ea8ff727b1228a1bea6c840f2da38152e8f9f5ced05bd6659cd",
+         arm64_linux:  "ff112ecf694b7d6b3629a6228ed4e3f7a0d51401bdf48a5051a79d8749dccd06",
+         x86_64_linux: "3a4bbf2c0d06378d4e59b337647483751a0a2b1603db5fd4991847d0cfd6478c"
+
+  url "https://github.com/getsentry/sentry-cli/releases/download/#{version}/sentry-cli-#{os}-#{arch}"
+  name "Sentry CLI"
+  desc "Command-line utility to interact with Sentry"
+  homepage "https://docs.sentry.io/cli/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  binary "sentry-cli-#{os}-#{arch}", target: "sentry-cli"
+
+  zap trash: "~/.sentryclirc"
+end


### PR DESCRIPTION
Opening this as a draft for discussion as a potential migration pathway after https://github.com/Homebrew/homebrew-core/pull/298212

I'm not certain on the precedent of a straight migration from a Formula to a Cask in these instances.
If we want it as an optional migration, we could park this with a `sentry` token as a `replacement_cask` for the Formula, until the Formula is removed.


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
