### PR TITLE
unity-hub@beta 3.20.1

### DIFF
--- a/Casks/u/unity-hub@beta.rb
+++ b/Casks/u/unity-hub@beta.rb
@@ -2,10 +2,10 @@ cask "unity-hub@beta" do
   arch arm: "arm64", intel: on_system_conditional(macos: "x64", linux: "x86_64")
   url_end = on_system_conditional macos: "dmg", linux: "AppImage"
 
-  version "3.20.0"
-  sha256 arm:          "49bb701e48ac7aa02f352348fb6e0aae20f808730ee8f4c371b3c3494c6232d9",
-         intel:        "f74aa268470f9cc2a97b5aae1ebd2ded05ecbe37689d982c3f01a45d6caa9999",
-         x86_64_linux: "af1eda02fa1a036e478df0b68c2ef684d6734304b40f6b6e44e73dc42ad76d21"
+  version "3.20.1"
+  sha256 arm:          "1876a3d6ee431ed19f6d3b93b5b833510077a521a124478cb02a3d560bd9bc67",
+         intel:        "3b19d17dbf4462252023c0b3e3267d2ef5ffc32a4d9ed3b4c2bcfdb5fd0f9392",
+         x86_64_linux: "a1e59738db7697f574329b79720674632a6a23f33e84d7315119eb32c72f4337"
 
   on_macos do
     depends_on macos: :monterey


### PR DESCRIPTION
Full bump of `unity-hub@beta` to 3.20.1 for **all three** arches (`arm`, `intel`, `x86_64_linux`).

This supersedes #280274 ("unity-hub@beta 3.20.1 (arm only)"), which bumps only `arm` and would pin macOS-Intel **and x86_64 Linux** (`on_intel` covers Linux in this cask) to 3.20.0, leaving the `intel` `sha256` at its 3.20.0 value. 3.20.1 was not an arm-only release. Please close #280274.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

AI/LLM disclosure: this bump was prepared with Claude Code (Claude Opus 5). The scope of its changes is the `version` line and the three `sha256` values — no other stanza was modified, and this PR does not touch the cask's existing `zap` paths. The verification below was executed with its output checked, not asserted. No commit here is attributed to an AI, and I have no other pull request open in this repository.

The five "new cask" boxes are left unticked because this is a bump of an existing cask, not a new one.

-----

### Why the bot opened an arch-split PR

`unity-hub@beta` contains `on_macos`/`on_linux` blocks, so `brew bump` treats it as a cask with blocks and runs livecheck once per *simulated* arch. Both simulations request the same hardcoded livecheck URL (`beta-mac.yml`) with `strategy :electron_builder`, which reads `yaml["version"]` — there is no arch-dependent input anywhere on that path, so an `arm`/`intel` divergence can only mean two reads of one URL disagreed. Ours served a stale channel pointer to one of them (Intel is fetched first), and `bump-cask-pr` then kept both versions and emitted the `on_arm`/`on_intel` split.

I work on Unity Hub: that was a CDN cache-invalidation bug on our side, now fixed in our release pipeline so the channel pointer converges promptly after a release. All three channel pointers currently read 3.20.1.

### Verification

For each artifact I confirmed the downloaded bytes match the `sha512` **and** `size` published in our channel manifests (`beta-mac.yml`, `beta-linux.yml`) before deriving `sha256`, so each checksum provably belongs to the intended file:

| arch | file | sha256 |
|---|---|---|
| `arm` | `UnityHubSetup-3.20.1-arm64.dmg` | `1876a3d6ee431ed19f6d3b93b5b833510077a521a124478cb02a3d560bd9bc67` |
| `intel` | `UnityHubSetup-3.20.1-x64.dmg` | `3b19d17dbf4462252023c0b3e3267d2ef5ffc32a4d9ed3b4c2bcfdb5fd0f9392` |
| `x86_64_linux` | `UnityHubSetup-3.20.1-x86_64.AppImage` | `a1e59738db7697f574329b79720674632a6a23f33e84d7315119eb32c72f4337` |

As an independent cross-check, all three match the checksums in the `unity-hub` stable cask's 3.20.1 bump (#280273, merged). That is expected rather than a coincidence: both casks share a byte-identical `url` template and `arch`/`url_end` mapping, and differ only in their livecheck URL, so at the same version they resolve the same three files.

`brew audit --cask --online unity-hub@beta` exits 0 (arm64 macOS, Homebrew 6.0.17), including the livecheck version comparison that was the only failure on #280274. `brew style --fix` reports no offenses and rewrites nothing.

### Note on autobump

This is hand-written because `brew bump-cask-pr` declines to run on autobumped casks. #280274 being open appears to stop BrewTestBot opening a clean replacement, so this seemed better than waiting. Happy to close this instead if you would rather close #280274 and let the next autobump run pick it up.
