### PR TITLE
grok-bot 0.16.0 (new cask)

### DIFF
--- a/Casks/g/grok-bot.rb
+++ b/Casks/g/grok-bot.rb
@@ -1,0 +1,39 @@
+cask "grok-bot" do
+  version "0.16.0,076e9d4bf42abbfa576702aea18ddbc49d9d3ab5"
+  sha256 "f8aa79866a8fd5e53a6e852248eab819cf186d29312497d8b0a93e302a8e5f7a"
+
+  url "https://downloads.cursor.com/sand/stable/#{version.csv.second}/darwin/arm64/Cursor-darwin-arm64.zip"
+  name "Grok Bot"
+  desc "AI coding agent from xAI and Cursor"
+  homepage "https://cursor.com/grok"
+
+  livecheck do
+    url "https://api2.cursor.sh/updates/api/update/darwin-arm64/sand/0.0.0/stable"
+    regex(%r{/sand/stable/(\h+)/}i)
+    strategy :json do |json, regex|
+      ver = json["name"] || json["version"] || json["productVersion"]
+      next unless ver
+
+      match = json["url"]&.match(regex)
+      next if match.blank?
+
+      "#{ver},#{match[1]}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: :monterey
+  depends_on arch: :arm64
+
+  app "Grok Bot.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.anysphere.sand",
+    "~/Library/Application Support/Grok Bot",
+    "~/Library/Caches/com.anysphere.sand",
+    "~/Library/HTTPStorages/com.anysphere.sand",
+    "~/Library/Logs/Grok Bot",
+    "~/Library/Preferences/com.anysphere.sand.plist",
+    "~/Library/Saved Application State/com.anysphere.sand.savedState",
+  ]
+end

--- a/Casks/g/grok-bot.rb
+++ b/Casks/g/grok-bot.rb
@@ -1,29 +1,25 @@
 cask "grok-bot" do
-  version "0.16.0,076e9d4bf42abbfa576702aea18ddbc49d9d3ab5"
-  sha256 "f8aa79866a8fd5e53a6e852248eab819cf186d29312497d8b0a93e302a8e5f7a"
+  arch arm: "arm64", intel: "x64"
+  arch_suffix = on_arch_conditional intel: "_x64"
 
-  url "https://downloads.cursor.com/sand/stable/#{version.csv.second}/darwin/arm64/Cursor-darwin-arm64.zip"
+  version "0.16.0"
+  sha256 arm:   "6dae3cc5259eecd749b28e3622fe9f0333d7aacb32dd71c03dc7fac658617cd4",
+         intel: "ec7950bff3b22f0e35da1d2cb4f117a7e971f3a323679aba1ed8190584197f15"
+
+  url "https://downloads.cursor.com/sand/stable/darwin-#{arch}/#{version}/Grok_Bot_#{version}#{arch_suffix}.dmg"
   name "Grok Bot"
-  desc "AI coding agent from xAI and Cursor"
-  homepage "https://cursor.com/grok"
+  desc "AI teammates that work across your apps and tools"
+  homepage "https://x.ai/bot"
 
   livecheck do
-    url "https://api2.cursor.sh/updates/api/update/darwin-arm64/sand/0.0.0/stable"
-    regex(%r{/sand/stable/(\h+)/}i)
-    strategy :json do |json, regex|
-      ver = json["name"] || json["version"] || json["productVersion"]
-      next unless ver
-
-      match = json["url"]&.match(regex)
-      next if match.blank?
-
-      "#{ver},#{match[1]}"
+    url "https://api2.cursor.sh/updates/api/update/darwin-#{arch}/sand/0.0.0/stable"
+    strategy :json do |json|
+      json["name"]
     end
   end
 
   auto_updates true
   depends_on macos: :monterey
-  depends_on arch: :arm64
 
   app "Grok Bot.app"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<cask>` is the token of the cask you're editing. -->

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Used Cursor (Composer) to draft the cask from the official download URL and Cursor-style update API (`sand` product). Verified locally with `brew audit --cask --new/--online`, `brew style --fix`, and install/uninstall. Livecheck follows the same JSON strategy as the `cursor` cask. Zap paths are based on bundle id `com.anysphere.sand` / app name `Grok Bot`; please flag if maintainers prefer additional paths after first-run artifacts appear.

Note: Grok Bot is early-access / subscription-gated software distributed via downloads.cursor.com. Happy to adjust if that conflicts with Acceptable Casks guidance.

-----