### PR TITLE
warp-agent-cli (new cask)

### DIFF
--- a/Casks/w/warp-agent-cli.rb
+++ b/Casks/w/warp-agent-cli.rb
@@ -1,0 +1,28 @@
+cask "warp-agent-cli" do
+  arch arm: "aarch64", intel: "x86_64"
+  os macos: "macos", linux: "linux"
+
+  version "0.2026.08.05.09.03.stable_01"
+  sha256 arm:          "c5dae2b82787089264de4bfe36f66f9c7b4c9dbd006bcb9855d7f0adf8cb1877",
+         intel:        "9d97106fc1d0064eb97aff2b1c625b5236127d7054a391df19014edf5240c6a7",
+         arm64_linux:  "f6a5d7c2ec357ef1b392e9f2e245a05cd389e1e3ca025c1d6008455ecfd7f97a",
+         x86_64_linux: "e6b9cac6447fbd7d147300fd582ff88c7afe7359f17f1a74afdde478fbcd0f5c"
+
+  on_macos do
+    depends_on macos: :sonoma
+  end
+
+  url "https://app.warp.dev/download/agent-cli/artifact?os=#{os}&arch=#{arch}&version=v#{version}"
+  name "Warp Agent CLI"
+  desc "Agentic development environment for command-line workflows"
+  homepage "https://www.warp.dev/"
+
+  livecheck do
+    url "https://releases.warp.dev/channel_versions.json"
+    strategy :json do |json|
+      (json.dig("stable", "tui_version") || json.dig("stable", "version"))&.delete_prefix("v")
+    end
+  end
+
+  binary "warp-tui-stable", target: "warp"
+end

--- a/Casks/w/warp-agent-cli.rb
+++ b/Casks/w/warp-agent-cli.rb
@@ -25,4 +25,10 @@ cask "warp-agent-cli" do
   end
 
   binary "warp-tui-stable", target: "warp"
+
+  zap trash: [
+    "~/.local/bin/warp",
+    "~/.warp",
+    "~/Library/Logs/warp-cli",
+  ]
 end


### PR DESCRIPTION
Adds Warp Agent CLI using Warp’s endorsed prebuilt production artifacts for macOS and Linux on arm64 and x86-64. The macOS binary is signed and notarized by Warp. This follows the binary-cask distribution model used by other terminal coding agents and keeps package-manager installs owned by Homebrew.

-----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I disclosed the AI/LLM usage below and reviewed its output; I did not attribute the commit to AI and will answer maintainer questions and review comments myself without AI/LLM.

I used Warp Oz with `gpt-5.6-sol (high)` to adapt the cask already reviewed and published in `warpdotdev/homebrew-warp` and to run the validation commands. I reviewed the final cask and all validation output. The cask intentionally has no `zap` stanza because Warp state may be shared with other Warp installation methods.
