### PR TITLE
saega 1.0.16 (new cask)

### DIFF
--- a/Casks/s/saega.rb
+++ b/Casks/s/saega.rb
@@ -1,0 +1,32 @@
+# typed: strict
+# frozen_string_literal: true
+
+cask "saega" do
+  arch arm: "arm64"
+
+  version "1.0.16"
+  sha256 "230afad610a2be220a63cd75e4ecce97ab396bc525009c6d578c42ed67970c00"
+
+  url "https://storage.googleapis.com/saega-downloads/Saega-#{version}.dmg"
+  name "Saega"
+  desc "Privacy-first dictation app built for Swedish and Norwegian"
+  homepage "https://saega.app/"
+
+  livecheck do
+    url "https://saega.app/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+  depends_on arch:  :arm64
+
+  app "Saega.app"
+
+  zap trash: [
+    "~/Library/Application Support/Saega",
+    "~/Library/Caches/app.saega.app",
+    "~/Library/Logs/Saega",
+    "~/Library/Preferences/app.saega.app.plist",
+  ]
+end


### PR DESCRIPTION
Adds a cask for [Saega](https://saega.app/), a privacy-first dictation app built for Swedish and Norwegian (Apple Silicon only). 

- Speech recognition (KB-Whisper / NB-Whisper) runs fully on-device.
- Developer ID signed and notarized by Apple

-----

- [x] The submission is for a stable version.
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

- [x] I used Claude Code (Anthropic) to prepare this cask and run the checks above; I reviewed the diff and the `zap` paths myself before submitting, and will answer review comments myself.